### PR TITLE
feat(auth): OAuth flow on sign-up page

### DIFF
--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,12 @@
 import { SignUpForm } from "@/core/features/auth/components/SignUpForm";
+import { getConfiguredOAuthProviders } from "@/core/features/auth/oauth/config";
 
 export default function SignUpPage() {
+  const configuredOAuthProviders = getConfiguredOAuthProviders();
+
   return (
     <div className="flex h-screen w-screen items-center justify-center">
-      <SignUpForm />
+      <SignUpForm configuredOAuthProviders={configuredOAuthProviders} />
     </div>
   );
 }

--- a/app/api/oauth/[provider]/route.ts
+++ b/app/api/oauth/[provider]/route.ts
@@ -13,8 +13,17 @@ import {
   OAuthNoVerifiedEmailError,
   OAuthUnverifiedEmailError,
 } from "@/core/features/auth/oauth/errors";
+import {
+  clearOAuthErrorReturnCookie,
+  getOAuthErrorReturnPathAndClear,
+} from "@/core/features/auth/oauth/oauthErrorReturn";
 import { createSession } from "@/core/features/auth/session";
 import { setSessionCookie } from "@/core/features/auth/cookies";
+
+async function redirectWithOAuthError(oauthErrorKey: string): Promise<never> {
+  const path = await getOAuthErrorReturnPathAndClear();
+  redirect(`${path}?oauthError=${oauthErrorKey}`);
+}
 
 export async function GET(
   request: NextRequest,
@@ -27,17 +36,17 @@ export async function GET(
   const parsedProvider = z.enum(oAuthProviders).safeParse(rawProvider);
 
   if (!parsedProvider.success) {
-    redirect(`${routes.signIn}?oauthError=oauth_invalid_provider`);
+    return await redirectWithOAuthError("oauth_invalid_provider");
   }
 
   const provider = parsedProvider.data;
 
   if (typeof code !== "string" || typeof state !== "string") {
-    redirect(`${routes.signIn}?oauthError=oauth_failed`);
+    return await redirectWithOAuthError("oauth_failed");
   }
 
   if (getOAuthConfig(provider) == null) {
-    redirect(`${routes.signIn}?oauthError=oauth_not_configured`);
+    return await redirectWithOAuthError("oauth_not_configured");
   }
 
   try {
@@ -52,20 +61,21 @@ export async function GET(
     await setSessionCookie(session.token, session.expiresAt);
   } catch (error) {
     if (error instanceof OAuthMissingEmailError) {
-      redirect(`${routes.signIn}?oauthError=oauth_missing_email`);
+      return await redirectWithOAuthError("oauth_missing_email");
     }
 
     if (error instanceof OAuthUnverifiedEmailError) {
-      redirect(`${routes.signIn}?oauthError=oauth_unverified_email`);
+      return await redirectWithOAuthError("oauth_unverified_email");
     }
 
     if (error instanceof OAuthNoVerifiedEmailError) {
-      redirect(`${routes.signIn}?oauthError=oauth_no_verified_email`);
+      return await redirectWithOAuthError("oauth_no_verified_email");
     }
 
     console.error("OAuth error:", error);
-    redirect(`${routes.signIn}?oauthError=oauth_failed`);
+    return await redirectWithOAuthError("oauth_failed");
   }
 
+  await clearOAuthErrorReturnCookie();
   redirect(routes.app);
 }

--- a/core/features/auth/actions.ts
+++ b/core/features/auth/actions.ts
@@ -23,6 +23,11 @@ import { createUserDb, findUserByEmailDb } from "@/core/features/auth/db";
 import { signInSchema, signUpSchema } from "@/core/features/auth/schemas";
 import { getOAuthClient } from "@/core/features/auth/oauth/base";
 import { getOAuthConfig } from "@/core/features/auth/oauth/config";
+import {
+  clearOAuthErrorReturnCookie,
+  setOAuthErrorReturnForNextOAuth,
+  type OAuthErrorReturn,
+} from "@/core/features/auth/oauth/oauthErrorReturn";
 import { getUser } from "@/core/features/users/actions";
 import { routes } from "@/core/data/routes";
 import type { CurrentUser } from "@/core/features/auth/types";
@@ -273,10 +278,29 @@ export async function validateSessionAction(token: string): Promise<boolean> {
   }
 }
 
-export async function signInWithOAuthAction(provider: OAuthProvider) {
+export type SignInWithOAuthOptions = {
+  /** Where to send the user if OAuth fails after the IdP redirect. Defaults to sign-in. */
+  errorReturn?: OAuthErrorReturn;
+};
+
+/**
+ * Starts the OAuth authorization redirect. Sets a short-lived cookie when `errorReturn` is
+ * `"sign-up"` so the callback can send errors back to `/sign-up`.
+ */
+export async function signInWithOAuthAction(
+  provider: OAuthProvider,
+  options?: SignInWithOAuthOptions,
+) {
+  const errorReturn = options?.errorReturn ?? "sign-in";
+
   if (getOAuthConfig(provider) == null) {
-    redirect(`${routes.signIn}?oauthError=oauth_not_configured`);
+    await clearOAuthErrorReturnCookie();
+    const path =
+      errorReturn === "sign-up" ? routes.signUp : routes.signIn;
+    redirect(`${path}?oauthError=oauth_not_configured`);
   }
+
+  await setOAuthErrorReturnForNextOAuth(errorReturn);
 
   const oAuthClient = getOAuthClient(provider);
 

--- a/core/features/auth/components/OAuthSignInSection.tsx
+++ b/core/features/auth/components/OAuthSignInSection.tsx
@@ -2,7 +2,10 @@
 
 import { Button } from "@/core/components/ui/button";
 import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
-import { signInWithOAuthAction } from "@/core/features/auth/actions";
+import {
+  signInWithOAuthAction,
+  type SignInWithOAuthOptions,
+} from "@/core/features/auth/actions";
 
 /**
  * Lucide deprecated brand icons (see lucide#670). Inline SVGs keep OAuth marks
@@ -89,8 +92,10 @@ function oauthProviderButton(provider: OAuthProvider) {
 
 export function OAuthSignInSection({
   configuredOAuthProviders,
+  oauthErrorReturn = "sign-in",
 }: {
   configuredOAuthProviders: OAuthProvider[];
+  oauthErrorReturn?: SignInWithOAuthOptions["errorReturn"];
 }) {
   if (configuredOAuthProviders.length === 0) {
     return null;
@@ -108,7 +113,11 @@ export function OAuthSignInSection({
               variant="outline"
               className="w-full justify-center"
               type="button"
-              onClick={async () => await signInWithOAuthAction(provider)}>
+              onClick={async () =>
+                await signInWithOAuthAction(provider, {
+                  errorReturn: oauthErrorReturn,
+                })
+              }>
               <Icon className="size-4" />
               {label}
             </Button>

--- a/core/features/auth/components/SignUpForm.tsx
+++ b/core/features/auth/components/SignUpForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState } from "react";
+import { Suspense, useActionState } from "react";
 import Link from "next/link";
 
 import { Button } from "@/core/components/ui/button";
@@ -15,9 +15,16 @@ import { Input } from "@/core/components/ui/input";
 import { Label } from "@/core/components/ui/label";
 import { PasswordInput } from "@/core/components/ui/password-input";
 import { routes } from "@/core/data/routes";
+import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
 import { signUpAction } from "@/core/features/auth/actions";
+import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQueryErrorBanner";
+import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInSection";
 
-export function SignUpForm() {
+export function SignUpForm({
+  configuredOAuthProviders,
+}: {
+  configuredOAuthProviders: OAuthProvider[];
+}) {
   const [state, action, isPending] = useActionState(signUpAction, null);
 
   return (
@@ -28,13 +35,17 @@ export function SignUpForm() {
           Enter your information to create a new account
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
+        <Suspense fallback={null}>
+          <OAuthQueryErrorBanner formError={state?.error} />
+        </Suspense>
+
+        <OAuthSignInSection
+          configuredOAuthProviders={configuredOAuthProviders}
+          oauthErrorReturn="sign-up"
+        />
+
         <form action={action} className="space-y-4">
-          {state?.error && (
-            <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
-              {state.error}
-            </div>
-          )}
 
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>
@@ -97,7 +108,7 @@ export function SignUpForm() {
           </Button>
         </form>
 
-        <div className="mt-4 text-center text-sm">
+        <div className="text-center text-sm">
           Already have an account?{" "}
           <Link href={routes.signIn} className="text-primary hover:underline">
             Sign in

--- a/core/features/auth/oauth/oauthErrorReturn.test.ts
+++ b/core/features/auth/oauth/oauthErrorReturn.test.ts
@@ -1,0 +1,22 @@
+import { routes } from "@/core/data/routes";
+import { oauthErrorReturnToPath } from "@/core/features/auth/oauth/oauthErrorReturn";
+
+describe("oauthErrorReturnToPath", () => {
+  it("maps sign-up to routes.signUp", () => {
+    expect(oauthErrorReturnToPath("sign-up")).toBe(routes.signUp);
+  });
+
+  it("maps sign-in to routes.signIn", () => {
+    expect(oauthErrorReturnToPath("sign-in")).toBe(routes.signIn);
+  });
+
+  it("defaults to sign-in for undefined", () => {
+    expect(oauthErrorReturnToPath(undefined)).toBe(routes.signIn);
+  });
+
+  it("defaults to sign-in for tampered or unknown values", () => {
+    expect(oauthErrorReturnToPath("https://evil.example")).toBe(routes.signIn);
+    expect(oauthErrorReturnToPath("sign-up ")).toBe(routes.signIn);
+    expect(oauthErrorReturnToPath("")).toBe(routes.signIn);
+  });
+});

--- a/core/features/auth/oauth/oauthErrorReturn.ts
+++ b/core/features/auth/oauth/oauthErrorReturn.ts
@@ -1,0 +1,60 @@
+import { cookies } from "next/headers";
+
+import { routes } from "@/core/data/routes";
+
+/** Matches OAuth state/code verifier lifetime in `base.ts`. */
+const COOKIE_EXPIRATION_MS = 60 * 10 * 1000;
+
+export const OAUTH_ERROR_RETURN_COOKIE_KEY = "oauth_error_return";
+
+export type OAuthErrorReturn = "sign-in" | "sign-up";
+
+/**
+ * Maps a stored cookie value to an allowlisted auth path. Unknown values default to sign-in.
+ */
+export function oauthErrorReturnToPath(raw: string | undefined): string {
+  if (raw === "sign-up") {
+    return routes.signUp;
+  }
+
+  return routes.signIn;
+}
+
+/**
+ * Sets or clears the short-lived cookie that tells the OAuth callback where to send errors.
+ * Call with `"sign-up"` when starting OAuth from the sign-up page; use `"sign-in"` to clear a stale value.
+ */
+export async function setOAuthErrorReturnForNextOAuth(
+  errorReturn: OAuthErrorReturn,
+): Promise<void> {
+  const cookieStore = await cookies();
+
+  if (errorReturn === "sign-up") {
+    cookieStore.set(OAUTH_ERROR_RETURN_COOKIE_KEY, "sign-up", {
+      secure: true,
+      httpOnly: true,
+      sameSite: "lax",
+      expires: new Date(Date.now() + COOKIE_EXPIRATION_MS),
+    });
+
+    return;
+  }
+
+  cookieStore.delete(OAUTH_ERROR_RETURN_COOKIE_KEY);
+}
+
+/**
+ * Reads the error-return target, removes the cookie, and returns the allowlisted path.
+ */
+export async function getOAuthErrorReturnPathAndClear(): Promise<string> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(OAUTH_ERROR_RETURN_COOKIE_KEY)?.value;
+  cookieStore.delete(OAUTH_ERROR_RETURN_COOKIE_KEY);
+
+  return oauthErrorReturnToPath(raw);
+}
+
+export async function clearOAuthErrorReturnCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(OAUTH_ERROR_RETURN_COOKIE_KEY);
+}


### PR DESCRIPTION
## Summary

Adds the same OAuth provider buttons and error banner pattern used on sign-in to the sign-up page.

## Behavior

- **Sign-up page** loads configured providers and renders `OAuthSignInSection` with `oauthErrorReturn="sign-up"`.
- A short-lived **httpOnly** cookie (`oauth_error_return`) records when OAuth was started from sign-up so the `/api/oauth/[provider]` callback can redirect failures to `/sign-up?oauthError=...` instead of always `/sign-in`.
- Paths are **allowlisted** (`oauthErrorReturnToPath`); unknown cookie values fall back to sign-in.
- Cookie is cleared on successful login, on OAuth error redirects (read + delete), when starting OAuth from sign-in (deletes stale sign-up marker), and when the provider is not configured before redirecting to the error page.

## Tests

- `oauthErrorReturn.test.ts` covers allowlisted path resolution.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth provider authentication options now appear on the sign-up page
  * OAuth error redirects can now be configured to route users to either sign-up or sign-in flows based on context

* **Bug Fixes**
  * Improved OAuth error handling and redirection consistency across authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->