### PR TITLE
feat(auth): OAuth last-used provider hint (cookie + UI)

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { SignInForm } from "@/core/features/auth/components/SignInForm";
 import { getConfiguredOAuthProviders } from "@/core/features/auth/oauth/config";
 import { getLastUsedOAuthProvider } from "@/core/features/auth/oauth/oauthLastUsed";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 export default function SignInPage() {
   const configuredOAuthProviders = getConfiguredOAuthProviders();

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,12 +1,39 @@
+import { Suspense } from "react";
+
 import { SignInForm } from "@/core/features/auth/components/SignInForm";
 import { getConfiguredOAuthProviders } from "@/core/features/auth/oauth/config";
+import { getLastUsedOAuthProvider } from "@/core/features/auth/oauth/oauthLastUsed";
+import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
 
 export default function SignInPage() {
   const configuredOAuthProviders = getConfiguredOAuthProviders();
 
   return (
     <div className="flex h-screen w-screen items-center justify-center">
-      <SignInForm configuredOAuthProviders={configuredOAuthProviders} />
+      <Suspense
+        fallback={
+          <SignInForm configuredOAuthProviders={configuredOAuthProviders} />
+        }
+      >
+        <SignInFormWithLastUsedOAuth
+          configuredOAuthProviders={configuredOAuthProviders}
+        />
+      </Suspense>
     </div>
+  );
+}
+
+async function SignInFormWithLastUsedOAuth({
+  configuredOAuthProviders,
+}: {
+  configuredOAuthProviders: OAuthProvider[];
+}) {
+  const lastUsedOAuthProvider = await getLastUsedOAuthProvider();
+
+  return (
+    <SignInForm
+      configuredOAuthProviders={configuredOAuthProviders}
+      lastUsedOAuthProvider={lastUsedOAuthProvider}
+    />
   );
 }

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { SignUpForm } from "@/core/features/auth/components/SignUpForm";
 import { getConfiguredOAuthProviders } from "@/core/features/auth/oauth/config";
 import { getLastUsedOAuthProvider } from "@/core/features/auth/oauth/oauthLastUsed";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 export default function SignUpPage() {
   const configuredOAuthProviders = getConfiguredOAuthProviders();

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,12 +1,39 @@
+import { Suspense } from "react";
+
 import { SignUpForm } from "@/core/features/auth/components/SignUpForm";
 import { getConfiguredOAuthProviders } from "@/core/features/auth/oauth/config";
+import { getLastUsedOAuthProvider } from "@/core/features/auth/oauth/oauthLastUsed";
+import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
 
 export default function SignUpPage() {
   const configuredOAuthProviders = getConfiguredOAuthProviders();
 
   return (
     <div className="flex h-screen w-screen items-center justify-center">
-      <SignUpForm configuredOAuthProviders={configuredOAuthProviders} />
+      <Suspense
+        fallback={
+          <SignUpForm configuredOAuthProviders={configuredOAuthProviders} />
+        }
+      >
+        <SignUpFormWithLastUsedOAuth
+          configuredOAuthProviders={configuredOAuthProviders}
+        />
+      </Suspense>
     </div>
+  );
+}
+
+async function SignUpFormWithLastUsedOAuth({
+  configuredOAuthProviders,
+}: {
+  configuredOAuthProviders: OAuthProvider[];
+}) {
+  const lastUsedOAuthProvider = await getLastUsedOAuthProvider();
+
+  return (
+    <SignUpForm
+      configuredOAuthProviders={configuredOAuthProviders}
+      lastUsedOAuthProvider={lastUsedOAuthProvider}
+    />
   );
 }

--- a/app/api/oauth/[provider]/route.ts
+++ b/app/api/oauth/[provider]/route.ts
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import z from "zod";
 
-import { oAuthProviders } from "@/core/drizzle/schema";
+import { oAuthProviders } from "@/core/drizzle/schema/oauthProviderIds";
 import { routes } from "@/core/data/routes";
 import { getOAuthClient } from "@/core/features/auth/oauth/base";
 import { connectUserToAccount } from "@/core/features/auth/oauth/connectUser";

--- a/app/api/oauth/[provider]/route.ts
+++ b/app/api/oauth/[provider]/route.ts
@@ -17,6 +17,7 @@ import {
   clearOAuthErrorReturnCookie,
   getOAuthErrorReturnPathAndClear,
 } from "@/core/features/auth/oauth/oauthErrorReturn";
+import { setLastUsedOAuthProviderCookie } from "@/core/features/auth/oauth/oauthLastUsed";
 import { createSession } from "@/core/features/auth/session";
 import { setSessionCookie } from "@/core/features/auth/cookies";
 
@@ -59,6 +60,7 @@ export async function GET(
 
     const session = await createSession(user.id);
     await setSessionCookie(session.token, session.expiresAt);
+    await setLastUsedOAuthProviderCookie(provider);
   } catch (error) {
     if (error instanceof OAuthMissingEmailError) {
       return await redirectWithOAuthError("oauth_missing_email");

--- a/core/drizzle/schema/oauthProviderIds.ts
+++ b/core/drizzle/schema/oauthProviderIds.ts
@@ -1,0 +1,6 @@
+/**
+ * OAuth IdP identifiers shared by auth UI and Drizzle. Kept free of pg-core so
+ * auth code can import values without loading the full schema graph (avoids circular init).
+ */
+export const oAuthProviders = ["google", "github", "discord"] as const;
+export type OAuthProvider = (typeof oAuthProviders)[number];

--- a/core/drizzle/schema/userOAuthAccount.ts
+++ b/core/drizzle/schema/userOAuthAccount.ts
@@ -9,9 +9,8 @@ import {
 
 import { createdAt, updatedAt } from "../schemaHelpers";
 import { UserTable } from "./user";
+import { oAuthProviders } from "./oauthProviderIds";
 
-export const oAuthProviders = ["google", "github", "discord"] as const;
-export type OAuthProvider = (typeof oAuthProviders)[number];
 export const oAuthProviderEnum = pgEnum("oauth_provider", oAuthProviders);
 
 export const UserOAuthAccountTable = pgTable(

--- a/core/features/auth/actions.ts
+++ b/core/features/auth/actions.ts
@@ -31,7 +31,7 @@ import {
 import { getUser } from "@/core/features/users/actions";
 import { routes } from "@/core/data/routes";
 import type { CurrentUser } from "@/core/features/auth/types";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 type AuthFieldErrors = {
   name?: string;

--- a/core/features/auth/components/OAuthSignInSection.tsx
+++ b/core/features/auth/components/OAuthSignInSection.tsx
@@ -3,7 +3,7 @@
 import { Badge } from "@/core/components/ui/badge";
 import { Button } from "@/core/components/ui/button";
 import { cn } from "@/core/lib/utils";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 import {
   signInWithOAuthAction,
   type SignInWithOAuthOptions,

--- a/core/features/auth/components/OAuthSignInSection.tsx
+++ b/core/features/auth/components/OAuthSignInSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { Badge } from "@/core/components/ui/badge";
 import { Button } from "@/core/components/ui/button";
+import { cn } from "@/core/lib/utils";
 import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
 import {
   signInWithOAuthAction,
@@ -92,9 +94,11 @@ function oauthProviderButton(provider: OAuthProvider) {
 
 export function OAuthSignInSection({
   configuredOAuthProviders,
+  lastUsedOAuthProvider,
   oauthErrorReturn = "sign-in",
 }: {
   configuredOAuthProviders: OAuthProvider[];
+  lastUsedOAuthProvider?: OAuthProvider;
   oauthErrorReturn?: SignInWithOAuthOptions["errorReturn"];
 }) {
   if (configuredOAuthProviders.length === 0) {
@@ -106,20 +110,31 @@ export function OAuthSignInSection({
       <div className="flex flex-col gap-2">
         {configuredOAuthProviders.map((provider) => {
           const { label, Icon } = oauthProviderButton(provider);
+          const isLastUsed = lastUsedOAuthProvider === provider;
 
           return (
             <Button
               key={provider}
               variant="outline"
-              className="w-full justify-center"
+              className={cn(
+                "w-full justify-center gap-2",
+                isLastUsed && "ring-2 ring-primary",
+              )}
               type="button"
               onClick={async () =>
                 await signInWithOAuthAction(provider, {
                   errorReturn: oauthErrorReturn,
                 })
               }>
-              <Icon className="size-4" />
-              {label}
+              <Icon className="size-4 shrink-0" />
+              <span className="min-w-0">{label}</span>
+              {isLastUsed && (
+                <Badge
+                  variant="secondary"
+                  className="shrink-0 text-muted-foreground">
+                  Last used
+                </Badge>
+              )}
             </Button>
           );
         })}

--- a/core/features/auth/components/SignInForm.tsx
+++ b/core/features/auth/components/SignInForm.tsx
@@ -22,8 +22,10 @@ import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQuer
 
 export function SignInForm({
   configuredOAuthProviders,
+  lastUsedOAuthProvider,
 }: {
   configuredOAuthProviders: OAuthProvider[];
+  lastUsedOAuthProvider?: OAuthProvider;
 }) {
   const [state, action, isPending] = useActionState(signInAction, null);
 
@@ -42,6 +44,7 @@ export function SignInForm({
 
         <OAuthSignInSection
           configuredOAuthProviders={configuredOAuthProviders}
+          lastUsedOAuthProvider={lastUsedOAuthProvider}
         />
 
         <form action={action} className="space-y-4">

--- a/core/features/auth/components/SignInForm.tsx
+++ b/core/features/auth/components/SignInForm.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/core/components/ui/input";
 import { Label } from "@/core/components/ui/label";
 import { PasswordInput } from "@/core/components/ui/password-input";
 import { routes } from "@/core/data/routes";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 import { signInAction } from "@/core/features/auth/actions";
 import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInSection";
 import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQueryErrorBanner";

--- a/core/features/auth/components/SignUpForm.tsx
+++ b/core/features/auth/components/SignUpForm.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/core/components/ui/input";
 import { Label } from "@/core/components/ui/label";
 import { PasswordInput } from "@/core/components/ui/password-input";
 import { routes } from "@/core/data/routes";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 import { signUpAction } from "@/core/features/auth/actions";
 import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQueryErrorBanner";
 import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInSection";

--- a/core/features/auth/components/SignUpForm.tsx
+++ b/core/features/auth/components/SignUpForm.tsx
@@ -22,8 +22,10 @@ import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInS
 
 export function SignUpForm({
   configuredOAuthProviders,
+  lastUsedOAuthProvider,
 }: {
   configuredOAuthProviders: OAuthProvider[];
+  lastUsedOAuthProvider?: OAuthProvider;
 }) {
   const [state, action, isPending] = useActionState(signUpAction, null);
 
@@ -42,11 +44,11 @@ export function SignUpForm({
 
         <OAuthSignInSection
           configuredOAuthProviders={configuredOAuthProviders}
+          lastUsedOAuthProvider={lastUsedOAuthProvider}
           oauthErrorReturn="sign-up"
         />
 
         <form action={action} className="space-y-4">
-
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>
             <Input
@@ -60,7 +62,9 @@ export function SignUpForm({
               required
             />
             {state?.fieldErrors?.name && (
-              <p className="text-sm text-destructive">{state.fieldErrors.name}</p>
+              <p className="text-sm text-destructive">
+                {state.fieldErrors.name}
+              </p>
             )}
           </div>
 
@@ -77,7 +81,9 @@ export function SignUpForm({
               required
             />
             {state?.fieldErrors?.email && (
-              <p className="text-sm text-destructive">{state.fieldErrors.email}</p>
+              <p className="text-sm text-destructive">
+                {state.fieldErrors.email}
+              </p>
             )}
           </div>
 

--- a/core/features/auth/oauth/base.ts
+++ b/core/features/auth/oauth/base.ts
@@ -4,7 +4,7 @@ import crypto from "crypto";
 import { env } from "@/core/data/env/server";
 import type { Cookies } from "@/core/features/auth/oauth/types";
 import { getOAuthConfig } from "@/core/features/auth/oauth/config";
-import type { OAuthProvider } from "@/core/drizzle/schema";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 import { createDiscordOAuthClient } from "./discord";
 import { createGoogleOAuthClient } from "./google";

--- a/core/features/auth/oauth/config.test.ts
+++ b/core/features/auth/oauth/config.test.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 const mockEnv: {
   DISCORD_CLIENT_ID?: string;

--- a/core/features/auth/oauth/config.ts
+++ b/core/features/auth/oauth/config.ts
@@ -1,14 +1,10 @@
 import { env } from "@/core/data/env/server";
-import type { OAuthProvider } from "@/core/drizzle/schema/userOAuthAccount";
+import {
+  oAuthProviders,
+  type OAuthProvider,
+} from "@/core/drizzle/schema/oauthProviderIds";
 
-/**
- * Must match `oAuthProviders` in `@/core/drizzle/schema/userOAuthAccount` (avoid importing Drizzle here).
- */
-const ALL_OAUTH_PROVIDERS: readonly OAuthProvider[] = [
-  "google",
-  "github",
-  "discord",
-];
+const ALL_OAUTH_PROVIDERS: readonly OAuthProvider[] = oAuthProviders;
 
 export type OAuthProviderCredentials = {
   clientId: string;

--- a/core/features/auth/oauth/connectUser.ts
+++ b/core/features/auth/oauth/connectUser.ts
@@ -1,10 +1,7 @@
 import { eq, and } from "drizzle-orm";
 
-import {
-  OAuthProvider,
-  UserTable,
-  UserOAuthAccountTable,
-} from "@/core/drizzle/schema";
+import { UserOAuthAccountTable, UserTable } from "@/core/drizzle/schema";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 import { generateUserId } from "@/core/features/auth/tokens";
 import { db } from "@/core/drizzle/db";
 

--- a/core/features/auth/oauth/errors.ts
+++ b/core/features/auth/oauth/errors.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { OAuthProvider } from "@/core/drizzle/schema";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 /**
  * Thrown when `getOAuthClient` cannot build a client because credentials are missing.

--- a/core/features/auth/oauth/oauthLastUsed.test.ts
+++ b/core/features/auth/oauth/oauthLastUsed.test.ts
@@ -1,0 +1,28 @@
+import {
+  OAUTH_LAST_USED_COOKIE_KEY,
+  parseOAuthLastUsedCookieValue,
+} from "@/core/features/auth/oauth/oauthLastUsed";
+
+describe("parseOAuthLastUsedCookieValue", () => {
+  it("returns undefined for undefined, empty, or invalid values", () => {
+    expect(parseOAuthLastUsedCookieValue(undefined)).toBeUndefined();
+    expect(parseOAuthLastUsedCookieValue("")).toBeUndefined();
+    expect(parseOAuthLastUsedCookieValue("facebook")).toBeUndefined();
+    expect(parseOAuthLastUsedCookieValue("google ")).toBeUndefined();
+    expect(
+      parseOAuthLastUsedCookieValue("https://evil.example"),
+    ).toBeUndefined();
+  });
+
+  it("returns allowlisted providers", () => {
+    expect(parseOAuthLastUsedCookieValue("google")).toBe("google");
+    expect(parseOAuthLastUsedCookieValue("github")).toBe("github");
+    expect(parseOAuthLastUsedCookieValue("discord")).toBe("discord");
+  });
+});
+
+describe("OAUTH_LAST_USED_COOKIE_KEY", () => {
+  it("is stable for callers and tests", () => {
+    expect(OAUTH_LAST_USED_COOKIE_KEY).toBe("oauth_last_used");
+  });
+});

--- a/core/features/auth/oauth/oauthLastUsed.ts
+++ b/core/features/auth/oauth/oauthLastUsed.ts
@@ -1,0 +1,58 @@
+import { cookies } from "next/headers";
+import z from "zod";
+
+import { COOKIE_OPTIONS } from "@/core/features/auth/constants";
+import {
+  oAuthProviders,
+  type OAuthProvider,
+} from "@/core/drizzle/schema/userOAuthAccount";
+
+/** UX hint only; not used for authorization. */
+export const OAUTH_LAST_USED_COOKIE_KEY = "oauth_last_used";
+
+const OAUTH_LAST_USED_MAX_AGE_MS = 400 * 24 * 60 * 60 * 1000;
+
+const oauthProviderSchema = z.enum(oAuthProviders);
+
+/**
+ * Parses a raw cookie value into an allowlisted OAuth provider, or undefined.
+ */
+export function parseOAuthLastUsedCookieValue(
+  raw: string | undefined,
+): OAuthProvider | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+
+  const parsed = oauthProviderSchema.safeParse(raw);
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  return parsed.data;
+}
+
+/**
+ * Persists which OAuth provider the user last signed in with (successful callback only).
+ */
+export async function setLastUsedOAuthProviderCookie(
+  provider: OAuthProvider,
+): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(OAUTH_LAST_USED_COOKIE_KEY, provider, {
+    ...COOKIE_OPTIONS,
+    expires: new Date(Date.now() + OAUTH_LAST_USED_MAX_AGE_MS),
+  });
+}
+
+/**
+ * Reads the last-used OAuth provider cookie for auth page UI.
+ */
+export async function getLastUsedOAuthProvider(): Promise<
+  OAuthProvider | undefined
+> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(OAUTH_LAST_USED_COOKIE_KEY)?.value;
+
+  return parseOAuthLastUsedCookieValue(raw);
+}

--- a/core/features/auth/oauth/oauthLastUsed.ts
+++ b/core/features/auth/oauth/oauthLastUsed.ts
@@ -1,11 +1,11 @@
 import { cookies } from "next/headers";
 import z from "zod";
 
-import { COOKIE_OPTIONS } from "@/core/features/auth/constants";
 import {
   oAuthProviders,
   type OAuthProvider,
-} from "@/core/drizzle/schema/userOAuthAccount";
+} from "@/core/drizzle/schema/oauthProviderIds";
+import { COOKIE_OPTIONS } from "@/core/features/auth/constants";
 
 /** UX hint only; not used for authorization. */
 export const OAUTH_LAST_USED_COOKIE_KEY = "oauth_last_used";

--- a/core/features/auth/oauth/oauthLinkPolicy.ts
+++ b/core/features/auth/oauth/oauthLinkPolicy.ts
@@ -1,4 +1,4 @@
-import type { OAuthProvider } from "@/core/drizzle/schema";
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 
 import { OAuthUnverifiedEmailError } from "./errors";
 


### PR DESCRIPTION
## Summary

Adds a first-party `oauth_last_used` cookie set only after a **successful** OAuth callback, alongside the session cookie. Sign-in and sign-up pages read it (behind **Suspense** so `cookies()` does not block the route) and pass the value into the OAuth button list.

## UI

- Subtle `ring-primary` on the last-used provider.
- Visible **Last used** badge (not color-only).

## Technical notes

- Cookie uses existing `COOKIE_OPTIONS` (httpOnly, SameSite=Lax, long expiry for UX).
- Values are allowlisted with zod (`parseOAuthLastUsedCookieValue`).
- Suspense fallback renders the same form without the hint to avoid a blank shell and to satisfy Next.js dynamic route requirements.

## Tests

- `core/features/auth/oauth/oauthLastUsed.test.ts` covers parsing edge cases.

Made with [Cursor](https://cursor.com)