### PR TITLE
feat(navbar): show signed-in user name and email in dropdown

### DIFF
--- a/app/app/_Navbar.tsx
+++ b/app/app/_Navbar.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@core/components/ui/dropdown-menu";
@@ -32,7 +33,7 @@ const navLinks = [
 export function Navbar({
   user,
 }: {
-  user: { name: string; image: string | null };
+  user: { name: string; email: string; image: string | null };
 }) {
   const { jobInfoId } = useParams();
   const pathName = usePathname();
@@ -73,6 +74,18 @@ export function Navbar({
             <UserAvatar user={user} />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuLabel className="font-normal">
+              <div className="flex flex-col gap-1 max-w-[12rem]">
+                <span className="text-sm font-semibold truncate">
+                  {user.name}
+                </span>
+                <span className="text-xs text-muted-foreground/80 truncate">
+                  {user.email}
+                </span>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
             <DropdownMenuItem asChild>
               <Link href={routes.upgrade}>
                 <CircleArrowUpIcon className="mr-2" />


### PR DESCRIPTION
## Summary

Adds a non-interactive two-line identity header at the top of the avatar dropdown in the app Navbar:

- Line 1: full name (`text-sm font-semibold`)
- Line 2: email (`text-xs text-muted-foreground/80`, dimmed for clear hierarchy in both themes)

Followed by a separator, then the existing `Upgrade` and `Logout` items (unchanged).

## UI

- Non-interactive: uses `DropdownMenuLabel`, not `DropdownMenuItem`, so the header is not focusable and keyboard navigation (arrow keys) skips straight to `Upgrade`.
- Truncation: both lines are `truncate` inside a `max-w-[12rem]` column so long names/emails keep the menu width controlled.
- Weight + muted-alpha (`/80`) is used to widen the perceived contrast gap instead of hardcoded off-token colors, so it plays nicely in both light and dark mode.

## Technical notes

- `Navbar`'s local `user` prop type widened from `{name, image}` to `{name, email, image}`. No caller changes required - `app/app/layout.tsx` already passes the full `AuthUser` object, which already exposes `email` in `core/features/auth/types.ts`.
- `UserAvatar` accepts the widened shape via TypeScript structural subtyping (it only reads `name` and `image`).
- No new dependencies, no extra fetching, no Clerk hook, no server roundtrip.

## Tests

No tests added. This is a purely presentational addition with no branching logic. The repo currently has no RTL/jsdom setup (`jest.config.mjs` is `testEnvironment: "node"` and all existing tests are backend logic under `core/features/auth/oauth/`). Standing up RTL for two lines of static JSX wasn't worth it; a better trigger will be the first component with real interaction/state logic to pin down.

## Manual verification

- Sign in, open avatar menu: name and dimmed email render on two lines above `Upgrade`, separated by a divider.
- Keyboard nav: Tab / arrow keys skip the label and land on `Upgrade` first.
- Long value stress test: wrapper caps width via `max-w-[12rem]` + `truncate`.
- `npm run check`: clean on the touched file (no new errors introduced).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User email address now displays in the account dropdown menu alongside the account name for improved account identification and visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->