### PR TITLE
test(stripe): webhook route coverage and Stripe test fixtures

### DIFF
--- a/app/api/stripe/webhooks/route.test.ts
+++ b/app/api/stripe/webhooks/route.test.ts
@@ -11,7 +11,7 @@ import {
   makeCheckoutSessionAsyncPaymentFailedEvent,
   makeSubscriptionDeletedEvent,
   makeSubscriptionUpdatedEvent,
-  makeUnknownStripeEvent,
+  makeUnhandledStripeWebhookEvent,
   makeStripeCheckoutSession,
   makeStripeSubscription,
   makeStripeEvent,
@@ -387,8 +387,8 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
     );
   });
 
-  it("no-ops on an unknown event type and still marks the event processed", async () => {
-    const event = makeUnknownStripeEvent();
+  it("no-ops on an unhandled event type and still marks the event processed", async () => {
+    const event = makeUnhandledStripeWebhookEvent();
     primeHappyPath(event);
 
     const response = await POST(

--- a/app/api/stripe/webhooks/route.test.ts
+++ b/app/api/stripe/webhooks/route.test.ts
@@ -1,0 +1,454 @@
+import type Stripe from "stripe";
+
+import { createTestServerEnv, type TestServerEnv } from "@core/test-utils/env";
+import {
+  createMockStripe,
+  type MockStripeClient,
+} from "@core/test-utils/mocks/stripe";
+import {
+  makeCheckoutSessionCompletedEvent,
+  makeCheckoutSessionAsyncPaymentSucceededEvent,
+  makeCheckoutSessionAsyncPaymentFailedEvent,
+  makeSubscriptionDeletedEvent,
+  makeSubscriptionUpdatedEvent,
+  makeUnknownStripeEvent,
+  makeStripeCheckoutSession,
+  makeStripeSubscription,
+  makeStripeEvent,
+} from "@core/test-utils/factories";
+
+let mockEnv: TestServerEnv = createTestServerEnv();
+
+jest.mock("@/core/data/env/server", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+
+const mockStripe: MockStripeClient = createMockStripe();
+
+jest.mock("@/core/features/billing/stripe", () => ({
+  getStripe: jest.fn(),
+}));
+
+jest.mock("@/core/features/billing/webhookHelpers", () => ({
+  claimEvent: jest.fn(),
+  unclaimEvent: jest.fn(),
+  fulfillCheckoutSession: jest.fn(),
+  markStripeEventProcessed: jest.fn(),
+  markStripeEventRemediationRequired: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/stripeSync", () => ({
+  syncSubscriptionFromStripe: jest.fn(),
+}));
+
+import { getStripe } from "@/core/features/billing/stripe";
+import {
+  claimEvent,
+  fulfillCheckoutSession,
+  markStripeEventProcessed,
+  markStripeEventRemediationRequired,
+  unclaimEvent,
+} from "@/core/features/billing/webhookHelpers";
+import { syncSubscriptionFromStripe } from "@/core/features/users/stripeSync";
+
+import { POST } from "./route";
+
+const mockGetStripe = getStripe as jest.MockedFunction<typeof getStripe>;
+const mockClaimEvent = claimEvent as jest.MockedFunction<typeof claimEvent>;
+const mockUnclaimEvent = unclaimEvent as jest.MockedFunction<
+  typeof unclaimEvent
+>;
+const mockFulfill = fulfillCheckoutSession as jest.MockedFunction<
+  typeof fulfillCheckoutSession
+>;
+const mockMarkProcessed = markStripeEventProcessed as jest.MockedFunction<
+  typeof markStripeEventProcessed
+>;
+const mockMarkRemediation =
+  markStripeEventRemediationRequired as jest.MockedFunction<
+    typeof markStripeEventRemediationRequired
+  >;
+const mockSyncSubscription = syncSubscriptionFromStripe as jest.MockedFunction<
+  typeof syncSubscriptionFromStripe
+>;
+
+const VALID_SIGNATURE_HEADER = "t=1,v1=test-signature";
+
+function buildWebhookRequest(
+  body: string | undefined,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost:3000/api/stripe/webhooks", {
+    method: "POST",
+    headers: new Headers(headers),
+    body,
+  });
+}
+
+function primeHappyPath(event: Stripe.Event): void {
+  mockStripe.webhooks.constructEvent.mockReturnValueOnce(event);
+  mockClaimEvent.mockResolvedValueOnce("claimed");
+}
+
+let consoleErrorSpy: jest.SpyInstance;
+let consoleWarnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  mockEnv = createTestServerEnv();
+
+  mockStripe.webhooks.constructEvent.mockReset();
+  mockStripe.subscriptions.retrieve.mockReset();
+
+  mockGetStripe.mockReset();
+  mockGetStripe.mockReturnValue(mockStripe as unknown as Stripe);
+
+  mockClaimEvent.mockReset();
+  mockUnclaimEvent.mockReset().mockResolvedValue(undefined);
+  mockFulfill.mockReset().mockResolvedValue(undefined);
+  mockMarkProcessed.mockReset().mockResolvedValue(undefined);
+  mockMarkRemediation.mockReset().mockResolvedValue(undefined);
+  mockSyncSubscription.mockReset().mockResolvedValue(undefined);
+
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
+});
+
+describe("POST /api/stripe/webhooks — preconditions", () => {
+  it("returns 501 when STRIPE_WEBHOOK_SECRET is not configured", async () => {
+    mockEnv = createTestServerEnv({ STRIPE_WEBHOOK_SECRET: undefined });
+
+    const response = await POST(buildWebhookRequest("{}"));
+
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toEqual({
+      error: "Webhook secret not configured",
+    });
+    expect(mockStripe.webhooks.constructEvent).not.toHaveBeenCalled();
+    expect(mockClaimEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 when Stripe client is not available", async () => {
+    mockGetStripe.mockReturnValue(null);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toEqual({
+      error: "Stripe not configured",
+    });
+    expect(mockClaimEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the stripe-signature header is missing", async () => {
+    const response = await POST(buildWebhookRequest("{}"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing stripe-signature",
+    });
+    expect(mockStripe.webhooks.constructEvent).not.toHaveBeenCalled();
+    expect(mockClaimEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when reading the request body fails", async () => {
+    const failingRequest = {
+      headers: new Headers({ "stripe-signature": VALID_SIGNATURE_HEADER }),
+      text: () => Promise.reject(new Error("read failed")),
+    } as unknown as Request;
+
+    const response = await POST(failingRequest);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to read body",
+    });
+    expect(mockStripe.webhooks.constructEvent).not.toHaveBeenCalled();
+    expect(mockClaimEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when signature verification throws", async () => {
+    mockStripe.webhooks.constructEvent.mockImplementation(() => {
+      throw new Error("invalid signature");
+    });
+
+    const response = await POST(
+      buildWebhookRequest("raw-body", {
+        "stripe-signature": "bogus",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid signature",
+    });
+    expect(mockClaimEvent).not.toHaveBeenCalled();
+    expect(mockFulfill).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/stripe/webhooks — idempotency", () => {
+  it("short-circuits with 200 when the event was already processed", async () => {
+    const event = makeCheckoutSessionCompletedEvent();
+    mockStripe.webhooks.constructEvent.mockReturnValueOnce(event);
+    mockClaimEvent.mockResolvedValueOnce("duplicate_processed");
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFulfill).not.toHaveBeenCalled();
+    expect(mockMarkProcessed).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 while a concurrent delivery is still processing", async () => {
+    const event = makeCheckoutSessionCompletedEvent();
+    mockStripe.webhooks.constructEvent.mockReturnValueOnce(event);
+    mockClaimEvent.mockResolvedValueOnce("duplicate_in_progress");
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(mockFulfill).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 so Stripe keeps retrying when remediation is required", async () => {
+    const event = makeCheckoutSessionCompletedEvent();
+    mockStripe.webhooks.constructEvent.mockReturnValueOnce(event);
+    mockClaimEvent.mockResolvedValueOnce("duplicate_remediation");
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Stripe webhook event stuck after failed unclaim; remediation required",
+    });
+    expect(mockFulfill).not.toHaveBeenCalled();
+    expect(mockMarkProcessed).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/stripe/webhooks — event handlers", () => {
+  it("fulfills the checkout on checkout.session.completed and marks the event processed", async () => {
+    const session = makeStripeCheckoutSession({
+      userId: "user-42",
+      customerId: "cus_test_42",
+      subscriptionId: "sub_test_42",
+    });
+    const event = makeStripeEvent({
+      type: "checkout.session.completed",
+      object: session,
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFulfill).toHaveBeenCalledTimes(1);
+    expect(mockFulfill).toHaveBeenCalledWith(session);
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+    expect(mockUnclaimEvent).not.toHaveBeenCalled();
+  });
+
+  it("also fulfills the checkout on checkout.session.async_payment_succeeded", async () => {
+    const event = makeCheckoutSessionAsyncPaymentSucceededEvent({
+      userId: "user-async",
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFulfill).toHaveBeenCalledTimes(1);
+    expect(mockFulfill).toHaveBeenCalledWith(event.data.object);
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+  });
+
+  it("does not fulfill on checkout.session.async_payment_failed but still marks processed", async () => {
+    const event = makeCheckoutSessionAsyncPaymentFailedEvent();
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFulfill).not.toHaveBeenCalled();
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+  });
+
+  it("syncs the subscription on customer.subscription.updated with the resolved customer id", async () => {
+    const subscription = makeStripeSubscription({
+      id: "sub_test_updated",
+      customer: "cus_test_updated",
+      status: "active",
+    });
+    const event = makeStripeEvent({
+      type: "customer.subscription.updated",
+      object: subscription,
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncSubscription).toHaveBeenCalledTimes(1);
+    expect(mockSyncSubscription).toHaveBeenCalledWith(
+      mockStripe,
+      "sub_test_updated",
+      "cus_test_updated",
+    );
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+  });
+
+  it("resolves the customer id when subscription.customer is an expanded object", async () => {
+    const subscription = {
+      id: "sub_test_expanded",
+      object: "subscription",
+      customer: { id: "cus_test_expanded", object: "customer" },
+      status: "active",
+    } as unknown as Stripe.Subscription;
+    const event = makeStripeEvent({
+      type: "customer.subscription.updated",
+      object: subscription,
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncSubscription).toHaveBeenCalledWith(
+      mockStripe,
+      "sub_test_expanded",
+      "cus_test_expanded",
+    );
+  });
+
+  it("skips syncing when a subscription event has no resolvable customer id", async () => {
+    const subscription = {
+      id: "sub_test_no_customer",
+      object: "subscription",
+      customer: null,
+      status: "active",
+    } as unknown as Stripe.Subscription;
+    const event = makeStripeEvent({
+      type: "customer.subscription.updated",
+      object: subscription,
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncSubscription).not.toHaveBeenCalled();
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+  });
+
+  it("syncs the subscription on customer.subscription.deleted", async () => {
+    const event = makeSubscriptionDeletedEvent({
+      id: "sub_test_del",
+      customer: "cus_test_del",
+    });
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncSubscription).toHaveBeenCalledWith(
+      mockStripe,
+      "sub_test_del",
+      "cus_test_del",
+    );
+  });
+
+  it("no-ops on an unknown event type and still marks the event processed", async () => {
+    const event = makeUnknownStripeEvent();
+    primeHappyPath(event);
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFulfill).not.toHaveBeenCalled();
+    expect(mockSyncSubscription).not.toHaveBeenCalled();
+    expect(mockMarkProcessed).toHaveBeenCalledWith(event.id);
+  });
+});
+
+describe("POST /api/stripe/webhooks — handler failure recovery", () => {
+  it("unclaims the event and returns 500 without marking processed when the handler throws", async () => {
+    const event = makeSubscriptionUpdatedEvent();
+    primeHappyPath(event);
+    mockSyncSubscription.mockRejectedValueOnce(new Error("db unavailable"));
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Webhook handler failed",
+    });
+    expect(mockUnclaimEvent).toHaveBeenCalledWith(event.id);
+    expect(mockMarkProcessed).not.toHaveBeenCalled();
+    expect(mockMarkRemediation).not.toHaveBeenCalled();
+  });
+
+  it("flags the row for remediation when both the handler and unclaim fail", async () => {
+    const event = makeCheckoutSessionCompletedEvent();
+    primeHappyPath(event);
+    mockFulfill.mockRejectedValueOnce(new Error("handler boom"));
+    mockUnclaimEvent.mockRejectedValueOnce(new Error("unclaim boom"));
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockUnclaimEvent).toHaveBeenCalledWith(event.id);
+    expect(mockMarkRemediation).toHaveBeenCalledWith(event.id, "unclaim boom");
+    expect(mockMarkProcessed).not.toHaveBeenCalled();
+  });
+
+  it("still returns 500 when even the remediation write fails", async () => {
+    const event = makeCheckoutSessionCompletedEvent();
+    primeHappyPath(event);
+    mockFulfill.mockRejectedValueOnce(new Error("handler boom"));
+    mockUnclaimEvent.mockRejectedValueOnce(new Error("unclaim boom"));
+    mockMarkRemediation.mockRejectedValueOnce(new Error("flag boom"));
+
+    const response = await POST(
+      buildWebhookRequest("{}", { "stripe-signature": VALID_SIGNATURE_HEADER }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockMarkProcessed).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/stripe/webhooks/route.test.ts
+++ b/app/api/stripe/webhooks/route.test.ts
@@ -449,6 +449,7 @@ describe("POST /api/stripe/webhooks — handler failure recovery", () => {
     );
 
     expect(response.status).toBe(500);
+    expect(mockMarkRemediation).toHaveBeenCalledWith(event.id, "unclaim boom");
     expect(mockMarkProcessed).not.toHaveBeenCalled();
   });
 });

--- a/core/test-utils/README.md
+++ b/core/test-utils/README.md
@@ -10,12 +10,21 @@ This folder grows incrementally — add a helper only when a real test needs it.
 
 - `env.ts` — `createTestServerEnv`, `createTestClientEnv`. Return safe,
   placeholder env objects for mocking `@/core/data/env/*`.
-- `factories/` — pure data builders: `makeUser`, `makeProUser`,
-  `makeSession`, `makeExpiredSession`.
+- `factories/` — pure data builders:
+  - `makeUser`, `makeProUser`, `makeSession`, `makeExpiredSession`.
+  - `makeStripeSubscription`, `makeStripeCheckoutSession`,
+    `makeStripeEvent`, plus `makeCheckoutSessionCompletedEvent`,
+    `makeCheckoutSessionAsyncPaymentSucceededEvent`,
+    `makeCheckoutSessionAsyncPaymentFailedEvent`,
+    `makeSubscriptionUpdatedEvent`, `makeSubscriptionDeletedEvent`,
+    `makeUnknownStripeEvent`.
 - `render.tsx` — `renderWithProviders` that wraps children in
   `ThemeProvider` + `Toaster`, plus a re-export of every RTL export.
 - `mocks/next.ts` — factories for stubbing `next/cache`, `next/headers`,
   and `next/navigation`, plus tagged error classes for redirect / notFound.
+- `mocks/stripe.ts` — `createMockStripe`: a minimal Stripe client stub
+  exposing `webhooks.constructEvent` and `subscriptions.retrieve` as
+  `jest.fn()`s for route and sync tests.
 
 ## Conventions
 
@@ -80,12 +89,35 @@ import { NextRedirectError } from "@core/test-utils/mocks/next";
 await expect(signOutAction()).rejects.toBeInstanceOf(NextRedirectError);
 ```
 
+## Mocking Stripe at the route boundary
+
+The webhook route calls `getStripe()` and then `stripe.webhooks.constructEvent`.
+Tests replace both at the module boundary and feed a prebuilt event fixture
+through the mock instead of signing a real payload:
+
+```ts
+import { createMockStripe } from "@core/test-utils/mocks/stripe";
+import { makeCheckoutSessionCompletedEvent } from "@core/test-utils/factories";
+
+const stripe = createMockStripe();
+
+jest.mock("@/core/features/billing/stripe", () => ({
+  getStripe: () => stripe,
+}));
+
+const event = makeCheckoutSessionCompletedEvent({ userId: "user-1" });
+stripe.webhooks.constructEvent.mockReturnValueOnce(event);
+```
+
+Signature verification failure is simulated by making `constructEvent` throw.
+Collaborators downstream of the route (`webhookHelpers`, `stripeSync`) are
+mocked separately so the route's branching is the unit under test.
+
 ## Planned additions (ship with the PR that first needs them)
 
-- `mocks/stripe.ts` — Stripe client + signed webhook event fixture builder.
 - `mocks/db.ts` — chainable Drizzle query mock.
 - `mocks/ai.ts` — AI SDK stream stubs.
 - `mocks/arcjet.ts` — Arcjet `protect` allow/deny scenarios.
 - `mocks/hume.ts` — Hume API and `@humeai/voice-react` stubs.
-- `factories/jobInfo.ts`, `factories/interview.ts`, `factories/question.ts`,
-  `factories/stripeEvent.ts` — per-feature fixture builders.
+- `factories/jobInfo.ts`, `factories/interview.ts`, `factories/question.ts`
+  — per-feature fixture builders.

--- a/core/test-utils/README.md
+++ b/core/test-utils/README.md
@@ -17,7 +17,7 @@ This folder grows incrementally — add a helper only when a real test needs it.
     `makeCheckoutSessionAsyncPaymentSucceededEvent`,
     `makeCheckoutSessionAsyncPaymentFailedEvent`,
     `makeSubscriptionUpdatedEvent`, `makeSubscriptionDeletedEvent`,
-    `makeUnknownStripeEvent`.
+    `makeUnhandledStripeWebhookEvent`.
 - `render.tsx` — `renderWithProviders` that wraps children in
   `ThemeProvider` + `Toaster`, plus a re-export of every RTL export.
 - `mocks/next.ts` — factories for stubbing `next/cache`, `next/headers`,

--- a/core/test-utils/factories/index.ts
+++ b/core/test-utils/factories/index.ts
@@ -1,2 +1,13 @@
 export { makeUser, makeProUser } from "./user";
 export { makeSession, makeExpiredSession } from "./session";
+export {
+  makeStripeSubscription,
+  makeStripeCheckoutSession,
+  makeStripeEvent,
+  makeCheckoutSessionCompletedEvent,
+  makeCheckoutSessionAsyncPaymentSucceededEvent,
+  makeCheckoutSessionAsyncPaymentFailedEvent,
+  makeSubscriptionUpdatedEvent,
+  makeSubscriptionDeletedEvent,
+  makeUnknownStripeEvent,
+} from "./stripeEvent";

--- a/core/test-utils/factories/index.ts
+++ b/core/test-utils/factories/index.ts
@@ -9,5 +9,5 @@ export {
   makeCheckoutSessionAsyncPaymentFailedEvent,
   makeSubscriptionUpdatedEvent,
   makeSubscriptionDeletedEvent,
-  makeUnknownStripeEvent,
+  makeUnhandledStripeWebhookEvent,
 } from "./stripeEvent";

--- a/core/test-utils/factories/stripeEvent.test.ts
+++ b/core/test-utils/factories/stripeEvent.test.ts
@@ -1,0 +1,146 @@
+import type Stripe from "stripe";
+
+import {
+  makeCheckoutSessionAsyncPaymentFailedEvent,
+  makeCheckoutSessionAsyncPaymentSucceededEvent,
+  makeCheckoutSessionCompletedEvent,
+  makeStripeCheckoutSession,
+  makeStripeEvent,
+  makeStripeSubscription,
+  makeSubscriptionDeletedEvent,
+  makeSubscriptionUpdatedEvent,
+  makeUnknownStripeEvent,
+} from "./stripeEvent";
+
+describe("makeStripeSubscription", () => {
+  it("returns a subscription with placeholder defaults", () => {
+    const subscription = makeStripeSubscription();
+
+    expect(subscription.id).toMatch(/^sub_test_/);
+    expect(typeof subscription.customer).toBe("string");
+    expect(subscription.customer).toMatch(/^cus_test_/);
+    expect(subscription.status).toBe("active");
+  });
+
+  it("yields a unique id per call", () => {
+    const a = makeStripeSubscription();
+    const b = makeStripeSubscription();
+
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("shallow-merges overrides", () => {
+    const subscription = makeStripeSubscription({
+      id: "sub_test_custom",
+      status: "past_due",
+    });
+
+    expect(subscription.id).toBe("sub_test_custom");
+    expect(subscription.status).toBe("past_due");
+  });
+});
+
+describe("makeStripeCheckoutSession", () => {
+  it("sets metadata.userId, customer, and subscription with defaults", () => {
+    const session = makeStripeCheckoutSession();
+
+    expect(session.payment_status).toBe("paid");
+    expect(session.metadata?.userId).toMatch(/^user-/);
+    expect(typeof session.customer).toBe("string");
+    expect(typeof session.subscription).toBe("string");
+  });
+
+  it("omits metadata.userId when userId is explicitly null", () => {
+    const session = makeStripeCheckoutSession({ userId: null });
+
+    expect(session.metadata?.userId).toBeUndefined();
+  });
+
+  it("allows clearing customer and subscription via null overrides", () => {
+    const session = makeStripeCheckoutSession({
+      customerId: null,
+      subscriptionId: null,
+    });
+
+    expect(session.customer).toBeNull();
+    expect(session.subscription).toBeNull();
+  });
+
+  it("propagates paymentStatus overrides", () => {
+    const session = makeStripeCheckoutSession({ paymentStatus: "unpaid" });
+
+    expect(session.payment_status).toBe("unpaid");
+  });
+});
+
+describe("makeStripeEvent", () => {
+  it("wraps the given object inside data.object with the given type", () => {
+    const object = { id: "arbitrary" };
+
+    const event = makeStripeEvent({ type: "custom.event.type", object });
+
+    expect(event.type).toBe("custom.event.type");
+    expect(event.data.object).toBe(object);
+    expect(event.id).toMatch(/^evt_test_/);
+    expect(event.livemode).toBe(false);
+  });
+
+  it("respects an explicit event id override", () => {
+    const event = makeStripeEvent({
+      id: "evt_test_pinned",
+      type: "custom.x",
+      object: {},
+    });
+
+    expect(event.id).toBe("evt_test_pinned");
+  });
+});
+
+describe("named Stripe event builders", () => {
+  it("makeCheckoutSessionCompletedEvent has the correct type and nested session", () => {
+    const event = makeCheckoutSessionCompletedEvent({ userId: "user-c1" });
+
+    expect(event.type).toBe("checkout.session.completed");
+    const session = event.data.object as Stripe.Checkout.Session;
+    expect(session.metadata?.userId).toBe("user-c1");
+    expect(session.payment_status).toBe("paid");
+  });
+
+  it("makeCheckoutSessionAsyncPaymentSucceededEvent builds the success variant", () => {
+    const event = makeCheckoutSessionAsyncPaymentSucceededEvent();
+
+    expect(event.type).toBe("checkout.session.async_payment_succeeded");
+    const session = event.data.object as Stripe.Checkout.Session;
+    expect(session.payment_status).toBe("paid");
+  });
+
+  it("makeCheckoutSessionAsyncPaymentFailedEvent defaults paymentStatus to unpaid", () => {
+    const event = makeCheckoutSessionAsyncPaymentFailedEvent();
+
+    expect(event.type).toBe("checkout.session.async_payment_failed");
+    const session = event.data.object as Stripe.Checkout.Session;
+    expect(session.payment_status).toBe("unpaid");
+  });
+
+  it("makeSubscriptionUpdatedEvent wraps an active subscription", () => {
+    const event = makeSubscriptionUpdatedEvent();
+
+    expect(event.type).toBe("customer.subscription.updated");
+    const subscription = event.data.object as Stripe.Subscription;
+    expect(subscription.status).toBe("active");
+  });
+
+  it("makeSubscriptionDeletedEvent defaults the subscription status to canceled", () => {
+    const event = makeSubscriptionDeletedEvent();
+
+    expect(event.type).toBe("customer.subscription.deleted");
+    const subscription = event.data.object as Stripe.Subscription;
+    expect(subscription.status).toBe("canceled");
+  });
+
+  it("makeUnknownStripeEvent uses a type the webhook does not recognize", () => {
+    const event = makeUnknownStripeEvent();
+
+    expect(event.type).not.toMatch(/^(checkout|customer)\./);
+  });
+});

--- a/core/test-utils/factories/stripeEvent.test.ts
+++ b/core/test-utils/factories/stripeEvent.test.ts
@@ -9,7 +9,7 @@ import {
   makeStripeSubscription,
   makeSubscriptionDeletedEvent,
   makeSubscriptionUpdatedEvent,
-  makeUnknownStripeEvent,
+  makeUnhandledStripeWebhookEvent,
 } from "./stripeEvent";
 
 describe("makeStripeSubscription", () => {
@@ -138,9 +138,9 @@ describe("named Stripe event builders", () => {
     expect(subscription.status).toBe("canceled");
   });
 
-  it("makeUnknownStripeEvent uses a type the webhook does not recognize", () => {
-    const event = makeUnknownStripeEvent();
+  it("makeUnhandledStripeWebhookEvent uses a real type the webhook route does not handle", () => {
+    const event = makeUnhandledStripeWebhookEvent();
 
-    expect(event.type).not.toMatch(/^(checkout|customer)\./);
+    expect(event.type).toBe("invoice.voided");
   });
 });

--- a/core/test-utils/factories/stripeEvent.ts
+++ b/core/test-utils/factories/stripeEvent.ts
@@ -1,0 +1,199 @@
+/**
+ * Fixture builders for Stripe webhook events and their payload objects.
+ *
+ * These return `Stripe.Event` / `Stripe.Subscription` / `Stripe.Checkout.Session`
+ * shapes that are close enough to the real API for route tests. Only fields the
+ * webhook route and its collaborators actually read are guaranteed — the rest
+ * are minimal placeholders cast to satisfy TypeScript.
+ *
+ * Never put real customer emails or payment identifiers in tests. Defaults use
+ * `cus_test_*`, `sub_test_*`, `cs_test_*`, and `evt_test_*` placeholders.
+ */
+
+import type Stripe from "stripe";
+
+let eventCounter = 0;
+let sessionCounter = 0;
+let subscriptionCounter = 0;
+
+function nextEventIndex(): number {
+  eventCounter += 1;
+  return eventCounter;
+}
+
+function nextSessionIndex(): number {
+  sessionCounter += 1;
+  return sessionCounter;
+}
+
+function nextSubscriptionIndex(): number {
+  subscriptionCounter += 1;
+  return subscriptionCounter;
+}
+
+export type MakeStripeSubscriptionOverrides = Partial<
+  Pick<Stripe.Subscription, "id" | "customer" | "status">
+> & {
+  cancelAtPeriodEnd?: boolean;
+};
+
+/**
+ * Builds a minimal `Stripe.Subscription` fixture. Only the fields the app's
+ * sync logic reads (`id`, `customer`, `status`) are meaningful.
+ */
+export function makeStripeSubscription(
+  overrides: MakeStripeSubscriptionOverrides = {},
+): Stripe.Subscription {
+  const index = nextSubscriptionIndex();
+
+  const subscription = {
+    id: overrides.id ?? `sub_test_${index}`,
+    object: "subscription" as const,
+    customer: overrides.customer ?? `cus_test_${index}`,
+    status: overrides.status ?? "active",
+    cancel_at_period_end: overrides.cancelAtPeriodEnd ?? false,
+  };
+
+  return subscription as unknown as Stripe.Subscription;
+}
+
+export type MakeStripeCheckoutSessionOverrides = {
+  id?: string;
+  userId?: string | null;
+  customerId?: string | null;
+  subscriptionId?: string | null;
+  paymentStatus?: Stripe.Checkout.Session.PaymentStatus;
+};
+
+/**
+ * Builds a minimal `Stripe.Checkout.Session` fixture with the fields
+ * `fulfillCheckoutSession` reads: `metadata.userId`, `customer`,
+ * `subscription`, and `payment_status`.
+ */
+export function makeStripeCheckoutSession(
+  overrides: MakeStripeCheckoutSessionOverrides = {},
+): Stripe.Checkout.Session {
+  const index = nextSessionIndex();
+  const userId =
+    overrides.userId === undefined ? `user-${index}` : overrides.userId;
+
+  const session = {
+    id: overrides.id ?? `cs_test_${index}`,
+    object: "checkout.session" as const,
+    payment_status: overrides.paymentStatus ?? "paid",
+    metadata: userId === null ? {} : { userId },
+    customer:
+      overrides.customerId === undefined
+        ? `cus_test_${index}`
+        : overrides.customerId,
+    subscription:
+      overrides.subscriptionId === undefined
+        ? `sub_test_${index}`
+        : overrides.subscriptionId,
+  };
+
+  return session as unknown as Stripe.Checkout.Session;
+}
+
+export type MakeStripeEventOverrides<TObject> = {
+  id?: string;
+  type: Stripe.Event.Type | (string & {});
+  object: TObject;
+};
+
+/**
+ * Generic `Stripe.Event` builder. Prefer the named builders below
+ * (`makeCheckoutSessionCompletedEvent` etc.) unless you need a custom type.
+ */
+export function makeStripeEvent<TObject>(
+  overrides: MakeStripeEventOverrides<TObject>,
+): Stripe.Event {
+  const index = nextEventIndex();
+
+  const event = {
+    id: overrides.id ?? `evt_test_${index}`,
+    object: "event" as const,
+    type: overrides.type,
+    api_version: "2024-06-20",
+    created: Math.floor(Date.parse("2024-01-01T00:00:00Z") / 1000),
+    data: { object: overrides.object },
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+  };
+
+  return event as unknown as Stripe.Event;
+}
+
+export function makeCheckoutSessionCompletedEvent(
+  sessionOverrides: MakeStripeCheckoutSessionOverrides = {},
+  eventId?: string,
+): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "checkout.session.completed",
+    object: makeStripeCheckoutSession(sessionOverrides),
+  });
+}
+
+export function makeCheckoutSessionAsyncPaymentSucceededEvent(
+  sessionOverrides: MakeStripeCheckoutSessionOverrides = {},
+  eventId?: string,
+): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "checkout.session.async_payment_succeeded",
+    object: makeStripeCheckoutSession(sessionOverrides),
+  });
+}
+
+export function makeCheckoutSessionAsyncPaymentFailedEvent(
+  sessionOverrides: MakeStripeCheckoutSessionOverrides = {},
+  eventId?: string,
+): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "checkout.session.async_payment_failed",
+    object: makeStripeCheckoutSession({
+      paymentStatus: "unpaid",
+      ...sessionOverrides,
+    }),
+  });
+}
+
+export function makeSubscriptionUpdatedEvent(
+  subscriptionOverrides: MakeStripeSubscriptionOverrides = {},
+  eventId?: string,
+): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "customer.subscription.updated",
+    object: makeStripeSubscription(subscriptionOverrides),
+  });
+}
+
+export function makeSubscriptionDeletedEvent(
+  subscriptionOverrides: MakeStripeSubscriptionOverrides = {},
+  eventId?: string,
+): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "customer.subscription.deleted",
+    object: makeStripeSubscription({
+      status: "canceled",
+      ...subscriptionOverrides,
+    }),
+  });
+}
+
+/**
+ * Builds an event whose `type` the webhook route does not recognize, so the
+ * default branch (no-op, 200) can be asserted.
+ */
+export function makeUnknownStripeEvent(eventId?: string): Stripe.Event {
+  return makeStripeEvent({
+    id: eventId,
+    type: "invoice.voided" as Stripe.Event.Type,
+    object: {},
+  });
+}

--- a/core/test-utils/factories/stripeEvent.ts
+++ b/core/test-utils/factories/stripeEvent.ts
@@ -187,13 +187,16 @@ export function makeSubscriptionDeletedEvent(
 }
 
 /**
- * Builds an event whose `type` the webhook route does not recognize, so the
- * default branch (no-op, 200) can be asserted.
+ * Builds a real Stripe event (`invoice.voided` is a valid `Stripe.Event.Type`)
+ * that this app's webhook route does not handle, so tests can assert the
+ * default branch (no-op, HTTP 200).
  */
-export function makeUnknownStripeEvent(eventId?: string): Stripe.Event {
+export function makeUnhandledStripeWebhookEvent(
+  eventId?: string,
+): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "invoice.voided" as Stripe.Event.Type,
+    type: "invoice.voided",
     object: {},
   });
 }

--- a/core/test-utils/mocks/stripe.test.ts
+++ b/core/test-utils/mocks/stripe.test.ts
@@ -1,0 +1,31 @@
+import { createMockStripe } from "./stripe";
+
+describe("createMockStripe", () => {
+  it("returns jest.fn() instances for the surfaces the app consumes", () => {
+    const stripe = createMockStripe();
+
+    expect(jest.isMockFunction(stripe.webhooks.constructEvent)).toBe(true);
+    expect(jest.isMockFunction(stripe.subscriptions.retrieve)).toBe(true);
+  });
+
+  it("records constructEvent arguments so tests can assert the call shape", () => {
+    const stripe = createMockStripe();
+
+    stripe.webhooks.constructEvent("raw-body", "sig-header", "whsec_test");
+
+    expect(stripe.webhooks.constructEvent).toHaveBeenCalledTimes(1);
+    expect(stripe.webhooks.constructEvent).toHaveBeenCalledWith(
+      "raw-body",
+      "sig-header",
+      "whsec_test",
+    );
+  });
+
+  it("returns a fresh set of mocks per call so tests don't share state", () => {
+    const a = createMockStripe();
+    const b = createMockStripe();
+
+    expect(a.webhooks.constructEvent).not.toBe(b.webhooks.constructEvent);
+    expect(a.subscriptions.retrieve).not.toBe(b.subscriptions.retrieve);
+  });
+});

--- a/core/test-utils/mocks/stripe.ts
+++ b/core/test-utils/mocks/stripe.ts
@@ -1,0 +1,52 @@
+/**
+ * Factory for stubbing the Stripe SDK client in Jest.
+ *
+ * The webhook route calls `getStripe()` and then uses the returned client's
+ * `webhooks.constructEvent` (signature verification) and `subscriptions.retrieve`
+ * (subscription sync). The mock exposes both as `jest.fn()`s so tests can
+ * control return values and assert call shapes.
+ *
+ * Tests that exercise `@/core/features/billing/stripe` typically replace
+ * `getStripe` itself via `jest.mock`; the Stripe SDK is not re-implemented
+ * here — only the surface the route consumes.
+ *
+ * @example
+ *   const stripe = createMockStripe();
+ *   stripe.webhooks.constructEvent.mockReturnValue(event);
+ *
+ *   jest.mock("@/core/features/billing/stripe", () => ({
+ *     getStripe: () => stripe,
+ *   }));
+ */
+
+import type Stripe from "stripe";
+
+export type MockStripeClient = {
+  webhooks: {
+    constructEvent: jest.Mock<
+      Stripe.Event,
+      [string | Buffer, string | string[], string]
+    >;
+  };
+  subscriptions: {
+    retrieve: jest.Mock<Promise<Stripe.Subscription>, [string]>;
+  };
+};
+
+/**
+ * Returns a fresh stripe client mock with the minimal surface the app uses.
+ *
+ * `constructEvent` is a bare `jest.fn()` — set a return value per test to
+ * simulate a valid signature, or `mockImplementation(() => { throw … })` to
+ * simulate verification failure.
+ */
+export function createMockStripe(): MockStripeClient {
+  return {
+    webhooks: {
+      constructEvent: jest.fn(),
+    },
+    subscriptions: {
+      retrieve: jest.fn(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements roadmap **PR #2 / Phase 1a**: Jest coverage for `app/api/stripe/webhooks/route.ts` plus shared Stripe fixtures and a minimal client mock.

## Scope

- **Files covered:** `app/api/stripe/webhooks/route.ts` (via co-located `route.test.ts`).
- **Infra:** `core/test-utils/mocks/stripe.ts`, `core/test-utils/factories/stripeEvent.ts`, exports in `factories/index.ts`, README updates, and self-tests for the new helpers.

## Behavior covered

- Preconditions: missing webhook secret, Stripe not configured, missing signature, body read failure, invalid signature.
- Idempotency: `duplicate_processed` (200), `duplicate_in_progress` (503), `duplicate_remediation` (500).
- Event branches: checkout completed / async payment succeeded & failed, subscription updated & deleted (including expanded customer), unknown event type.
- Failure recovery: handler error triggers unclaim; unclaim failure flags remediation.

## Checklist

- [x] Happy path covered for each export (route + new test-utils surface).
- [x] Unhappy paths: auth / validation / external-service failure where applicable.
- [x] No real network / DB / Stripe / AI calls.
- [x] No customer emails or payment data in logs, fixtures, or assertions.

## Verification

- [x] `npm test` green
- [x] `npx biome check` on touched files
- [x] `npx tsc --noEmit` clean

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Stripe webhook event handling, including signature verification, idempotency, and event-type-specific processing.
  * Added test fixture builders for Stripe webhook events and subscription objects.
  * Added test coverage for Stripe mock client utilities.

* **Documentation**
  * Updated testing documentation with patterns and examples for webhook validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->