### PR TITLE
Consolidate Stripe webhook event type constants

### DIFF
--- a/app/api/stripe/webhooks/route.test.ts
+++ b/app/api/stripe/webhooks/route.test.ts
@@ -44,6 +44,7 @@ jest.mock("@/core/features/users/stripeSync", () => ({
 }));
 
 import { getStripe } from "@/core/features/billing/stripe";
+import { STRIPE_WEBHOOK_EVENT_TYPES } from "@/core/features/billing/stripeEventTypes";
 import {
   claimEvent,
   fulfillCheckoutSession,
@@ -250,7 +251,7 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
       subscriptionId: "sub_test_42",
     });
     const event = makeStripeEvent({
-      type: "checkout.session.completed",
+      type: STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionCompleted,
       object: session,
     });
     primeHappyPath(event);
@@ -302,7 +303,7 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
       status: "active",
     });
     const event = makeStripeEvent({
-      type: "customer.subscription.updated",
+      type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
       object: subscription,
     });
     primeHappyPath(event);
@@ -329,7 +330,7 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
       status: "active",
     } as unknown as Stripe.Subscription;
     const event = makeStripeEvent({
-      type: "customer.subscription.updated",
+      type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
       object: subscription,
     });
     primeHappyPath(event);
@@ -354,7 +355,7 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
       status: "active",
     } as unknown as Stripe.Subscription;
     const event = makeStripeEvent({
-      type: "customer.subscription.updated",
+      type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
       object: subscription,
     });
     primeHappyPath(event);

--- a/app/api/stripe/webhooks/route.ts
+++ b/app/api/stripe/webhooks/route.ts
@@ -26,6 +26,7 @@ import {
   fulfillCheckoutSession,
   markStripeEventProcessed,
 } from "@/core/features/billing/webhookHelpers";
+import { STRIPE_WEBHOOK_EVENT_TYPES } from "@/core/features/billing/stripeEventTypes";
 import { syncSubscriptionFromStripe } from "@/core/features/users/stripeSync";
 import { getStripe } from "@/core/features/billing/stripe";
 import { toSafeErrorMeta } from "@/core/lib/toSafeErrorMeta";
@@ -97,24 +98,24 @@ export async function POST(request: Request) {
 
   try {
     switch (event.type) {
-      case "checkout.session.completed":
-      case "checkout.session.async_payment_succeeded": {
+      case STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionCompleted:
+      case STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentSucceeded: {
         const session = event.data.object as Stripe.Checkout.Session;
         await fulfillCheckoutSession(session);
         break;
       }
 
-      case "checkout.session.async_payment_failed": {
+      case STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentFailed: {
         const session = event.data.object as Stripe.Checkout.Session;
         console.warn(
-          "checkout.session.async_payment_failed: async payment failed for checkout session",
+          `${STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentFailed}: async payment failed for checkout session`,
           "userId",
           session.metadata?.userId,
         );
         break;
       }
 
-      case "customer.subscription.updated": {
+      case STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated: {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId =
           typeof subscription.customer === "string"
@@ -126,7 +127,7 @@ export async function POST(request: Request) {
         break;
       }
 
-      case "customer.subscription.deleted": {
+      case STRIPE_WEBHOOK_EVENT_TYPES.subscriptionDeleted: {
         const subscription = event.data.object as Stripe.Subscription;
         const customerId =
           typeof subscription.customer === "string"

--- a/core/features/billing/stripeEventTypes.ts
+++ b/core/features/billing/stripeEventTypes.ts
@@ -1,0 +1,11 @@
+import type Stripe from "stripe";
+
+export const STRIPE_WEBHOOK_EVENT_TYPES = {
+  checkoutSessionCompleted: "checkout.session.completed",
+  checkoutSessionAsyncPaymentSucceeded:
+    "checkout.session.async_payment_succeeded",
+  checkoutSessionAsyncPaymentFailed: "checkout.session.async_payment_failed",
+  subscriptionUpdated: "customer.subscription.updated",
+  subscriptionDeleted: "customer.subscription.deleted",
+  invoiceVoided: "invoice.voided",
+} as const satisfies Record<string, Stripe.Event.Type>;

--- a/core/test-utils/factories/stripeEvent.test.ts
+++ b/core/test-utils/factories/stripeEvent.test.ts
@@ -1,5 +1,7 @@
 import type Stripe from "stripe";
 
+import { STRIPE_WEBHOOK_EVENT_TYPES } from "@/core/features/billing/stripeEventTypes";
+
 import {
   makeCheckoutSessionAsyncPaymentFailedEvent,
   makeCheckoutSessionAsyncPaymentSucceededEvent,
@@ -100,7 +102,9 @@ describe("named Stripe event builders", () => {
   it("makeCheckoutSessionCompletedEvent has the correct type and nested session", () => {
     const event = makeCheckoutSessionCompletedEvent({ userId: "user-c1" });
 
-    expect(event.type).toBe("checkout.session.completed");
+    expect(event.type).toBe(
+      STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionCompleted,
+    );
     const session = event.data.object as Stripe.Checkout.Session;
     expect(session.metadata?.userId).toBe("user-c1");
     expect(session.payment_status).toBe("paid");
@@ -109,7 +113,9 @@ describe("named Stripe event builders", () => {
   it("makeCheckoutSessionAsyncPaymentSucceededEvent builds the success variant", () => {
     const event = makeCheckoutSessionAsyncPaymentSucceededEvent();
 
-    expect(event.type).toBe("checkout.session.async_payment_succeeded");
+    expect(event.type).toBe(
+      STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentSucceeded,
+    );
     const session = event.data.object as Stripe.Checkout.Session;
     expect(session.payment_status).toBe("paid");
   });
@@ -117,7 +123,9 @@ describe("named Stripe event builders", () => {
   it("makeCheckoutSessionAsyncPaymentFailedEvent defaults paymentStatus to unpaid", () => {
     const event = makeCheckoutSessionAsyncPaymentFailedEvent();
 
-    expect(event.type).toBe("checkout.session.async_payment_failed");
+    expect(event.type).toBe(
+      STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentFailed,
+    );
     const session = event.data.object as Stripe.Checkout.Session;
     expect(session.payment_status).toBe("unpaid");
   });
@@ -125,7 +133,7 @@ describe("named Stripe event builders", () => {
   it("makeSubscriptionUpdatedEvent wraps an active subscription", () => {
     const event = makeSubscriptionUpdatedEvent();
 
-    expect(event.type).toBe("customer.subscription.updated");
+    expect(event.type).toBe(STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated);
     const subscription = event.data.object as Stripe.Subscription;
     expect(subscription.status).toBe("active");
   });
@@ -133,7 +141,7 @@ describe("named Stripe event builders", () => {
   it("makeSubscriptionDeletedEvent defaults the subscription status to canceled", () => {
     const event = makeSubscriptionDeletedEvent();
 
-    expect(event.type).toBe("customer.subscription.deleted");
+    expect(event.type).toBe(STRIPE_WEBHOOK_EVENT_TYPES.subscriptionDeleted);
     const subscription = event.data.object as Stripe.Subscription;
     expect(subscription.status).toBe("canceled");
   });
@@ -141,6 +149,6 @@ describe("named Stripe event builders", () => {
   it("makeUnhandledStripeWebhookEvent uses a real type the webhook route does not handle", () => {
     const event = makeUnhandledStripeWebhookEvent();
 
-    expect(event.type).toBe("invoice.voided");
+    expect(event.type).toBe(STRIPE_WEBHOOK_EVENT_TYPES.invoiceVoided);
   });
 });

--- a/core/test-utils/factories/stripeEvent.ts
+++ b/core/test-utils/factories/stripeEvent.ts
@@ -12,6 +12,8 @@
 
 import type Stripe from "stripe";
 
+import { STRIPE_WEBHOOK_EVENT_TYPES } from "@/core/features/billing/stripeEventTypes";
+
 let eventCounter = 0;
 let sessionCounter = 0;
 let subscriptionCounter = 0;
@@ -131,7 +133,7 @@ export function makeCheckoutSessionCompletedEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "checkout.session.completed",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionCompleted,
     object: makeStripeCheckoutSession(sessionOverrides),
   });
 }
@@ -142,7 +144,7 @@ export function makeCheckoutSessionAsyncPaymentSucceededEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "checkout.session.async_payment_succeeded",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentSucceeded,
     object: makeStripeCheckoutSession(sessionOverrides),
   });
 }
@@ -153,7 +155,7 @@ export function makeCheckoutSessionAsyncPaymentFailedEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "checkout.session.async_payment_failed",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionAsyncPaymentFailed,
     object: makeStripeCheckoutSession({
       paymentStatus: "unpaid",
       ...sessionOverrides,
@@ -167,7 +169,7 @@ export function makeSubscriptionUpdatedEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "customer.subscription.updated",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
     object: makeStripeSubscription(subscriptionOverrides),
   });
 }
@@ -178,7 +180,7 @@ export function makeSubscriptionDeletedEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "customer.subscription.deleted",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionDeleted,
     object: makeStripeSubscription({
       status: "canceled",
       ...subscriptionOverrides,
@@ -196,7 +198,7 @@ export function makeUnhandledStripeWebhookEvent(
 ): Stripe.Event {
   return makeStripeEvent({
     id: eventId,
-    type: "invoice.voided",
+    type: STRIPE_WEBHOOK_EVENT_TYPES.invoiceVoided,
     object: {},
   });
 }


### PR DESCRIPTION
## Summary
- Added a shared `STRIPE_WEBHOOK_EVENT_TYPES` module for Stripe webhook event names.
- Updated the webhook route and Stripe test factories to use the shared constants instead of repeated string literals.
- Updated route tests to reference the same constants, reducing drift between production code and fixtures.

## Testing
- `npx jest --selectProjects node --testMatch "**/*.test.ts"` passed.
- `npx biome check app/api/stripe/webhooks/route.ts app/api/stripe/webhooks/route.test.ts core/test-utils/factories/stripeEvent.ts core/test-utils/factories/stripeEvent.test.ts core/features/billing/stripeEventTypes.ts` passed.
- Confirmed the shared constants are imported and used in the route, fixtures, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized Stripe webhook event type definitions for improved consistency and maintainability across payment processing.

* **Tests**
  * Updated webhook and test factory assertions to align with centralized event type constants, ensuring payment event handling remains reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/25)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->