### PR TITLE
Add worktree-safe Jest discovery and shared Drizzle DB mocks

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -2,6 +2,28 @@
 
 ## Test coverage
 
+- Require Jest coverage for new behavior in auth, billing, AI workflows, and
+  database-backed feature flows.
+- Prefer narrow unit tests around module boundaries. Stub external services
+  such as Stripe, OAuth providers, Google AI, Hume, Arcjet, and the database.
+- Use shared helpers from `core/test-utils/` instead of ad hoc fixtures or
+  one-off mocks when a helper already exists.
+- Current baseline:
+  - Jest runs as separate `node` (`*.test.ts`) and `jsdom` (`*.test.tsx`)
+    projects.
+  - React Testing Library coverage exists for shared UI helpers.
+  - Auth/OAuth provider, linking, error-return, and connection flows have
+    coverage.
+  - Stripe webhook route branching and Stripe fixture helpers have coverage.
+- Planned next coverage helpers:
+  - `core/test-utils/mocks/db.ts` for chainable Drizzle query mocks.
+  - `core/test-utils/mocks/ai.ts` for AI SDK stream stubs.
+  - `core/test-utils/mocks/arcjet.ts` for allow/deny protection scenarios.
+  - `core/test-utils/mocks/hume.ts` for Hume API and voice-react stubs.
+  - Feature factories for job info, interviews, and questions.
+- When reviewing PRs, flag new feature logic without either a focused test or
+  an explicit explanation for why the behavior is covered elsewhere.
+
 ## Security-sensitive areas
 
 ## Common patterns to enforce

--- a/core/features/auth/oauth/connectUser.test.ts
+++ b/core/features/auth/oauth/connectUser.test.ts
@@ -13,63 +13,41 @@ import {
   UserOAuthAccountTable,
   UserTable,
 } from "@/core/drizzle/schema";
+import {
+  createDrizzleMutationChainMock,
+  createMockDrizzleDb,
+  createMockDrizzleTableQuery,
+} from "@core/test-utils/mocks/db";
 
 import { connectUserToAccount } from "@/core/features/auth/oauth/connectUser";
 import { OAuthUnverifiedEmailError } from "@/core/features/auth/oauth/errors";
 
 const mockTransaction = db.transaction as jest.MockedFunction<typeof db.transaction>;
 
-function chainUserInsert(insertReturning: { id: string }[]) {
-  return {
-    values: jest.fn().mockReturnValue({
-      onConflictDoNothing: jest.fn().mockReturnValue({
-        returning: jest.fn().mockResolvedValue(insertReturning),
-      }),
-    }),
-  };
-}
-
-function chainOAuthInsert() {
-  return {
-    values: jest.fn().mockReturnValue({
-      onConflictDoNothing: jest.fn().mockResolvedValue(undefined),
-    }),
-  };
-}
-
-function chainUpdate() {
-  return {
-    set: jest.fn().mockReturnValue({
-      where: jest.fn().mockResolvedValue(undefined),
-    }),
-  };
-}
-
 /** Shared tx shape: no OAuth link, email first null then row after insert conflict. */
 function createMockTxForInsertConflictRace() {
-  return {
+  const userQuery = createMockDrizzleTableQuery();
+  userQuery.findFirst
+    .mockResolvedValueOnce(null)
+    .mockResolvedValueOnce({
+      id: "winner-id",
+      emailVerified: null,
+    });
+
+  return createMockDrizzleDb({
     query: {
-      UserOAuthAccountTable: {
-        findFirst: jest.fn().mockResolvedValue(null),
-      },
-      UserTable: {
-        findFirst: jest
-          .fn()
-          .mockResolvedValueOnce(null)
-          .mockResolvedValueOnce({
-            id: "winner-id",
-            emailVerified: null,
-          }),
-      },
+      UserOAuthAccountTable: createMockDrizzleTableQuery({ findFirst: null }),
+      UserTable: userQuery,
     },
-    insert: jest.fn((table: unknown) => {
+    insert: (table) => {
       if (table === UserTable) {
-        return chainUserInsert([]);
+        return [];
       }
-      return chainOAuthInsert();
-    }),
-    update: jest.fn(() => chainUpdate()),
-  };
+
+      return undefined;
+    },
+    update: undefined,
+  });
 }
 
 describe("connectUserToAccount", () => {
@@ -79,16 +57,14 @@ describe("connectUserToAccount", () => {
 
   it("returns existing user when OAuth account is already linked", async () => {
     mockTransaction.mockImplementation(async (fn) => {
-      const tx = {
+      const tx = createMockDrizzleDb({
         query: {
-          UserOAuthAccountTable: {
-            findFirst: jest.fn().mockResolvedValue({ userId: "prior-user" }),
-          },
-          UserTable: { findFirst: jest.fn() },
+          UserOAuthAccountTable: createMockDrizzleTableQuery({
+            findFirst: { userId: "prior-user" },
+          }),
+          UserTable: createMockDrizzleTableQuery(),
         },
-        insert: jest.fn(),
-        update: jest.fn(),
-      };
+      });
       return fn(tx as never);
     });
 
@@ -108,33 +84,27 @@ describe("connectUserToAccount", () => {
   });
 
   it("reuses user by email and updates emailVerified when needed", async () => {
-    const updateSet = jest.fn().mockReturnValue({
-      where: jest.fn().mockResolvedValue(undefined),
-    });
+    const updateChain = createDrizzleMutationChainMock();
     const updateMock = jest.fn().mockReturnValue({
-      set: updateSet,
+      set: updateChain.set,
     });
 
     mockTransaction.mockImplementation(async (fn) => {
-      const tx = {
+      const tx = createMockDrizzleDb({
         query: {
-          UserOAuthAccountTable: {
-            findFirst: jest.fn().mockResolvedValue(null),
-          },
-          UserTable: {
-            findFirst: jest
-              .fn()
-              .mockResolvedValue({ id: "by-email", emailVerified: null }),
-          },
+          UserOAuthAccountTable: createMockDrizzleTableQuery({ findFirst: null }),
+          UserTable: createMockDrizzleTableQuery({
+            findFirst: { id: "by-email", emailVerified: null },
+          }),
         },
-        insert: jest.fn((table: unknown) => {
+        insert: (table) => {
           if (table === UserOAuthAccountTable) {
-            return chainOAuthInsert();
+            return undefined;
           }
           throw new Error("Unexpected UserTable insert when matching by email");
-        }),
-        update: updateMock,
-      };
+        },
+      });
+      tx.update = updateMock;
       return fn(tx as never);
     });
 
@@ -152,7 +122,7 @@ describe("connectUserToAccount", () => {
 
     expect(mockTransaction).toHaveBeenCalledTimes(1);
     expect(updateMock).toHaveBeenCalledWith(UserTable);
-    expect(updateSet).toHaveBeenCalledWith(
+    expect(updateChain.set).toHaveBeenCalledWith(
       expect.objectContaining({
         emailVerified: expect.any(Date),
       }),
@@ -161,23 +131,18 @@ describe("connectUserToAccount", () => {
 
   it("creates a user when insert returns a row", async () => {
     mockTransaction.mockImplementation(async (fn) => {
-      const tx = {
+      const tx = createMockDrizzleDb({
         query: {
-          UserOAuthAccountTable: {
-            findFirst: jest.fn().mockResolvedValue(null),
-          },
-          UserTable: {
-            findFirst: jest.fn().mockResolvedValue(null),
-          },
+          UserOAuthAccountTable: createMockDrizzleTableQuery({ findFirst: null }),
+          UserTable: createMockDrizzleTableQuery({ findFirst: null }),
         },
-        insert: jest.fn((table) => {
+        insert: (table) => {
           if (table === UserTable) {
-            return chainUserInsert([{ id: "generated-user-id" }]);
+            return [{ id: "generated-user-id" }];
           }
-          return chainOAuthInsert();
-        }),
-        update: jest.fn(),
-      };
+          return undefined;
+        },
+      });
       return fn(tx as never);
     });
 

--- a/core/test-utils/README.md
+++ b/core/test-utils/README.md
@@ -25,6 +25,8 @@ This folder grows incrementally — add a helper only when a real test needs it.
 - `mocks/stripe.ts` — `createMockStripe`: a minimal Stripe client stub
   exposing `webhooks.constructEvent` and `subscriptions.retrieve` as
   `jest.fn()`s for route and sync tests.
+- `mocks/db.ts` — Drizzle query and chainable mutation mock helpers for
+  database-backed unit tests.
 
 ## Conventions
 
@@ -115,7 +117,6 @@ mocked separately so the route's branching is the unit under test.
 
 ## Planned additions (ship with the PR that first needs them)
 
-- `mocks/db.ts` — chainable Drizzle query mock.
 - `mocks/ai.ts` — AI SDK stream stubs.
 - `mocks/arcjet.ts` — Arcjet `protect` allow/deny scenarios.
 - `mocks/hume.ts` — Hume API and `@humeai/voice-react` stubs.

--- a/core/test-utils/mocks/db.test.ts
+++ b/core/test-utils/mocks/db.test.ts
@@ -1,0 +1,100 @@
+import {
+  createDrizzleMutationChainMock,
+  createMockDrizzleDb,
+  createMockDrizzleTableQuery,
+} from "./db";
+
+describe("createDrizzleMutationChainMock", () => {
+  it("returns the same chain through Drizzle builder methods", () => {
+    const chain = createDrizzleMutationChainMock();
+
+    expect(chain.values({ id: "user-1" })).toBe(chain);
+    expect(chain.set({ name: "Updated" })).toBe(chain);
+    expect(chain.where({ kind: "predicate" })).toBe(chain);
+    expect(chain.from({ table: "users" })).toBe(chain);
+    expect(chain.onConflictDoNothing()).toBe(chain);
+  });
+
+  it("resolves returning rows from returning()", async () => {
+    const rows = [{ id: "user-1" }];
+    const chain = createDrizzleMutationChainMock(rows);
+
+    await expect(chain.returning({ id: "column" })).resolves.toBe(rows);
+  });
+});
+
+describe("createMockDrizzleTableQuery", () => {
+  it("exposes findFirst and findMany as jest functions with configured results", async () => {
+    const query = createMockDrizzleTableQuery({
+      findFirst: { id: "user-1" },
+      findMany: [{ id: "user-1" }, { id: "user-2" }],
+    });
+
+    await expect(query.findFirst({ columns: { id: true } })).resolves.toEqual({
+      id: "user-1",
+    });
+    await expect(query.findMany({})).resolves.toEqual([
+      { id: "user-1" },
+      { id: "user-2" },
+    ]);
+  });
+});
+
+describe("createMockDrizzleDb", () => {
+  it("returns chainable insert, update, delete, and select builders", async () => {
+    const db = createMockDrizzleDb({
+      insert: [{ id: "inserted" }],
+      update: [{ id: "updated" }],
+      delete: [{ id: "deleted" }],
+      select: [{ id: "selected" }],
+    });
+
+    await expect(
+      db.insert({ table: "users" }).values({}).returning(),
+    ).resolves.toEqual([{ id: "inserted" }]);
+    await expect(
+      db.update({ table: "users" }).set({}).where({}).returning(),
+    ).resolves.toEqual([{ id: "updated" }]);
+    await expect(
+      db.delete({ table: "users" }).where({}).returning(),
+    ).resolves.toEqual([{ id: "deleted" }]);
+    await expect(
+      db.select().from({ table: "users" }).where({}),
+    ).resolves.toEqual([{ id: "selected" }]);
+  });
+
+  it("runs transaction callbacks with an isolated transaction mock", async () => {
+    const db = createMockDrizzleDb();
+
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.insert({ table: "users" }).values({ id: "user-1" });
+
+        return "committed";
+      }),
+    ).resolves.toBe("committed");
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows mutation results to vary by table", async () => {
+    const usersTable = { name: "users" };
+    const sessionsTable = { name: "sessions" };
+    const db = createMockDrizzleDb({
+      insert: (table) => {
+        if (table === usersTable) {
+          return [{ id: "user-1" }];
+        }
+
+        return [{ id: "session-1" }];
+      },
+    });
+
+    await expect(db.insert(usersTable).values({}).returning()).resolves.toEqual([
+      { id: "user-1" },
+    ]);
+    await expect(
+      db.insert(sessionsTable).values({}).returning(),
+    ).resolves.toEqual([{ id: "session-1" }]);
+  });
+});

--- a/core/test-utils/mocks/db.ts
+++ b/core/test-utils/mocks/db.ts
@@ -1,0 +1,127 @@
+type AnyTable = unknown;
+type AnyPredicate = unknown;
+type AnySelection = unknown;
+type AnyRecord = Record<string, unknown>;
+type FixedMutationResult = unknown[] | AnyRecord | null | undefined;
+type MutationResultOption =
+  | FixedMutationResult
+  | ((table: AnyTable) => FixedMutationResult);
+
+export type DrizzleMutationChainMock<TResult = unknown> = {
+  values: jest.Mock<DrizzleMutationChainMock<TResult>, [AnyRecord]>;
+  set: jest.Mock<DrizzleMutationChainMock<TResult>, [AnyRecord]>;
+  where: jest.Mock<DrizzleMutationChainMock<TResult>, [AnyPredicate]>;
+  from: jest.Mock<DrizzleMutationChainMock<TResult>, [AnyTable]>;
+  orderBy: jest.Mock<DrizzleMutationChainMock<TResult>, [AnyPredicate]>;
+  limit: jest.Mock<DrizzleMutationChainMock<TResult>, [number]>;
+  onConflictDoNothing: jest.Mock<DrizzleMutationChainMock<TResult>, [unknown?]>;
+  returning: jest.Mock<Promise<TResult>, [AnySelection?]>;
+  then: Promise<TResult>["then"];
+  catch: Promise<TResult>["catch"];
+  finally: Promise<TResult>["finally"];
+};
+
+export type MockDrizzleTableQuery<TFindFirst = unknown, TFindMany = unknown> = {
+  findFirst: jest.Mock<Promise<TFindFirst>, [unknown?]>;
+  findMany: jest.Mock<Promise<TFindMany>, [unknown?]>;
+};
+
+export type MockDrizzleDb = {
+  query: Record<string, MockDrizzleTableQuery>;
+  insert: jest.Mock<DrizzleMutationChainMock, [AnyTable]>;
+  update: jest.Mock<DrizzleMutationChainMock, [AnyTable]>;
+  delete: jest.Mock<DrizzleMutationChainMock, [AnyTable]>;
+  select: jest.Mock<DrizzleMutationChainMock, [AnySelection?]>;
+  transaction: jest.Mock<Promise<unknown>, [(tx: MockDrizzleDb) => unknown]>;
+};
+
+type MockDrizzleDbOptions = {
+  query?: Record<string, MockDrizzleTableQuery>;
+  insert?: MutationResultOption;
+  update?: MutationResultOption;
+  delete?: MutationResultOption;
+  select?: MutationResultOption;
+};
+
+export function createDrizzleMutationChainMock<TResult = unknown>(
+  result?: TResult,
+): DrizzleMutationChainMock<TResult> {
+  const chain = {
+    values: jest.fn(),
+    set: jest.fn(),
+    where: jest.fn(),
+    from: jest.fn(),
+    orderBy: jest.fn(),
+    limit: jest.fn(),
+    onConflictDoNothing: jest.fn(),
+    returning: jest.fn(),
+  } as DrizzleMutationChainMock<TResult>;
+
+  chain.values.mockReturnValue(chain);
+  chain.set.mockReturnValue(chain);
+  chain.from.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+  chain.limit.mockReturnValue(chain);
+  chain.onConflictDoNothing.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.returning.mockResolvedValue(result as TResult);
+  chain.then = (...args) => Promise.resolve(result as TResult).then(...args);
+  chain.catch = (...args) => Promise.resolve(result as TResult).catch(...args);
+  chain.finally = (...args) =>
+    Promise.resolve(result as TResult).finally(...args);
+
+  return chain;
+}
+
+export function createMockDrizzleTableQuery<
+  TFindFirst = unknown,
+  TFindMany = unknown,
+>({
+  findFirst,
+  findMany,
+}: {
+  findFirst?: TFindFirst;
+  findMany?: TFindMany;
+} = {}): MockDrizzleTableQuery<TFindFirst, TFindMany> {
+  return {
+    findFirst: jest.fn().mockResolvedValue(findFirst),
+    findMany: jest.fn().mockResolvedValue(findMany),
+  };
+}
+
+export function createMockDrizzleDb({
+  query = {},
+  insert,
+  update,
+  delete: deleteResult,
+  select,
+}: MockDrizzleDbOptions = {}): MockDrizzleDb {
+  const resolveResult = (option: MutationResultOption, table: AnyTable) => {
+    if (typeof option === "function") {
+      return option(table);
+    }
+
+    return option;
+  };
+
+  const db = {
+    query,
+    insert: jest.fn((table) =>
+      createDrizzleMutationChainMock(resolveResult(insert, table)),
+    ),
+    update: jest.fn((table) =>
+      createDrizzleMutationChainMock(resolveResult(update, table)),
+    ),
+    delete: jest.fn((table) =>
+      createDrizzleMutationChainMock(resolveResult(deleteResult, table)),
+    ),
+    select: jest.fn((selection) =>
+      createDrizzleMutationChainMock(resolveResult(select, selection)),
+    ),
+    transaction: jest.fn(),
+  } as MockDrizzleDb;
+
+  db.transaction.mockImplementation(async (callback) => callback(db));
+
+  return db;
+}

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -13,14 +13,14 @@ const nodeConfig = createJestConfig({
   ...sharedConfig,
   displayName: "node",
   testEnvironment: "node",
-  testMatch: ["<rootDir>/**/*.test.ts"],
+  testMatch: ["**/*.test.ts"],
 });
 
 const jsdomConfig = createJestConfig({
   ...sharedConfig,
   displayName: "jsdom",
   testEnvironment: "jsdom",
-  testMatch: ["<rootDir>/**/*.test.tsx"],
+  testMatch: ["**/*.test.tsx"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 });
 

--- a/jest.config.test.ts
+++ b/jest.config.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("jestConfig", () => {
+  it("uses relative testMatch patterns so tests run from dotted worktree paths", async () => {
+    const configSource = readFileSync(
+      join(process.cwd(), "jest.config.mjs"),
+      "utf8",
+    );
+
+    expect(configSource).toContain('testMatch: ["**/*.test.ts"]');
+    expect(configSource).toContain('testMatch: ["**/*.test.tsx"]');
+    expect(configSource).not.toContain('testMatch: ["<rootDir>/**/*.test.ts"]');
+    expect(configSource).not.toContain('testMatch: ["<rootDir>/**/*.test.tsx"]');
+  });
+});


### PR DESCRIPTION
**Summary**
- Fixed Jest test discovery in dotted worktree paths by switching project `testMatch` patterns to relative globs.
- Added a regression test to keep worktree-safe discovery from regressing.
- Introduced shared Drizzle DB test helpers for chainable queries, transactions, and table-specific results.
- Refactored OAuth connect-user tests to use the shared DB mock and documented the helper in `core/test-utils`.
- Filled in `BUGBOT.md` with the current test coverage baseline and next planned coverage helpers.

**Testing**
- Jest suite passes locally in the worktree.
- TypeScript check passes.
- Added focused unit coverage for the new DB mock helper and a Jest config regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added database mock utilities to enhance test coverage for database-backed features.
  * Refactored existing tests to use shared mocking helpers.

* **Chores**
  * Updated Jest configuration for improved test pattern matching.
  * Enhanced test documentation with coverage guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/26)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->