### PR TITLE
Enable Biome Tailwind CSS directives and fix Hume effect deps

### DIFF
--- a/app/app/jobInfo/[jobInfoId]/interviews/new/_StartCall.tsx
+++ b/app/app/jobInfo/[jobInfoId]/interviews/new/_StartCall.tsx
@@ -77,10 +77,12 @@ export function StartCall({
 
   //** This means Hume prevents us from having an interview, so we need to show a toast */
   useEffect(() => {
-    if (readyState === VoiceReadyState.CLOSED && !messages.length) {
-      errorToast(HUME_UNAVAILABLE_MESSAGE);
+    if (readyState !== VoiceReadyState.CLOSED || messages.length > 0) {
+      return;
     }
-  }, [jobInfo.id, messages.length, readyState, router]);
+
+    errorToast(HUME_UNAVAILABLE_MESSAGE);
+  }, [messages.length, readyState]);
 
   const handleStartInterview = async () => {
     const res = await createInterviewAction({ jobInfoId: jobInfo.id });

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,7 @@
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": { "ignoreUnknown": false },
   "formatter": { "enabled": true, "indentStyle": "space", "lineEnding": "lf" },
+  "css": { "parser": { "tailwindDirectives": true } },
   "linter": {
     "enabled": true,
     "rules": {


### PR DESCRIPTION
**Summary**
- Enabled Biome's CSS Tailwind directive parsing so `app/globals.css` lints cleanly without rewriting valid Tailwind v4 syntax.
- Removed unnecessary dependencies from the Hume-unavailable effect in `_StartCall.tsx` and switched it to an early-return pattern.

**Testing**
- `npm run lint` passed.
- `npm test` passed.