### PR TITLE
Add test coverage script and document the coverage workflow

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -16,7 +16,6 @@
     coverage.
   - Stripe webhook route branching and Stripe fixture helpers have coverage.
 - Planned next coverage helpers:
-  - `core/test-utils/mocks/db.ts` for chainable Drizzle query mocks.
   - `core/test-utils/mocks/ai.ts` for AI SDK stream stubs.
   - `core/test-utils/mocks/arcjet.ts` for allow/deny protection scenarios.
   - `core/test-utils/mocks/hume.ts` for Hume API and voice-react stubs.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Copy the printed signing secret (`whsec_...`) into `STRIPE_WEBHOOK_SECRET`.
 
 ## Development Notes
 
-- There is currently no test runner script in `package.json`. If you add tests, follow the workspace convention (`Jest` + React Testing Library, one `*.test.ts` file per source file).
+- Run tests with `npm test` and coverage with `npm run test:coverage`. Follow the workspace convention (`Jest` + React Testing Library, one `*.test.ts` file per source file).
 - Stripe webhook handling is explicitly idempotent via the `stripe_events` table and re-fetching subscription state from Stripe.
 - The middleware intentionally skips Arcjet checks for Stripe routes and applies Arcjet mainly to `/api/**`.
 - Neon is a strong fit for Vercel deployments because it provides managed Postgres with straightforward hosted connection management (no containerized DB required in production).

--- a/jest.config.test.ts
+++ b/jest.config.test.ts
@@ -14,3 +14,16 @@ describe("jestConfig", () => {
     expect(configSource).not.toContain('testMatch: ["<rootDir>/**/*.test.tsx"]');
   });
 });
+
+describe("package scripts", () => {
+  it("exposes a coverage command for tracking test coverage", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), "package.json"), "utf8"),
+    );
+
+    expect(packageJson.scripts).toMatchObject({
+      test: "jest",
+      "test:coverage": "jest --coverage",
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "biome format --write .",
     "check": "biome check --write .",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
## Summary
- Added a `test:coverage` script to run Jest with coverage reporting
- Added a Jest config test that guards the coverage script presence
- Updated repo guidance to point to the current test and coverage commands
- Removed an already-completed helper from the pending coverage notes

## Testing
- Jest suite passed locally
- Coverage run completed successfully
- Biome lint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development notes with instructions for running tests and generating coverage reports.
  * Removed outdated documentation reference.

* **Chores**
  * Added `npm run test:coverage` script for generating test coverage reports.

* **Tests**
  * Added validation test to ensure npm scripts are properly configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/29)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->