### PR TITLE
Add focused pure-logic coverage for core helpers and route metadata

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -46,6 +46,55 @@ metadata in `core/data/routes.ts`, and then the first permission or schema
 helpers. Defer broad thresholds until these gaps are covered and the OAuth
 modules are reviewed as a separate, mock-heavy slice.
 
+## Progress Notes
+
+### Pure Logic Slice - 2026-05-15
+
+Files/tests added:
+
+- `core/lib/assertUUID.test.ts`
+- `core/lib/toSafeErrorMeta.test.ts`
+- `core/lib/utils.test.ts`
+- `core/data/routes.test.ts`
+- `core/features/auth/schemas.test.ts`
+- `core/features/jobInfos/schemas.test.ts`
+- `core/features/jobInfos/lib/formatters.test.ts`
+- `core/features/questions/formatters.test.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/lib/assertUUID.test.ts core/lib/toSafeErrorMeta.test.ts core/lib/utils.test.ts core/data/routes.test.ts core/features/jobInfos/lib/formatters.test.ts core/features/questions/formatters.test.ts core/features/jobInfos/schemas.test.ts core/features/auth/schemas.test.ts`
+- `npm test`
+- `npm.cmd test`
+- `npm run test:coverage`
+- `npm.cmd run test:coverage`
+
+Result:
+
+- Focused slice passed: 8 test suites, 29 tests, 0 snapshots.
+- `npm test` and `npm run test:coverage` still fail in PowerShell before Jest
+  starts because the unsigned `npm.ps1` shim is blocked by the local execution
+  policy.
+- `npm.cmd test` passed: 28 test suites, 159 tests, 0 snapshots.
+- `npm.cmd run test:coverage` passed: 28 test suites, 159 tests, 0 snapshots.
+- Updated coverage summary: 69.57% statements, 66.18% branches, 65.33%
+  functions, and 72.6% lines.
+
+Notes:
+
+- Jest continues to emit repeated `baseline-browser-mapping` warnings that the
+  local data is over two months old. This did not block test or coverage
+  execution.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Continue with the next low-mock slice by covering `core/features/auth/password.ts`
+and lightweight permission behavior with module-level auth/user mocks. After
+that, move into service-layer tests using the existing database mock helpers.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/data/routes.test.ts
+++ b/core/data/routes.test.ts
@@ -1,0 +1,48 @@
+import { routes } from "@/core/data/routes";
+
+describe("routes", () => {
+  it("exposes stable top-level page routes", () => {
+    expect(routes).toEqual(
+      expect.objectContaining({
+        landing: "/",
+        app: "/app",
+        signIn: "/sign-in",
+        signUp: "/sign-up",
+        upgrade: "/app/upgrade",
+        newJobInfo: "/app/jobInfo/new",
+      }),
+    );
+  });
+
+  it("builds job info nested routes from ids without mutating the values", () => {
+    const jobInfoId = "job-123";
+    const interviewId = "interview-456";
+
+    expect(routes.jobInfo(jobInfoId)).toBe("/app/jobInfo/job-123");
+    expect(routes.interviews(jobInfoId)).toBe(
+      "/app/jobInfo/job-123/interviews",
+    );
+    expect(routes.newInterview(jobInfoId)).toBe(
+      "/app/jobInfo/job-123/interviews/new",
+    );
+    expect(routes.interview(jobInfoId, interviewId)).toBe(
+      "/app/jobInfo/job-123/interviews/interview-456",
+    );
+    expect(routes.questions(jobInfoId)).toBe("/app/jobInfo/job-123/questions");
+  });
+
+  it("builds interview feedback routes", () => {
+    expect(routes.feedback("interview-456")).toBe(
+      "/app/interviews/interview-456/feedback",
+    );
+  });
+
+  it("exposes stable API routes", () => {
+    expect(routes.api).toEqual({
+      aiResumeAnalysis: "/api/ai/resumes/analyze",
+      aiQuestionGeneration: "/api/ai/questions/generate-question",
+      aiQuestionFeedback: "/api/ai/questions/generate-feedback",
+      validateSession: "/api/auth/validate-session",
+    });
+  });
+});

--- a/core/features/auth/schemas.test.ts
+++ b/core/features/auth/schemas.test.ts
@@ -1,0 +1,90 @@
+import { signInSchema, signUpSchema } from "@/core/features/auth/schemas";
+
+describe("signUpSchema", () => {
+  it("trims names and emails while preserving password whitespace", () => {
+    const result = signUpSchema.parse({
+      name: "  Ada Lovelace  ",
+      email: "  ada@example.test  ",
+      password: "  abc12345  ",
+    });
+
+    expect(result).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.test",
+      password: "  abc12345  ",
+    });
+  });
+
+  it("requires password letters and numbers", () => {
+    const result = signUpSchema.safeParse({
+      name: "Ada Lovelace",
+      email: "ada@example.test",
+      password: "abcdefgh",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.flatten().fieldErrors.password).toContain(
+      "Password must contain at least one letter and one number",
+    );
+  });
+
+  it("rejects blank names and invalid emails", () => {
+    const result = signUpSchema.safeParse({
+      name: "  ",
+      email: "not-an-email",
+      password: "abc12345",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.flatten().fieldErrors).toEqual(
+      expect.objectContaining({
+        name: ["Name is required"],
+        email: ["Invalid email address"],
+      }),
+    );
+  });
+});
+
+describe("signInSchema", () => {
+  it("trims emails while preserving password whitespace", () => {
+    const result = signInSchema.parse({
+      email: "  ada@example.test  ",
+      password: "  abc12345  ",
+    });
+
+    expect(result).toEqual({
+      email: "ada@example.test",
+      password: "  abc12345  ",
+    });
+  });
+
+  it("rejects missing credentials", () => {
+    const result = signInSchema.safeParse({
+      email: "",
+      password: "",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.flatten().fieldErrors.email).toContain(
+      "Email is required",
+    );
+    expect(result.error.flatten().fieldErrors.password).toContain(
+      "Password is required",
+    );
+  });
+});

--- a/core/features/jobInfos/lib/formatters.test.ts
+++ b/core/features/jobInfos/lib/formatters.test.ts
@@ -1,0 +1,17 @@
+import { formatExperienceLevel } from "@/core/features/jobInfos/lib/formatters";
+
+describe("formatExperienceLevel", () => {
+  it.each([
+    ["junior", "Junior"],
+    ["mid-level", "Mid-Level"],
+    ["senior", "Senior"],
+  ] as const)("formats %s as %s", (level, expected) => {
+    expect(formatExperienceLevel(level)).toBe(expected);
+  });
+
+  it("throws for unknown levels", () => {
+    expect(() => formatExperienceLevel("lead" as never)).toThrow(
+      "Unknown experience level: lead",
+    );
+  });
+});

--- a/core/features/jobInfos/schemas.test.ts
+++ b/core/features/jobInfos/schemas.test.ts
@@ -1,0 +1,53 @@
+import { jobInfoSchema } from "@/core/features/jobInfos/schemas";
+
+describe("jobInfoSchema", () => {
+  const validJobInfo = {
+    name: "Backend role",
+    title: "Senior Engineer",
+    experienceLevel: "senior",
+    description: "Build APIs and lead delivery.",
+  };
+
+  it("accepts valid job info input", () => {
+    expect(jobInfoSchema.parse(validJobInfo)).toEqual(validJobInfo);
+  });
+
+  it("allows a nullable title", () => {
+    const input = {
+      ...validJobInfo,
+      title: null,
+    };
+
+    expect(jobInfoSchema.parse(input).title).toBeNull();
+  });
+
+  it("rejects missing required text fields", () => {
+    const result = jobInfoSchema.safeParse({
+      ...validJobInfo,
+      name: "",
+      description: "",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.flatten().fieldErrors).toEqual(
+      expect.objectContaining({
+        name: ["Required"],
+        description: ["Required"],
+      }),
+    );
+  });
+
+  it("rejects unsupported experience levels", () => {
+    const result = jobInfoSchema.safeParse({
+      ...validJobInfo,
+      experienceLevel: "lead",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/core/features/questions/formatters.test.ts
+++ b/core/features/questions/formatters.test.ts
@@ -1,0 +1,17 @@
+import { formatQuestionDifficulty } from "@/core/features/questions/formatters";
+
+describe("formatQuestionDifficulty", () => {
+  it.each([
+    ["easy", "Easy"],
+    ["medium", "Medium"],
+    ["hard", "Hard"],
+  ] as const)("formats %s as %s", (difficulty, expected) => {
+    expect(formatQuestionDifficulty(difficulty)).toBe(expected);
+  });
+
+  it("throws for unknown difficulties", () => {
+    expect(() => formatQuestionDifficulty("expert" as never)).toThrow(
+      "Unknown question difficulty: expert",
+    );
+  });
+});

--- a/core/lib/assertUUID.test.ts
+++ b/core/lib/assertUUID.test.ts
@@ -1,0 +1,14 @@
+import { assertUUID } from "@/core/lib/assertUUID";
+
+describe("assertUUID", () => {
+  it("accepts valid UUID values", () => {
+    expect(assertUUID("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    expect(assertUUID("00000000-0000-4000-8000-000000000000")).toBe(true);
+  });
+
+  it("rejects non-UUID values", () => {
+    expect(assertUUID("")).toBe(false);
+    expect(assertUUID("job-info-id")).toBe(false);
+    expect(assertUUID("550e8400-e29b-41d4-a716")).toBe(false);
+  });
+});

--- a/core/lib/toSafeErrorMeta.test.ts
+++ b/core/lib/toSafeErrorMeta.test.ts
@@ -1,0 +1,29 @@
+import { toSafeErrorMeta } from "@/core/lib/toSafeErrorMeta";
+
+describe("toSafeErrorMeta", () => {
+  it("keeps the error name while omitting message and stack", () => {
+    const error = new TypeError("Sensitive failure details");
+
+    expect(toSafeErrorMeta(error)).toEqual({ name: "TypeError" });
+  });
+
+  it("stringifies truthy error codes", () => {
+    const error = Object.assign(new Error("Payment failed"), { code: 402 });
+
+    expect(toSafeErrorMeta(error)).toEqual({
+      name: "Error",
+      code: "402",
+    });
+  });
+
+  it("omits missing or falsy error codes", () => {
+    const error = Object.assign(new Error("Validation failed"), { code: "" });
+
+    expect(toSafeErrorMeta(error)).toEqual({ name: "Error" });
+  });
+
+  it("returns UnknownError for non-Error values", () => {
+    expect(toSafeErrorMeta("boom")).toEqual({ name: "UnknownError" });
+    expect(toSafeErrorMeta(null)).toEqual({ name: "UnknownError" });
+  });
+});

--- a/core/lib/utils.test.ts
+++ b/core/lib/utils.test.ts
@@ -1,0 +1,13 @@
+import { cn } from "@/core/lib/utils";
+
+describe("cn", () => {
+  it("joins string and conditional class names", () => {
+    expect(cn("items-center", false && "hidden", { "gap-2": true })).toBe(
+      "items-center gap-2",
+    );
+  });
+
+  it("lets later Tailwind classes override earlier conflicting classes", () => {
+    expect(cn("px-2 py-1", "px-4")).toBe("py-1 px-4");
+  });
+});


### PR DESCRIPTION
## Summary
- Added fast, low-mock tests for `core/lib`, `core/data/routes.ts`, and selected schema/formatter helpers.
- Covered UUID validation, safe error metadata, class merging, route builders, and auth/job-info/question schema behavior.
- Documented the slice in `TEST_COVERAGE_PLAN.md` with run details, results, and the next recommended slice.

## Testing
- `npm.cmd test` 
- `npm.cmd run test:coverage`
- Focused new tests passed locally; the PowerShell `npm` shim still fails before Jest starts due to execution policy, so the equivalent `npm.cmd` commands were used for verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for routes validation, authentication and sign-up schemas, job information and question formatters, UUID validation utilities, error metadata handling, and core utility functions to improve code reliability and maintainability.

* **Documentation**
  * Updated test coverage documentation with progress tracking, test execution results, and recommended next steps for continued test expansion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/32)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->