### PR TITLE
Add password and permission coverage tests

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -95,6 +95,54 @@ Continue with the next low-mock slice by covering `core/features/auth/password.t
 and lightweight permission behavior with module-level auth/user mocks. After
 that, move into service-layer tests using the existing database mock helpers.
 
+### Password and Permission Helpers Slice - 2026-05-15
+
+Files/tests added:
+
+- `core/features/auth/password.test.ts`
+- `core/features/auth/permissions.test.ts`
+- `core/features/questions/permissions.test.ts`
+- `core/features/interviews/permissions.test.ts`
+- `core/features/resumeAnalysis/permissions.test.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/features/auth/password.test.ts core/features/auth/permissions.test.ts`
+- `npm.cmd test -- core/features/auth/password.test.ts core/features/auth/permissions.test.ts core/features/questions/permissions.test.ts core/features/interviews/permissions.test.ts core/features/resumeAnalysis/permissions.test.ts`
+- `npm test`
+- `npm.cmd test`
+- `npm run test:coverage`
+- `npm.cmd run test:coverage`
+
+Result:
+
+- Initial focused run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd ci` installed dependencies from `package-lock.json`.
+- Focused slice passed: 5 test suites, 26 tests, 0 snapshots.
+- `npm test` and `npm run test:coverage` still fail in PowerShell before Jest
+  starts because the unsigned `npm.ps1` shim is blocked by the local execution
+  policy.
+- `npm.cmd test` passed: 33 test suites, 185 tests, 0 snapshots.
+- `npm.cmd run test:coverage` passed: 33 test suites, 185 tests, 0 snapshots.
+- Updated coverage summary: 73.85% statements, 72.15% branches, 69.18%
+  functions, and 76.9% lines.
+
+Notes:
+
+- Jest continues to emit repeated `baseline-browser-mapping` warnings that the
+  local data is over two months old. This did not block test or coverage
+  execution.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Move next into service-layer tests for `core/features/jobInfos/service.ts`,
+`core/features/interviews/service.ts`, and `core/features/questions/service.ts`
+using the existing database mock helpers. Keep API routes and OAuth base-flow
+coverage as separate mock-heavy slices.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/password.test.ts
+++ b/core/features/auth/password.test.ts
@@ -1,0 +1,69 @@
+import {
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
+} from "@/core/features/auth/constants";
+
+import {
+  hashPassword,
+  normalizePassword,
+  validatePassword,
+  verifyPassword,
+} from "./password";
+
+describe("normalizePassword", () => {
+  it("normalizes canonically equivalent Unicode passwords to NFC", () => {
+    const decomposed = "Cafe\u0301123";
+    const composed = "Caf\u00e9123";
+
+    expect(normalizePassword(decomposed)).toBe(composed);
+  });
+});
+
+describe("password hashing", () => {
+  it("hashes normalized passwords and verifies canonically equivalent input", async () => {
+    const hash = await hashPassword("Cafe\u0301123");
+
+    expect(hash).not.toBe("Cafe\u0301123");
+    await expect(verifyPassword("Caf\u00e9123", hash)).resolves.toBe(true);
+  });
+
+  it("rejects non-matching passwords", async () => {
+    const hash = await hashPassword("Correct123");
+
+    await expect(verifyPassword("Wrong123", hash)).resolves.toBe(false);
+  });
+});
+
+describe("validatePassword", () => {
+  it("accepts passwords within length limits that include letters and numbers", () => {
+    expect(validatePassword("abc12345")).toEqual({ isValid: true });
+  });
+
+  it("rejects passwords shorter than the minimum length", () => {
+    expect(validatePassword("a1".repeat(MIN_PASSWORD_LENGTH / 2 - 1))).toEqual({
+      isValid: false,
+      error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+    });
+  });
+
+  it("rejects passwords longer than the maximum length after normalization", () => {
+    const password = `A1${"x".repeat(MAX_PASSWORD_LENGTH - 1)}`;
+
+    expect(validatePassword(password)).toEqual({
+      isValid: false,
+      error: `Password must be less than ${MAX_PASSWORD_LENGTH} characters`,
+    });
+  });
+
+  it("requires at least one ASCII letter and one number", () => {
+    expect(validatePassword("abcdefgh")).toEqual({
+      isValid: false,
+      error: "Password must contain at least one letter and one number",
+    });
+
+    expect(validatePassword("12345678")).toEqual({
+      isValid: false,
+      error: "Password must contain at least one letter and one number",
+    });
+  });
+});

--- a/core/features/auth/permissions.test.ts
+++ b/core/features/auth/permissions.test.ts
@@ -1,0 +1,105 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/actions", () => ({
+  getUser: jest.fn(),
+}));
+
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  FREE_PLAN_LIMITS,
+  getUserPlan,
+  getUserSubscriptionInfo,
+  hasPermission,
+  hasUnlimitedAccess,
+  PERMISSIONS,
+} from "@/core/features/auth/permissions";
+import { getUser } from "@/core/features/users/actions";
+import { makeProUser, makeUser } from "@core/test-utils/factories/user";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetUser = jest.mocked(getUser);
+
+describe("auth permission helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("exposes free plan limits used by feature permission checks", () => {
+    expect(FREE_PLAN_LIMITS).toEqual({
+      interviews: 1,
+      questions: 10,
+      resume_analyses: 3,
+    });
+  });
+
+  it("denies permissions when there is no signed-in user", async () => {
+    mockGetCurrentUser.mockResolvedValue({ userId: null });
+
+    await expect(
+      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
+    ).resolves.toBe(false);
+
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("denies permissions when the signed-in user cannot be loaded", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    await expect(
+      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
+    ).resolves.toBe(false);
+  });
+
+  it("grants limited free-plan permissions and denies pro-only permissions", async () => {
+    mockGetUser.mockResolvedValue(makeUser({ plan: "free" }));
+
+    await expect(
+      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
+    ).resolves.toBe(true);
+    await expect(
+      hasPermission(PERMISSIONS.UNLIMITED.QUESTIONS),
+    ).resolves.toBe(false);
+  });
+
+  it("grants unlimited permissions for pro users", async () => {
+    mockGetUser.mockResolvedValue(makeProUser());
+
+    await expect(
+      hasPermission(PERMISSIONS.UNLIMITED.INTERVIEWS),
+    ).resolves.toBe(true);
+    await expect(hasUnlimitedAccess("questions")).resolves.toBe(true);
+  });
+
+  it("defaults missing user plans to free", async () => {
+    mockGetUser.mockResolvedValue(makeUser({ plan: null }));
+
+    await expect(getUserPlan()).resolves.toBe("free");
+    await expect(
+      hasPermission(PERMISSIONS.LIMITED.INTERVIEWS),
+    ).resolves.toBe(true);
+  });
+
+  it("returns subscription info for anonymous users without loading a user", async () => {
+    mockGetCurrentUser.mockResolvedValue({ userId: null });
+
+    await expect(getUserSubscriptionInfo()).resolves.toEqual({
+      plan: "free",
+      hasExistingSubscription: false,
+    });
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("reports the current plan and whether a Stripe subscription exists", async () => {
+    mockGetUser.mockResolvedValue(
+      makeProUser({ stripeSubscriptionId: "sub_test_1" }),
+    );
+
+    await expect(getUserSubscriptionInfo()).resolves.toEqual({
+      plan: "pro",
+      hasExistingSubscription: true,
+    });
+  });
+});

--- a/core/features/interviews/permissions.test.ts
+++ b/core/features/interviews/permissions.test.ts
@@ -1,0 +1,86 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/permissions", () => ({
+  FREE_PLAN_LIMITS: {
+    interviews: 1,
+    questions: 10,
+    resume_analyses: 3,
+  },
+  PERMISSIONS: {
+    UNLIMITED: {
+      INTERVIEWS: "unlimited_interviews",
+      QUESTIONS: "unlimited_questions",
+      RESUME_ANALYSES: "unlimited_resume_analyses",
+    },
+    LIMITED: {
+      INTERVIEWS: "limited_interviews",
+      QUESTIONS: "limited_questions",
+    },
+  },
+  hasPermission: jest.fn(),
+}));
+
+jest.mock("@/core/features/interviews/db", () => ({
+  getInterviewCountDb: jest.fn(),
+}));
+
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  FREE_PLAN_LIMITS,
+  hasPermission,
+  PERMISSIONS,
+} from "@/core/features/auth/permissions";
+import { getInterviewCountDb } from "@/core/features/interviews/db";
+
+import { checkInterviewPermission } from "./permissions";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockHasPermission = jest.mocked(hasPermission);
+const mockGetInterviewCountDb = jest.mocked(getInterviewCountDb);
+
+describe("checkInterviewPermission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockHasPermission.mockResolvedValue(false);
+  });
+
+  it("allows users with unlimited interview permission without reading usage", async () => {
+    mockHasPermission.mockResolvedValueOnce(true);
+
+    await expect(checkInterviewPermission()).resolves.toBe(true);
+
+    expect(mockHasPermission).toHaveBeenCalledWith(
+      PERMISSIONS.UNLIMITED.INTERVIEWS,
+    );
+    expect(mockGetInterviewCountDb).not.toHaveBeenCalled();
+  });
+
+  it("denies users without limited or unlimited interview permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    await expect(checkInterviewPermission()).resolves.toBe(false);
+
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetInterviewCountDb).not.toHaveBeenCalled();
+  });
+
+  it("allows limited users below the free interview limit", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockGetInterviewCountDb.mockResolvedValue(FREE_PLAN_LIMITS.interviews - 1);
+
+    await expect(checkInterviewPermission()).resolves.toBe(true);
+
+    expect(mockGetInterviewCountDb).toHaveBeenCalledWith("user-1");
+  });
+
+  it("denies limited users at the free interview limit", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockGetInterviewCountDb.mockResolvedValue(FREE_PLAN_LIMITS.interviews);
+
+    await expect(checkInterviewPermission()).resolves.toBe(false);
+  });
+
+});

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -1,0 +1,93 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/permissions", () => ({
+  FREE_PLAN_LIMITS: {
+    interviews: 1,
+    questions: 10,
+    resume_analyses: 3,
+  },
+  PERMISSIONS: {
+    UNLIMITED: {
+      INTERVIEWS: "unlimited_interviews",
+      QUESTIONS: "unlimited_questions",
+      RESUME_ANALYSES: "unlimited_resume_analyses",
+    },
+    LIMITED: {
+      INTERVIEWS: "limited_interviews",
+      QUESTIONS: "limited_questions",
+    },
+  },
+  hasPermission: jest.fn(),
+}));
+
+jest.mock("@/core/features/questions/db", () => ({
+  getQuestionCountDb: jest.fn(),
+}));
+
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  FREE_PLAN_LIMITS,
+  hasPermission,
+  PERMISSIONS,
+} from "@/core/features/auth/permissions";
+import { getQuestionCountDb } from "@/core/features/questions/db";
+
+import { checkQuestionsPermission } from "./permissions";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockHasPermission = jest.mocked(hasPermission);
+const mockGetQuestionCountDb = jest.mocked(getQuestionCountDb);
+
+describe("checkQuestionsPermission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockHasPermission.mockResolvedValue(false);
+  });
+
+  it("denies anonymous users without checking plan permissions", async () => {
+    mockGetCurrentUser.mockResolvedValue({ userId: null });
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(mockHasPermission).not.toHaveBeenCalled();
+    expect(mockGetQuestionCountDb).not.toHaveBeenCalled();
+  });
+
+  it("allows users with unlimited question permission without reading usage", async () => {
+    mockHasPermission.mockResolvedValueOnce(true);
+
+    await expect(checkQuestionsPermission()).resolves.toBe(true);
+
+    expect(mockHasPermission).toHaveBeenCalledWith(
+      PERMISSIONS.UNLIMITED.QUESTIONS,
+    );
+    expect(mockGetQuestionCountDb).not.toHaveBeenCalled();
+  });
+
+  it("denies users without limited or unlimited question permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(mockGetQuestionCountDb).not.toHaveBeenCalled();
+  });
+
+  it("allows limited users below the free question limit", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockGetQuestionCountDb.mockResolvedValue(FREE_PLAN_LIMITS.questions - 1);
+
+    await expect(checkQuestionsPermission()).resolves.toBe(true);
+
+    expect(mockGetQuestionCountDb).toHaveBeenCalledWith("user-1");
+  });
+
+  it("denies limited users at the free question limit", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockGetQuestionCountDb.mockResolvedValue(FREE_PLAN_LIMITS.questions);
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+  });
+});

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/permissions", () => ({
+  PERMISSIONS: {
+    UNLIMITED: {
+      INTERVIEWS: "unlimited_interviews",
+      QUESTIONS: "unlimited_questions",
+      RESUME_ANALYSES: "unlimited_resume_analyses",
+    },
+    LIMITED: {
+      INTERVIEWS: "limited_interviews",
+      QUESTIONS: "limited_questions",
+    },
+  },
+  hasPermission: jest.fn(),
+}));
+
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  hasPermission,
+  PERMISSIONS,
+} from "@/core/features/auth/permissions";
+
+import { checkResumeAnalysisPermission } from "./permissions";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockHasPermission = jest.mocked(hasPermission);
+
+describe("checkResumeAnalysisPermission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockHasPermission.mockResolvedValue(true);
+  });
+
+  it("denies anonymous users without checking plan permissions", async () => {
+    mockGetCurrentUser.mockResolvedValue({ userId: null });
+
+    await expect(checkResumeAnalysisPermission()).resolves.toBe(false);
+
+    expect(mockHasPermission).not.toHaveBeenCalled();
+  });
+
+  it("delegates signed-in users to the resume analysis permission", async () => {
+    await expect(checkResumeAnalysisPermission()).resolves.toBe(true);
+
+    expect(mockHasPermission).toHaveBeenCalledWith(
+      PERMISSIONS.UNLIMITED.RESUME_ANALYSES,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Added focused unit tests for password normalization, hashing, verification, and validation in `core/features/auth/password.ts`.
- Added low-mock permission tests for auth, questions, interviews, and resume analysis helpers.
- Updated `TEST_COVERAGE_PLAN.md` with the new slice, commands run, validation results, coverage summary, and the next recommendation.

## Testing
- `npm.cmd ci`
- `npm.cmd test` and `npm.cmd run test:coverage` passed
- `npm test` and `npm run test:coverage` are still blocked in PowerShell by the unsigned `npm.ps1` shim
- Focused new tests passed, and the full Jest suite passed with coverage enabled