### PR TITLE
Add service-layer tests and consolidate shared test constants

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -143,6 +143,54 @@ Move next into service-layer tests for `core/features/jobInfos/service.ts`,
 using the existing database mock helpers. Keep API routes and OAuth base-flow
 coverage as separate mock-heavy slices.
 
+### Service Layer Slice - 2026-05-18
+
+Files/tests added:
+
+- `core/features/jobInfos/service.test.ts`
+- `core/features/interviews/service.test.ts`
+- `core/features/questions/service.test.ts`
+- `core/features/jobInfos/serviceErrors.ts`
+- `core/features/interviews/serviceErrors.ts`
+- `core/test-utils/factories/jobInfo.ts`
+- `core/test-utils/factories/interview.ts`
+- `core/test-utils/factories/question.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/features/jobInfos/service.test.ts core/features/interviews/service.test.ts core/features/questions/service.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Focused service slice passed: 3 test suites, 25 tests, 0 snapshots.
+- `npm.cmd test -- --runInBand` passed: 36 test suites, 210 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 36 test suites, 210
+  tests, 0 snapshots.
+- Updated coverage summary: 76.44% statements, 74.16% branches, 72.19%
+  functions, and 79.04% lines.
+
+Notes:
+
+- Service-layer tests cover auth delegation, ownership checks, permission and
+  not-found paths, DAL calls, and interview feedback generation behavior.
+- New factories use safe synthetic identifiers and do not include real customer
+  emails.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Move next into server action tests for `core/features/jobInfos/actions.ts`,
+`core/features/interviews/actions.ts`, `core/features/questions/actions.ts`, and
+`core/features/users/actions.ts`. Keep API route coverage as the following
+mock-heavy slice.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/db.test.ts
+++ b/core/features/auth/db.test.ts
@@ -16,7 +16,7 @@ import {
   createMockDrizzleTableQuery,
   type MockDrizzleDb,
 } from "@core/test-utils/mocks/db";
-import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/constants";
 import { makeSession } from "@core/test-utils/factories/session";
 import { makeUser } from "@core/test-utils/factories/user";
 

--- a/core/features/auth/permissions.test.ts
+++ b/core/features/auth/permissions.test.ts
@@ -16,15 +16,23 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 import { getUser } from "@/core/features/users/actions";
-import { makeProUser, makeUser } from "@core/test-utils/factories/user";
+import {
+  makeCurrentUser,
+  makeProUser,
+  makeUser,
+} from "@/core/test-utils/factories/user";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockGetUser = jest.mocked(getUser);
 
+const SIGNED_IN_USER_ID = "user-1";
+
 describe("auth permission helpers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
   });
 
   it("exposes free plan limits used by feature permission checks", () => {
@@ -36,11 +44,11 @@ describe("auth permission helpers", () => {
   });
 
   it("denies permissions when there is no signed-in user", async () => {
-    mockGetCurrentUser.mockResolvedValue({ userId: null });
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
 
-    await expect(
-      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
-    ).resolves.toBe(false);
+    await expect(hasPermission(PERMISSIONS.LIMITED.QUESTIONS)).resolves.toBe(
+      false,
+    );
 
     expect(mockGetUser).not.toHaveBeenCalled();
   });
@@ -48,42 +56,39 @@ describe("auth permission helpers", () => {
   it("denies permissions when the signed-in user cannot be loaded", async () => {
     mockGetUser.mockResolvedValue(null);
 
-    await expect(
-      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
-    ).resolves.toBe(false);
+    await expect(hasPermission(PERMISSIONS.LIMITED.QUESTIONS)).resolves.toBe(
+      false,
+    );
   });
 
   it("grants limited free-plan permissions and denies pro-only permissions", async () => {
     mockGetUser.mockResolvedValue(makeUser({ plan: "free" }));
 
-    await expect(
-      hasPermission(PERMISSIONS.LIMITED.QUESTIONS),
-    ).resolves.toBe(true);
-    await expect(
-      hasPermission(PERMISSIONS.UNLIMITED.QUESTIONS),
-    ).resolves.toBe(false);
+    await expect(hasPermission(PERMISSIONS.LIMITED.QUESTIONS)).resolves.toBe(
+      true,
+    );
+    await expect(hasPermission(PERMISSIONS.UNLIMITED.QUESTIONS)).resolves.toBe(
+      false,
+    );
   });
 
   it("grants unlimited permissions for pro users", async () => {
     mockGetUser.mockResolvedValue(makeProUser());
 
-    await expect(
-      hasPermission(PERMISSIONS.UNLIMITED.INTERVIEWS),
-    ).resolves.toBe(true);
+    await expect(hasPermission(PERMISSIONS.UNLIMITED.INTERVIEWS)).resolves.toBe(
+      true,
+    );
     await expect(hasUnlimitedAccess("questions")).resolves.toBe(true);
   });
 
-  it("defaults missing user plans to free", async () => {
-    mockGetUser.mockResolvedValue(makeUser({ plan: null }));
+  it("defaults missing user records to the free plan", async () => {
+    mockGetUser.mockResolvedValue(null);
 
     await expect(getUserPlan()).resolves.toBe("free");
-    await expect(
-      hasPermission(PERMISSIONS.LIMITED.INTERVIEWS),
-    ).resolves.toBe(true);
   });
 
   it("returns subscription info for anonymous users without loading a user", async () => {
-    mockGetCurrentUser.mockResolvedValue({ userId: null });
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
 
     await expect(getUserSubscriptionInfo()).resolves.toEqual({
       plan: "free",

--- a/core/features/auth/permissions.test.ts
+++ b/core/features/auth/permissions.test.ts
@@ -21,11 +21,12 @@ import {
   makeProUser,
   makeUser,
 } from "@/core/test-utils/factories/user";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockGetUser = jest.mocked(getUser);
 
-const SIGNED_IN_USER_ID = "user-1";
+const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("auth permission helpers", () => {
   beforeEach(() => {

--- a/core/features/interviews/permissions.test.ts
+++ b/core/features/interviews/permissions.test.ts
@@ -33,17 +33,21 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 import { getInterviewCountDb } from "@/core/features/interviews/db";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkInterviewPermission } from "./permissions";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetInterviewCountDb = jest.mocked(getInterviewCountDb);
+const SIGNED_IN_USER_ID = "user-1";
 
 describe("checkInterviewPermission", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
     mockHasPermission.mockResolvedValue(false);
   });
 
@@ -73,7 +77,7 @@ describe("checkInterviewPermission", () => {
 
     await expect(checkInterviewPermission()).resolves.toBe(true);
 
-    expect(mockGetInterviewCountDb).toHaveBeenCalledWith("user-1");
+    expect(mockGetInterviewCountDb).toHaveBeenCalledWith(SIGNED_IN_USER_ID);
   });
 
   it("denies limited users at the free interview limit", async () => {

--- a/core/features/interviews/permissions.test.ts
+++ b/core/features/interviews/permissions.test.ts
@@ -33,6 +33,7 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 import { getInterviewCountDb } from "@/core/features/interviews/db";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkInterviewPermission } from "./permissions";
@@ -40,7 +41,8 @@ import { checkInterviewPermission } from "./permissions";
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetInterviewCountDb = jest.mocked(getInterviewCountDb);
-const SIGNED_IN_USER_ID = "user-1";
+
+const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("checkInterviewPermission", () => {
   beforeEach(() => {
@@ -86,5 +88,4 @@ describe("checkInterviewPermission", () => {
 
     await expect(checkInterviewPermission()).resolves.toBe(false);
   });
-
 });

--- a/core/features/interviews/service.test.ts
+++ b/core/features/interviews/service.test.ts
@@ -1,0 +1,235 @@
+jest.mock("next/cache", () => ({
+  refresh: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+  getCurrentUserWithProfile: jest.fn(),
+}));
+
+jest.mock("@/core/features/interviews/dal", () => ({
+  getInterviewByIdDal: jest.fn(),
+  getInterviewsDal: jest.fn(),
+  insertInterviewDal: jest.fn(),
+  updateInterviewDal: jest.fn(),
+}));
+
+jest.mock("@/core/services/ai/interviews", () => ({
+  generateAiInterviewFeedback: jest.fn(),
+}));
+
+import { refresh } from "next/cache";
+
+import { PermissionError } from "@/core/dal/helpers";
+import {
+  getCurrentUser,
+  getCurrentUserWithProfile,
+} from "@/core/features/auth/actions";
+import {
+  getInterviewByIdDal,
+  getInterviewsDal,
+  insertInterviewDal,
+  updateInterviewDal,
+} from "@/core/features/interviews/dal";
+import {
+  createInterviewService,
+  generateInterviewFeedbackService,
+  getInterviewByIdService,
+  getInterviewsService,
+  updateInterviewService,
+} from "@/core/features/interviews/service";
+import { INTERVIEW_SERVICE_ERRORS } from "@/core/features/interviews/serviceErrors";
+import { generateAiInterviewFeedback } from "@/core/services/ai/interviews";
+import { makeInterview, makeJobInfo, makeUser } from "@/core/test-utils/factories";
+
+const mockRefresh = jest.mocked(refresh);
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUserWithProfile = jest.mocked(getCurrentUserWithProfile);
+const mockGetInterviewByIdDal = jest.mocked(getInterviewByIdDal);
+const mockGetInterviewsDal = jest.mocked(getInterviewsDal);
+const mockInsertInterviewDal = jest.mocked(insertInterviewDal);
+const mockUpdateInterviewDal = jest.mocked(updateInterviewDal);
+const mockGenerateAiInterviewFeedback = jest.mocked(
+  generateAiInterviewFeedback,
+);
+
+const SIGNED_IN_USER_ID = "user-1";
+const OTHER_USER_ID = "user-2";
+const SIGNED_IN_USER_NAME = "Ada";
+
+function makeCurrentUser(
+  userId: string | null,
+  user = makeUser({ id: userId ?? SIGNED_IN_USER_ID }),
+) {
+  return {
+    userId,
+    user,
+    redirectToSignIn: jest.fn(() => {
+      throw new Error("redirect");
+    }),
+  };
+}
+
+describe("interview service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+    mockGetCurrentUserWithProfile.mockResolvedValue(
+      makeCurrentUser(
+        SIGNED_IN_USER_ID,
+        makeUser({ id: SIGNED_IN_USER_ID, name: SIGNED_IN_USER_NAME }),
+      ),
+    );
+  });
+
+  it("returns an interview when the requested user owns its job info", async () => {
+    const interview = makeInterview({
+      jobInfo: makeJobInfo({ userId: SIGNED_IN_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+
+    await expect(
+      getInterviewByIdService(interview.id, SIGNED_IN_USER_ID),
+    ).resolves.toBe(interview);
+  });
+
+  it("returns null when the interview does not exist", async () => {
+    mockGetInterviewByIdDal.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getInterviewByIdDal>>,
+    );
+
+    await expect(
+      getInterviewByIdService("interview-1", SIGNED_IN_USER_ID),
+    ).resolves.toBe(null);
+  });
+
+  it("returns null when another user owns the interview job info", async () => {
+    const interview = makeInterview({
+      jobInfo: makeJobInfo({ userId: OTHER_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+
+    await expect(
+      getInterviewByIdService(interview.id, SIGNED_IN_USER_ID),
+    ).resolves.toBe(null);
+  });
+
+  it("gets interviews for a job info and user", async () => {
+    const interviews = [makeInterview()];
+    mockGetInterviewsDal.mockResolvedValue(interviews);
+
+    await expect(
+      getInterviewsService("job-info-1", SIGNED_IN_USER_ID),
+    ).resolves.toBe(interviews);
+
+    expect(mockGetInterviewsDal).toHaveBeenCalledWith(
+      "job-info-1",
+      SIGNED_IN_USER_ID,
+    );
+  });
+
+  it("creates interviews with the default zero duration", async () => {
+    const interview = makeInterview({ jobInfoId: "job-info-1" });
+    mockInsertInterviewDal.mockResolvedValue(interview);
+
+    await expect(createInterviewService("job-info-1")).resolves.toBe(interview);
+
+    expect(mockInsertInterviewDal).toHaveBeenCalledWith({
+      jobInfoId: "job-info-1",
+      duration: "00:00:00",
+    });
+  });
+
+  it("updates an interview when the signed-in user owns it", async () => {
+    const interview = makeInterview({
+      jobInfo: makeJobInfo({ userId: SIGNED_IN_USER_ID }),
+    });
+    const update = { duration: "00:14:30" };
+    const updatedInterview = { ...interview, ...update };
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+    mockUpdateInterviewDal.mockResolvedValue(updatedInterview);
+
+    await expect(updateInterviewService(interview.id, update)).resolves.toBe(
+      updatedInterview,
+    );
+
+    expect(mockUpdateInterviewDal).toHaveBeenCalledWith(interview.id, update);
+  });
+
+  it("rejects interview updates when no accessible interview exists", async () => {
+    mockGetInterviewByIdDal.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getInterviewByIdDal>>,
+    );
+
+    await expect(
+      updateInterviewService("interview-1", { duration: "00:01:00" }),
+    ).rejects.toBeInstanceOf(PermissionError);
+
+    expect(mockUpdateInterviewDal).not.toHaveBeenCalled();
+  });
+
+  it("rejects interview updates owned by a different user", async () => {
+    const interview = makeInterview({
+      jobInfo: makeJobInfo({ userId: OTHER_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+
+    await expect(
+      updateInterviewService(interview.id, { duration: "00:01:00" }),
+    ).rejects.toBeInstanceOf(PermissionError);
+
+    expect(mockUpdateInterviewDal).not.toHaveBeenCalled();
+  });
+
+  it("generates and stores feedback for a completed owned interview", async () => {
+    const interview = makeInterview({
+      humeChatId: "chat-test-1",
+      jobInfo: makeJobInfo({ userId: SIGNED_IN_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+    mockGenerateAiInterviewFeedback.mockResolvedValue("Useful feedback");
+
+    await expect(generateInterviewFeedbackService(interview.id)).resolves.toBe(
+      "Useful feedback",
+    );
+
+    expect(mockGenerateAiInterviewFeedback).toHaveBeenCalledWith({
+      humeChatId: "chat-test-1",
+      jobInfo: interview.jobInfo,
+      userName: SIGNED_IN_USER_NAME,
+    });
+    expect(mockUpdateInterviewDal).toHaveBeenCalledWith(interview.id, {
+      feedback: "Useful feedback",
+    });
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects feedback generation when the interview is not completed", async () => {
+    const interview = makeInterview({
+      humeChatId: null,
+      jobInfo: makeJobInfo({ userId: SIGNED_IN_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+
+    await expect(
+      generateInterviewFeedbackService(interview.id),
+    ).rejects.toBeInstanceOf(PermissionError);
+
+    expect(mockGenerateAiInterviewFeedback).not.toHaveBeenCalled();
+  });
+
+  it("throws when AI feedback generation returns no feedback", async () => {
+    const interview = makeInterview({
+      humeChatId: "chat-test-1",
+      jobInfo: makeJobInfo({ userId: SIGNED_IN_USER_ID }),
+    });
+    mockGetInterviewByIdDal.mockResolvedValue(interview);
+    mockGenerateAiInterviewFeedback.mockResolvedValue("");
+
+    await expect(generateInterviewFeedbackService(interview.id)).rejects.toThrow(
+      INTERVIEW_SERVICE_ERRORS.feedbackGenerationFailed,
+    );
+
+    expect(mockUpdateInterviewDal).not.toHaveBeenCalled();
+  });
+});

--- a/core/features/interviews/service.test.ts
+++ b/core/features/interviews/service.test.ts
@@ -40,7 +40,13 @@ import {
 } from "@/core/features/interviews/service";
 import { INTERVIEW_SERVICE_ERRORS } from "@/core/features/interviews/serviceErrors";
 import { generateAiInterviewFeedback } from "@/core/services/ai/interviews";
+import {
+  TEST_OTHER_USER_ID,
+  TEST_USER_ID,
+  TEST_USER_NAME,
+} from "@/core/test-utils/constants";
 import { makeInterview, makeJobInfo, makeUser } from "@/core/test-utils/factories";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 const mockRefresh = jest.mocked(refresh);
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
@@ -53,32 +59,21 @@ const mockGenerateAiInterviewFeedback = jest.mocked(
   generateAiInterviewFeedback,
 );
 
-const SIGNED_IN_USER_ID = "user-1";
-const OTHER_USER_ID = "user-2";
-const SIGNED_IN_USER_NAME = "Ada";
-
-function makeCurrentUser(
-  userId: string | null,
-  user = makeUser({ id: userId ?? SIGNED_IN_USER_ID }),
-) {
-  return {
-    userId,
-    user,
-    redirectToSignIn: jest.fn(() => {
-      throw new Error("redirect");
-    }),
-  };
-}
+const SIGNED_IN_USER_ID = TEST_USER_ID;
+const OTHER_USER_ID = TEST_OTHER_USER_ID;
+const SIGNED_IN_USER_NAME = TEST_USER_NAME;
 
 describe("interview service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
     mockGetCurrentUserWithProfile.mockResolvedValue(
-      makeCurrentUser(
-        SIGNED_IN_USER_ID,
-        makeUser({ id: SIGNED_IN_USER_ID, name: SIGNED_IN_USER_NAME }),
-      ),
+      makeCurrentUser({
+        userId: SIGNED_IN_USER_ID,
+        user: makeUser({ id: SIGNED_IN_USER_ID, name: SIGNED_IN_USER_NAME }),
+      }),
     );
   });
 

--- a/core/features/interviews/service.ts
+++ b/core/features/interviews/service.ts
@@ -11,6 +11,7 @@ import {
   insertInterviewDal,
   updateInterviewDal,
 } from "@/core/features/interviews/dal";
+import { INTERVIEW_SERVICE_ERRORS } from "@/core/features/interviews/serviceErrors";
 import { generateAiInterviewFeedback } from "@/core/services/ai/interviews";
 
 /**
@@ -71,15 +72,11 @@ export async function updateInterviewService(
   const interview = await getInterviewByIdDal(id);
 
   if (!interview) {
-    throw new PermissionError(
-      "Interview not found or you don't have access to it"
-    );
+    throw new PermissionError(INTERVIEW_SERVICE_ERRORS.notFoundOrNoAccess);
   }
 
   if (interview.jobInfo.userId !== userId) {
-    throw new PermissionError(
-      "You don't have permission to update this interview"
-    );
+    throw new PermissionError(INTERVIEW_SERVICE_ERRORS.updateForbidden);
   }
 
   return await updateInterviewDal(id, data);
@@ -96,13 +93,11 @@ export async function generateInterviewFeedbackService(interviewId: string) {
   const interview = await getInterviewByIdService(interviewId, userId);
 
   if (!interview) {
-    throw new PermissionError(
-      "Interview not found or you don't have access to it"
-    );
+    throw new PermissionError(INTERVIEW_SERVICE_ERRORS.notFoundOrNoAccess);
   }
 
   if (!interview.humeChatId) {
-    throw new PermissionError("Interview has not been completed yet");
+    throw new PermissionError(INTERVIEW_SERVICE_ERRORS.notCompleted);
   }
 
   // Generate feedback
@@ -113,7 +108,7 @@ export async function generateInterviewFeedbackService(interviewId: string) {
   });
 
   if (!feedback) {
-    throw new Error("Failed to generate feedback");
+    throw new Error(INTERVIEW_SERVICE_ERRORS.feedbackGenerationFailed);
   }
 
   // Update interview with feedback

--- a/core/features/interviews/serviceErrors.ts
+++ b/core/features/interviews/serviceErrors.ts
@@ -1,0 +1,6 @@
+export const INTERVIEW_SERVICE_ERRORS = {
+  notFoundOrNoAccess: "Interview not found or you don't have access to it",
+  updateForbidden: "You don't have permission to update this interview",
+  notCompleted: "Interview has not been completed yet",
+  feedbackGenerationFailed: "Failed to generate feedback",
+} as const;

--- a/core/features/jobInfos/service.test.ts
+++ b/core/features/jobInfos/service.test.ts
@@ -30,7 +30,12 @@ import {
   updateJobInfoService,
   verifyJobInfoAccessService,
 } from "@/core/features/jobInfos/service";
+import {
+  TEST_OTHER_USER_ID,
+  TEST_USER_ID,
+} from "@/core/test-utils/constants";
 import { makeJobInfo } from "@/core/test-utils/factories";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockCreateJobInfoDal = jest.mocked(createJobInfoDal);
@@ -47,22 +52,15 @@ const jobInfoInput = {
   description: "Build thoughtful product interfaces.",
 };
 
-const SIGNED_IN_USER_ID = "user-1";
-const OTHER_USER_ID = "user-2";
-
-function makeCurrentUser(userId: string | null) {
-  return {
-    userId,
-    redirectToSignIn: jest.fn(() => {
-      throw new Error("redirect");
-    }),
-  };
-}
+const SIGNED_IN_USER_ID = TEST_USER_ID;
+const OTHER_USER_ID = TEST_OTHER_USER_ID;
 
 describe("job info service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
   });
 
   it("creates a job info for the signed-in user", async () => {

--- a/core/features/jobInfos/service.test.ts
+++ b/core/features/jobInfos/service.test.ts
@@ -1,0 +1,196 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/jobInfos/dal", () => ({
+  createJobInfoDal: jest.fn(),
+  getJobInfoDal: jest.fn(),
+  getJobInfoByIdDal: jest.fn(),
+  getJobInfosDal: jest.fn(),
+  removeJobInfoDal: jest.fn(),
+  updateJobInfoDal: jest.fn(),
+}));
+
+import { NotFoundError, PermissionError } from "@/core/dal/helpers";
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  createJobInfoDal,
+  getJobInfoByIdDal,
+  getJobInfoDal,
+  getJobInfosDal,
+  removeJobInfoDal,
+  updateJobInfoDal,
+} from "@/core/features/jobInfos/dal";
+import {
+  createJobInfoService,
+  getJobInfoByIdService,
+  getJobInfoService,
+  getJobInfosService,
+  removeJobInfoService,
+  updateJobInfoService,
+  verifyJobInfoAccessService,
+} from "@/core/features/jobInfos/service";
+import { makeJobInfo } from "@/core/test-utils/factories";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockCreateJobInfoDal = jest.mocked(createJobInfoDal);
+const mockGetJobInfoDal = jest.mocked(getJobInfoDal);
+const mockGetJobInfoByIdDal = jest.mocked(getJobInfoByIdDal);
+const mockGetJobInfosDal = jest.mocked(getJobInfosDal);
+const mockRemoveJobInfoDal = jest.mocked(removeJobInfoDal);
+const mockUpdateJobInfoDal = jest.mocked(updateJobInfoDal);
+
+const jobInfoInput = {
+  name: "Example Co",
+  title: "Frontend Engineer",
+  experienceLevel: "mid-level" as const,
+  description: "Build thoughtful product interfaces.",
+};
+
+const SIGNED_IN_USER_ID = "user-1";
+const OTHER_USER_ID = "user-2";
+
+function makeCurrentUser(userId: string | null) {
+  return {
+    userId,
+    redirectToSignIn: jest.fn(() => {
+      throw new Error("redirect");
+    }),
+  };
+}
+
+describe("job info service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+  });
+
+  it("creates a job info for the signed-in user", async () => {
+    const jobInfo = makeJobInfo({ ...jobInfoInput, userId: SIGNED_IN_USER_ID });
+    mockCreateJobInfoDal.mockResolvedValue(jobInfo);
+
+    await expect(createJobInfoService(jobInfoInput)).resolves.toBe(jobInfo);
+
+    expect(mockCreateJobInfoDal).toHaveBeenCalledWith({
+      ...jobInfoInput,
+      userId: SIGNED_IN_USER_ID,
+    });
+  });
+
+  it("updates a job info when the signed-in user owns it", async () => {
+    const existingJobInfo = makeJobInfo({ userId: SIGNED_IN_USER_ID });
+    const updatedJobInfo = { ...existingJobInfo, ...jobInfoInput };
+    mockGetJobInfoDal.mockResolvedValue(existingJobInfo);
+    mockUpdateJobInfoDal.mockResolvedValue(updatedJobInfo);
+
+    await expect(
+      updateJobInfoService(existingJobInfo.id, jobInfoInput),
+    ).resolves.toBe(updatedJobInfo);
+
+    expect(mockGetJobInfoDal).toHaveBeenCalledWith(
+      existingJobInfo.id,
+      SIGNED_IN_USER_ID,
+    );
+    expect(mockUpdateJobInfoDal).toHaveBeenCalledWith(
+      existingJobInfo.id,
+      jobInfoInput,
+    );
+  });
+
+  it("rejects updates when the job info cannot be found for the user", async () => {
+    mockGetJobInfoDal.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getJobInfoDal>>,
+    );
+
+    await expect(
+      updateJobInfoService("job-info-1", jobInfoInput),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(mockUpdateJobInfoDal).not.toHaveBeenCalled();
+  });
+
+  it("rejects updates when ownership does not match the signed-in user", async () => {
+    const existingJobInfo = makeJobInfo({ userId: OTHER_USER_ID });
+    mockGetJobInfoDal.mockResolvedValue(existingJobInfo);
+
+    await expect(
+      updateJobInfoService(existingJobInfo.id, jobInfoInput),
+    ).rejects.toBeInstanceOf(PermissionError);
+
+    expect(mockUpdateJobInfoDal).not.toHaveBeenCalled();
+  });
+
+  it("gets one job info through the ownership-aware DAL", async () => {
+    const jobInfo = makeJobInfo({ userId: SIGNED_IN_USER_ID });
+    mockGetJobInfoDal.mockResolvedValue(jobInfo);
+
+    await expect(getJobInfoService(jobInfo.id)).resolves.toBe(jobInfo);
+
+    expect(mockGetJobInfoDal).toHaveBeenCalledWith(
+      jobInfo.id,
+      SIGNED_IN_USER_ID,
+    );
+  });
+
+  it("gets one job info by id without requiring authentication", async () => {
+    const jobInfo = makeJobInfo();
+    mockGetJobInfoByIdDal.mockResolvedValue(jobInfo);
+
+    await expect(getJobInfoByIdService(jobInfo.id)).resolves.toBe(jobInfo);
+
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetJobInfoByIdDal).toHaveBeenCalledWith(jobInfo.id);
+  });
+
+  it("gets all job infos for the signed-in user", async () => {
+    const jobInfos = [makeJobInfo({ userId: SIGNED_IN_USER_ID })];
+    mockGetJobInfosDal.mockResolvedValue(jobInfos);
+
+    await expect(getJobInfosService()).resolves.toBe(jobInfos);
+
+    expect(mockGetJobInfosDal).toHaveBeenCalledWith(SIGNED_IN_USER_ID);
+  });
+
+  it("returns job info and user id when access is verified", async () => {
+    const jobInfo = makeJobInfo({ userId: SIGNED_IN_USER_ID });
+    mockGetJobInfoDal.mockResolvedValue(jobInfo);
+
+    await expect(verifyJobInfoAccessService(jobInfo.id)).resolves.toEqual({
+      jobInfo,
+      userId: SIGNED_IN_USER_ID,
+    });
+  });
+
+  it("rejects access verification when no accessible job info exists", async () => {
+    mockGetJobInfoDal.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getJobInfoDal>>,
+    );
+
+    await expect(
+      verifyJobInfoAccessService("job-info-1"),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("removes a job info after confirming user access", async () => {
+    const jobInfo = makeJobInfo({ userId: SIGNED_IN_USER_ID });
+    const result = { success: true as const, data: jobInfo };
+    mockGetJobInfoDal.mockResolvedValue(jobInfo);
+    mockRemoveJobInfoDal.mockResolvedValue(result);
+
+    await expect(removeJobInfoService(jobInfo.id)).resolves.toBe(result);
+
+    expect(mockRemoveJobInfoDal).toHaveBeenCalledWith(jobInfo.id);
+  });
+
+  it("does not remove job info when it is not accessible", async () => {
+    mockGetJobInfoDal.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getJobInfoDal>>,
+    );
+
+    await expect(removeJobInfoService("job-info-1")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+
+    expect(mockRemoveJobInfoDal).not.toHaveBeenCalled();
+  });
+});

--- a/core/features/jobInfos/service.ts
+++ b/core/features/jobInfos/service.ts
@@ -14,6 +14,7 @@ import {
   PermissionError,
   NotFoundError,
 } from "@/core/dal/helpers";
+import { JOB_INFO_SERVICE_ERRORS } from "@/core/features/jobInfos/serviceErrors";
 
 /**
  * Service Layer for JobInfo
@@ -57,15 +58,11 @@ export async function updateJobInfoService(
   const existingJobInfo = await getJobInfoDal(id, userId);
 
   if (!existingJobInfo) {
-    throw new NotFoundError(
-      "Job posting not found or you don't have permission to edit it."
-    );
+    throw new NotFoundError(JOB_INFO_SERVICE_ERRORS.notFoundOrNoEditPermission);
   }
 
   if (existingJobInfo.userId !== userId) {
-    throw new PermissionError(
-      "You don't have permission to edit this job posting."
-    );
+    throw new PermissionError(JOB_INFO_SERVICE_ERRORS.editForbidden);
   }
 
   const updated = await updateJobInfoDal(id, data);
@@ -112,9 +109,7 @@ export async function verifyJobInfoAccessService(jobInfoId: string) {
   const jobInfo = await getJobInfoDal(jobInfoId, userId);
 
   if (!jobInfo) {
-    throw new NotFoundError(
-      "Job posting not found or you don't have permission to access it."
-    );
+    throw new NotFoundError(JOB_INFO_SERVICE_ERRORS.notFoundOrNoAccess);
   }
 
   return { jobInfo, userId };
@@ -131,7 +126,7 @@ export async function removeJobInfoService(id: string) {
 
   if (!jobInfo) {
     throw new NotFoundError(
-      "Job posting not found or you don't have permission to delete it."
+      JOB_INFO_SERVICE_ERRORS.notFoundOrNoDeletePermission,
     );
   }
 

--- a/core/features/jobInfos/serviceErrors.ts
+++ b/core/features/jobInfos/serviceErrors.ts
@@ -1,0 +1,9 @@
+export const JOB_INFO_SERVICE_ERRORS = {
+  notFoundOrNoEditPermission:
+    "Job posting not found or you don't have permission to edit it.",
+  editForbidden: "You don't have permission to edit this job posting.",
+  notFoundOrNoAccess:
+    "Job posting not found or you don't have permission to access it.",
+  notFoundOrNoDeletePermission:
+    "Job posting not found or you don't have permission to delete it.",
+} as const;

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -33,6 +33,7 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 import { getQuestionCountDb } from "@/core/features/questions/db";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkQuestionsPermission } from "./permissions";
@@ -40,7 +41,8 @@ import { checkQuestionsPermission } from "./permissions";
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetQuestionCountDb = jest.mocked(getQuestionCountDb);
-const SIGNED_IN_USER_ID = "user-1";
+
+const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("checkQuestionsPermission", () => {
   beforeEach(() => {

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -33,22 +33,26 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 import { getQuestionCountDb } from "@/core/features/questions/db";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkQuestionsPermission } from "./permissions";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetQuestionCountDb = jest.mocked(getQuestionCountDb);
+const SIGNED_IN_USER_ID = "user-1";
 
 describe("checkQuestionsPermission", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
     mockHasPermission.mockResolvedValue(false);
   });
 
   it("denies anonymous users without checking plan permissions", async () => {
-    mockGetCurrentUser.mockResolvedValue({ userId: null });
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
 
     await expect(checkQuestionsPermission()).resolves.toBe(false);
 
@@ -81,7 +85,7 @@ describe("checkQuestionsPermission", () => {
 
     await expect(checkQuestionsPermission()).resolves.toBe(true);
 
-    expect(mockGetQuestionCountDb).toHaveBeenCalledWith("user-1");
+    expect(mockGetQuestionCountDb).toHaveBeenCalledWith(SIGNED_IN_USER_ID);
   });
 
   it("denies limited users at the free question limit", async () => {

--- a/core/features/questions/service.test.ts
+++ b/core/features/questions/service.test.ts
@@ -19,28 +19,23 @@ import {
   getQuestionsService,
   insertQuestionService,
 } from "@/core/features/questions/service";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeQuestion } from "@/core/test-utils/factories";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockGetQuestionsDal = jest.mocked(getQuestionsDal);
 const mockGetQuestionByIdDal = jest.mocked(getQuestionByIdDal);
 const mockInsertQuestionDal = jest.mocked(insertQuestionDal);
 
-const SIGNED_IN_USER_ID = "user-1";
-
-function makeCurrentUser(userId: string | null) {
-  return {
-    userId,
-    redirectToSignIn: jest.fn(() => {
-      throw new Error("redirect");
-    }),
-  };
-}
+const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("question service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
   });
 
   it("gets questions for a job info without requiring authentication", async () => {

--- a/core/features/questions/service.test.ts
+++ b/core/features/questions/service.test.ts
@@ -1,0 +1,89 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/questions/dal", () => ({
+  getQuestionByIdDal: jest.fn(),
+  getQuestionsDal: jest.fn(),
+  insertQuestionDal: jest.fn(),
+}));
+
+import { getCurrentUser } from "@/core/features/auth/actions";
+import {
+  getQuestionByIdDal,
+  getQuestionsDal,
+  insertQuestionDal,
+} from "@/core/features/questions/dal";
+import {
+  getQuestionByIdService,
+  getQuestionsService,
+  insertQuestionService,
+} from "@/core/features/questions/service";
+import { makeQuestion } from "@/core/test-utils/factories";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetQuestionsDal = jest.mocked(getQuestionsDal);
+const mockGetQuestionByIdDal = jest.mocked(getQuestionByIdDal);
+const mockInsertQuestionDal = jest.mocked(insertQuestionDal);
+
+const SIGNED_IN_USER_ID = "user-1";
+
+function makeCurrentUser(userId: string | null) {
+  return {
+    userId,
+    redirectToSignIn: jest.fn(() => {
+      throw new Error("redirect");
+    }),
+  };
+}
+
+describe("question service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser(SIGNED_IN_USER_ID));
+  });
+
+  it("gets questions for a job info without requiring authentication", async () => {
+    const questions = [makeQuestion({ jobInfoId: "job-info-1" })];
+    mockGetQuestionsDal.mockResolvedValue(questions);
+
+    await expect(getQuestionsService("job-info-1")).resolves.toBe(questions);
+
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetQuestionsDal).toHaveBeenCalledWith("job-info-1");
+  });
+
+  it("gets one question using the signed-in user id for ownership filtering", async () => {
+    const question = {
+      ...makeQuestion(),
+      jobInfo: { id: "job-info-1", userId: SIGNED_IN_USER_ID },
+    };
+    mockGetQuestionByIdDal.mockResolvedValue(question);
+
+    await expect(getQuestionByIdService(question.id)).resolves.toBe(question);
+
+    expect(mockGetQuestionByIdDal).toHaveBeenCalledWith(
+      question.id,
+      SIGNED_IN_USER_ID,
+    );
+  });
+
+  it("inserts a question with its job info and difficulty", async () => {
+    const text = "What tradeoff would you make?";
+    const jobInfoId = "job-info-1";
+    const difficulty = "hard";
+
+    const question = makeQuestion({ text, jobInfoId, difficulty });
+    mockInsertQuestionDal.mockResolvedValue(question);
+
+    await expect(
+      insertQuestionService(text, jobInfoId, difficulty),
+    ).resolves.toBe(question);
+
+    expect(mockInsertQuestionDal).toHaveBeenCalledWith({
+      text,
+      jobInfoId,
+      difficulty,
+    });
+  });
+});

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -22,21 +22,25 @@ import {
   hasPermission,
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkResumeAnalysisPermission } from "./permissions";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
+const SIGNED_IN_USER_ID = "user-1";
 
 describe("checkResumeAnalysisPermission", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue({ userId: "user-1" });
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
+    );
     mockHasPermission.mockResolvedValue(true);
   });
 
   it("denies anonymous users without checking plan permissions", async () => {
-    mockGetCurrentUser.mockResolvedValue({ userId: null });
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
 
     await expect(checkResumeAnalysisPermission()).resolves.toBe(false);
 

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -18,17 +18,16 @@ jest.mock("@/core/features/auth/permissions", () => ({
 }));
 
 import { getCurrentUser } from "@/core/features/auth/actions";
-import {
-  hasPermission,
-  PERMISSIONS,
-} from "@/core/features/auth/permissions";
+import { hasPermission, PERMISSIONS } from "@/core/features/auth/permissions";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkResumeAnalysisPermission } from "./permissions";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUser);
 const mockHasPermission = jest.mocked(hasPermission);
-const SIGNED_IN_USER_ID = "user-1";
+
+const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("checkResumeAnalysisPermission", () => {
   beforeEach(() => {

--- a/core/features/users/actions.ts
+++ b/core/features/users/actions.ts
@@ -5,13 +5,14 @@ import { cacheTag } from "next/dist/server/use-cache/cache-tag";
 import { getUserIdTag } from "@/core/features/users/dbCache";
 import { getUserByIdDb } from "@/core/features/users/db";
 import { DatabaseError } from "@/core/dal/helpers";
+import type { AuthUser } from "@/core/features/auth/types";
 
-export async function getUser(id: string) {
+export async function getUser(id: string): Promise<AuthUser | null> {
   "use cache";
   cacheTag(getUserIdTag(id));
 
   try {
-    return await getUserByIdDb(id);
+    return (await getUserByIdDb(id)) ?? null;
   } catch (error) {
     console.error("Database error getting user:", error);
     throw new DatabaseError("Failed to fetch user from database", error);

--- a/core/test-utils/constants.ts
+++ b/core/test-utils/constants.ts
@@ -3,3 +3,7 @@ export const TEST_FIXTURE_NOW_ISO = "2024-01-01T00:00:00.000Z" as const;
 
 /** Fixed instant in the past for expired-session fixtures. */
 export const TEST_EXPIRED_AT_ISO = "2020-01-01T00:00:00.000Z" as const;
+
+export const TEST_USER_ID = "user-1" as const;
+export const TEST_OTHER_USER_ID = "user-2" as const;
+export const TEST_USER_NAME = "Ada" as const;

--- a/core/test-utils/factories/index.ts
+++ b/core/test-utils/factories/index.ts
@@ -1,4 +1,4 @@
-export { makeUser, makeProUser } from "./user";
+export { makeUser, makeProUser, makeCurrentUser } from "./user";
 export { makeSession, makeExpiredSession } from "./session";
 export { makeJobInfo } from "./jobInfo";
 export { makeInterview, type InterviewWithJobInfo } from "./interview";

--- a/core/test-utils/factories/index.ts
+++ b/core/test-utils/factories/index.ts
@@ -1,5 +1,8 @@
 export { makeUser, makeProUser } from "./user";
 export { makeSession, makeExpiredSession } from "./session";
+export { makeJobInfo } from "./jobInfo";
+export { makeInterview, type InterviewWithJobInfo } from "./interview";
+export { makeQuestion } from "./question";
 export {
   makeStripeSubscription,
   makeStripeCheckoutSession,

--- a/core/test-utils/factories/interview.ts
+++ b/core/test-utils/factories/interview.ts
@@ -1,0 +1,34 @@
+import type { InterviewTable } from "@/core/drizzle/schema";
+import { makeJobInfo } from "@/core/test-utils/factories/jobInfo";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+
+let interviewCounter = 0;
+
+function nextInterviewIndex(): number {
+  interviewCounter += 1;
+  return interviewCounter;
+}
+
+export type InterviewWithJobInfo = typeof InterviewTable.$inferSelect & {
+  jobInfo: ReturnType<typeof makeJobInfo>;
+};
+
+export function makeInterview(
+  overrides: Partial<InterviewWithJobInfo> = {},
+): InterviewWithJobInfo {
+  const index = nextInterviewIndex();
+  const now = new Date(TEST_FIXTURE_NOW_ISO);
+  const jobInfo = overrides.jobInfo ?? makeJobInfo({ userId: `user-${index}` });
+
+  return {
+    id: `00000000-0000-4001-8000-${String(index).padStart(12, "0")}`,
+    jobInfoId: jobInfo.id,
+    duration: "00:00:00",
+    humeChatId: null,
+    feedback: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+    jobInfo,
+  };
+}

--- a/core/test-utils/factories/interview.ts
+++ b/core/test-utils/factories/interview.ts
@@ -1,6 +1,6 @@
 import type { InterviewTable } from "@/core/drizzle/schema";
 import { makeJobInfo } from "@/core/test-utils/factories/jobInfo";
-import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/constants";
 
 let interviewCounter = 0;
 

--- a/core/test-utils/factories/jobInfo.ts
+++ b/core/test-utils/factories/jobInfo.ts
@@ -1,0 +1,28 @@
+import type { JobInfoTable } from "@/core/drizzle/schema";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+
+let jobInfoCounter = 0;
+
+function nextJobInfoIndex(): number {
+  jobInfoCounter += 1;
+  return jobInfoCounter;
+}
+
+export function makeJobInfo(
+  overrides: Partial<typeof JobInfoTable.$inferSelect> = {},
+): typeof JobInfoTable.$inferSelect {
+  const index = nextJobInfoIndex();
+  const now = new Date(TEST_FIXTURE_NOW_ISO);
+
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    name: `Company ${index}`,
+    title: `Role ${index}`,
+    experienceLevel: "mid-level",
+    description: `Job description ${index}`,
+    userId: `user-${index}`,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}

--- a/core/test-utils/factories/jobInfo.ts
+++ b/core/test-utils/factories/jobInfo.ts
@@ -1,5 +1,5 @@
 import type { JobInfoTable } from "@/core/drizzle/schema";
-import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/constants";
 
 let jobInfoCounter = 0;
 

--- a/core/test-utils/factories/question.ts
+++ b/core/test-utils/factories/question.ts
@@ -1,5 +1,5 @@
 import type { QuestionTable } from "@/core/drizzle/schema";
-import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/constants";
 
 let questionCounter = 0;
 

--- a/core/test-utils/factories/question.ts
+++ b/core/test-utils/factories/question.ts
@@ -1,0 +1,26 @@
+import type { QuestionTable } from "@/core/drizzle/schema";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/fixture-dates";
+
+let questionCounter = 0;
+
+function nextQuestionIndex(): number {
+  questionCounter += 1;
+  return questionCounter;
+}
+
+export function makeQuestion(
+  overrides: Partial<typeof QuestionTable.$inferSelect> = {},
+): typeof QuestionTable.$inferSelect {
+  const index = nextQuestionIndex();
+  const now = new Date(TEST_FIXTURE_NOW_ISO);
+
+  return {
+    id: `00000000-0000-4002-8000-${String(index).padStart(12, "0")}`,
+    jobInfoId: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    text: `Question ${index}`,
+    difficulty: "medium",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}

--- a/core/test-utils/factories/session.test.ts
+++ b/core/test-utils/factories/session.test.ts
@@ -1,4 +1,4 @@
-import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
+import { TEST_FIXTURE_NOW_ISO } from "@/core/test-utils/constants";
 import { makeExpiredSession, makeSession } from "./session";
 
 describe("makeSession", () => {

--- a/core/test-utils/factories/session.ts
+++ b/core/test-utils/factories/session.ts
@@ -2,7 +2,7 @@ import type { Session } from "@/core/features/auth/session";
 import {
   TEST_EXPIRED_AT_ISO,
   TEST_FIXTURE_NOW_ISO,
-} from "@core/test-utils/fixture-dates";
+} from "@/core/test-utils/constants";
 
 let sessionCounter = 0;
 

--- a/core/test-utils/factories/user.test.ts
+++ b/core/test-utils/factories/user.test.ts
@@ -1,4 +1,7 @@
-import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
+import {
+  TEST_FIXTURE_NOW_ISO,
+  TEST_USER_ID,
+} from "@/core/test-utils/constants";
 import { makeCurrentUser, makeProUser, makeUser } from "./user";
 
 describe("makeUser", () => {
@@ -82,7 +85,7 @@ describe("makeCurrentUser", () => {
   it("returns an authenticated current-user fixture by default", () => {
     const currentUser = makeCurrentUser();
 
-    expect(currentUser.userId).toBe("user-1");
+    expect(currentUser.userId).toBe(TEST_USER_ID);
     expect(currentUser.redirectToSignIn).toEqual(expect.any(Function));
   });
 

--- a/core/test-utils/factories/user.test.ts
+++ b/core/test-utils/factories/user.test.ts
@@ -1,5 +1,5 @@
 import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
-import { makeProUser, makeUser } from "./user";
+import { makeCurrentUser, makeProUser, makeUser } from "./user";
 
 describe("makeUser", () => {
   it("returns a user with default free-plan shape and unverified oauth-free defaults", () => {
@@ -75,5 +75,20 @@ describe("makeProUser", () => {
 
     expect(user.plan).toBe("free");
     expect(user.stripeCustomerId).toBeNull();
+  });
+});
+
+describe("makeCurrentUser", () => {
+  it("returns an authenticated current-user fixture by default", () => {
+    const currentUser = makeCurrentUser();
+
+    expect(currentUser.userId).toBe("user-1");
+    expect(currentUser.redirectToSignIn).toEqual(expect.any(Function));
+  });
+
+  it("accepts overrides for anonymous-user scenarios", () => {
+    const currentUser = makeCurrentUser({ userId: null });
+
+    expect(currentUser.userId).toBeNull();
   });
 });

--- a/core/test-utils/factories/user.ts
+++ b/core/test-utils/factories/user.ts
@@ -1,4 +1,4 @@
-import type { AuthUser } from "@/core/features/auth/types";
+import type { AuthUser, CurrentUser } from "@/core/features/auth/types";
 import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
 
 let userCounter = 0;
@@ -55,4 +55,16 @@ export function makeProUser(overrides: Partial<AuthUser> = {}): AuthUser {
     stripeSubscriptionId: `sub_test_${index}`,
     ...overrides,
   });
+}
+
+export function makeCurrentUser(
+  overrides: Partial<CurrentUser> = {},
+): CurrentUser {
+  return {
+    userId: "user-1",
+    redirectToSignIn: jest.fn(() => {
+      throw new Error("redirect");
+    }),
+    ...overrides,
+  };
 }

--- a/core/test-utils/factories/user.ts
+++ b/core/test-utils/factories/user.ts
@@ -1,5 +1,8 @@
 import type { AuthUser, CurrentUser } from "@/core/features/auth/types";
-import { TEST_FIXTURE_NOW_ISO } from "@core/test-utils/fixture-dates";
+import {
+  TEST_FIXTURE_NOW_ISO,
+  TEST_USER_ID,
+} from "@/core/test-utils/constants";
 
 let userCounter = 0;
 
@@ -61,7 +64,7 @@ export function makeCurrentUser(
   overrides: Partial<CurrentUser> = {},
 ): CurrentUser {
   return {
-    userId: "user-1",
+    userId: TEST_USER_ID,
     redirectToSignIn: jest.fn(() => {
       throw new Error("redirect");
     }),


### PR DESCRIPTION
## Summary
- Add focused service-layer tests for job infos, interviews, and questions
- Centralize shared test fixtures and constants, including a common current-user helper
- Move service error messages into shared constants and align type signatures with nullable user lookups
- Update the coverage plan with the new service-layer slice

## Testing
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint`
- Focused Jest coverage for the updated permission and service tests
- Full Jest suite passed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for interview, job posting, and question service layers
  * Enhanced test utilities with reusable factories and constants for improved consistency across tests

* **Bug Fixes**
  * Fixed user retrieval function return type to properly handle null cases

* **Chores**
  * Centralized error message definitions across service layers
  * Reorganized test fixture constants and factories for better maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->