### PR TITLE
Extract job info action messages and add server action coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -191,6 +191,49 @@ Move next into server action tests for `core/features/jobInfos/actions.ts`,
 `core/features/users/actions.ts`. Keep API route coverage as the following
 mock-heavy slice.
 
+### Job Info Server Actions Slice - 2026-05-19
+
+Files/tests added:
+
+- `core/features/jobInfos/actionMessages.ts`
+- `core/features/jobInfos/actions.test.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/features/jobInfos/actions.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Focused action slice passed: 1 test suite, 16 tests, 0 snapshots.
+- `npm.cmd test -- --runInBand` passed: 37 test suites, 228 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 37 test suites, 228
+  tests, 0 snapshots.
+- Updated coverage summary: 78.14% statements, 75.69% branches, 73.84%
+  functions, and 80.69% lines.
+- `core/features/jobInfos/actions.ts` now reports 100% statements, branches,
+  functions, and lines.
+
+Notes:
+
+- Action tests cover schema validation, successful create/update returns,
+  mapped unauthorized/not-found/permission/database/unexpected errors, and thin
+  read/remove service delegates.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Continue the server action slice with `core/features/interviews/actions.ts`.
+Add a shared Arcjet mock helper if the allow/deny protection scenarios create
+duplication, then cover `core/features/questions/actions.ts` and
+`core/features/users/actions.ts` before moving into API routes.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/jobInfos/actionMessages.ts
+++ b/core/features/jobInfos/actionMessages.ts
@@ -1,0 +1,9 @@
+export const JOB_INFO_ACTION_MESSAGES = {
+  invalidInput: "Invalid job information. Please check all required fields.",
+  createUnauthorized: "You must be logged in to create a job posting.",
+  createDatabaseError: "Failed to save job posting. Please try again.",
+  updateUnauthorized: "You must be logged in to update this job posting.",
+  updateNotFound: "Job posting not found or you don't have access to it.",
+  updateDatabaseError: "Failed to update job posting. Please try again.",
+  unexpectedError: "An unexpected error occurred. Please try again.",
+} as const;

--- a/core/features/jobInfos/actions.test.ts
+++ b/core/features/jobInfos/actions.test.ts
@@ -1,0 +1,247 @@
+jest.mock("@/core/features/jobInfos/service", () => ({
+  createJobInfoService: jest.fn(),
+  getJobInfoByIdService: jest.fn(),
+  getJobInfoService: jest.fn(),
+  getJobInfosService: jest.fn(),
+  removeJobInfoService: jest.fn(),
+  updateJobInfoService: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+  getCurrentUserWithProfile: jest.fn(),
+}));
+
+import {
+  DatabaseError,
+  NotFoundError,
+  PermissionError,
+  UnauthorizedError,
+} from "@/core/dal/helpers";
+import {
+  createJobInfoAction,
+  getJobInfo,
+  getJobInfoById,
+  getJobInfos,
+  removeJobInfoAction,
+  updateJobInfoAction,
+} from "@/core/features/jobInfos/actions";
+import { JOB_INFO_ACTION_MESSAGES } from "@/core/features/jobInfos/actionMessages";
+import {
+  createJobInfoService,
+  getJobInfoByIdService,
+  getJobInfoService,
+  getJobInfosService,
+  removeJobInfoService,
+  updateJobInfoService,
+} from "@/core/features/jobInfos/service";
+import { makeJobInfo } from "@/core/test-utils/factories";
+
+const mockCreateJobInfoService = jest.mocked(createJobInfoService);
+const mockGetJobInfoByIdService = jest.mocked(getJobInfoByIdService);
+const mockGetJobInfoService = jest.mocked(getJobInfoService);
+const mockGetJobInfosService = jest.mocked(getJobInfosService);
+const mockRemoveJobInfoService = jest.mocked(removeJobInfoService);
+const mockUpdateJobInfoService = jest.mocked(updateJobInfoService);
+
+const validJobInfoInput = {
+  name: "Example Co",
+  title: "Frontend Engineer",
+  experienceLevel: "mid-level" as const,
+  description: "Build polished user-facing workflows.",
+};
+
+describe("job info actions", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("createJobInfoAction", () => {
+    it("returns a validation message when the input is invalid", async () => {
+      await expect(
+        createJobInfoAction({ ...validJobInfoInput, name: "" }),
+      ).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.invalidInput,
+      });
+
+      expect(mockCreateJobInfoService).not.toHaveBeenCalled();
+    });
+
+    it("returns the created job info id when the service succeeds", async () => {
+      const jobInfo = makeJobInfo(validJobInfoInput);
+      mockCreateJobInfoService.mockResolvedValue(jobInfo);
+
+      await expect(createJobInfoAction(validJobInfoInput)).resolves.toEqual({
+        success: true,
+        data: { id: jobInfo.id },
+      });
+
+      expect(mockCreateJobInfoService).toHaveBeenCalledWith(validJobInfoInput);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps unauthorized errors to a login message", async () => {
+      mockCreateJobInfoService.mockRejectedValue(new UnauthorizedError());
+
+      await expect(createJobInfoAction(validJobInfoInput)).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.createUnauthorized,
+      });
+    });
+
+    it("maps database errors to a retry message", async () => {
+      mockCreateJobInfoService.mockRejectedValue(
+        new DatabaseError("insert failed"),
+      );
+
+      await expect(createJobInfoAction(validJobInfoInput)).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.createDatabaseError,
+      });
+    });
+
+    it("maps unexpected errors to the generic retry message", async () => {
+      mockCreateJobInfoService.mockRejectedValue(new Error("boom"));
+
+      await expect(createJobInfoAction(validJobInfoInput)).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.unexpectedError,
+      });
+    });
+  });
+
+  describe("updateJobInfoAction", () => {
+    it("returns a validation message when the input is invalid", async () => {
+      await expect(updateJobInfoAction("job-info-id", null)).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.invalidInput,
+      });
+
+      expect(mockUpdateJobInfoService).not.toHaveBeenCalled();
+    });
+
+    it("returns the updated job info id when the service succeeds", async () => {
+      const jobInfo = makeJobInfo(validJobInfoInput);
+      mockUpdateJobInfoService.mockResolvedValue(jobInfo);
+
+      await expect(
+        updateJobInfoAction(jobInfo.id, validJobInfoInput),
+      ).resolves.toEqual({
+        success: true,
+        data: { id: jobInfo.id },
+      });
+
+      expect(mockUpdateJobInfoService).toHaveBeenCalledWith(
+        jobInfo.id,
+        validJobInfoInput,
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps unauthorized errors to a login message", async () => {
+      mockUpdateJobInfoService.mockRejectedValue(new UnauthorizedError());
+
+      await expect(
+        updateJobInfoAction("job-info-id", validJobInfoInput),
+      ).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.updateUnauthorized,
+      });
+    });
+
+    it("maps not found errors to an access message", async () => {
+      mockUpdateJobInfoService.mockRejectedValue(
+        new NotFoundError("not found"),
+      );
+
+      await expect(
+        updateJobInfoAction("job-info-id", validJobInfoInput),
+      ).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.updateNotFound,
+      });
+    });
+
+    it("returns permission error messages from the service", async () => {
+      mockUpdateJobInfoService.mockRejectedValue(
+        new PermissionError("Custom permission message"),
+      );
+
+      await expect(
+        updateJobInfoAction("job-info-id", validJobInfoInput),
+      ).resolves.toEqual({
+        success: false,
+        message: "Custom permission message",
+      });
+    });
+
+    it("maps database errors to a retry message", async () => {
+      mockUpdateJobInfoService.mockRejectedValue(
+        new DatabaseError("update failed"),
+      );
+
+      await expect(
+        updateJobInfoAction("job-info-id", validJobInfoInput),
+      ).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.updateDatabaseError,
+      });
+    });
+
+    it("maps unexpected errors to the generic retry message", async () => {
+      mockUpdateJobInfoService.mockRejectedValue(new Error("boom"));
+
+      await expect(
+        updateJobInfoAction("job-info-id", validJobInfoInput),
+      ).resolves.toEqual({
+        success: false,
+        message: JOB_INFO_ACTION_MESSAGES.unexpectedError,
+      });
+    });
+  });
+
+  it("gets one job info through the service", async () => {
+    const jobInfo = makeJobInfo();
+    mockGetJobInfoService.mockResolvedValue(jobInfo);
+
+    await expect(getJobInfo(jobInfo.id)).resolves.toBe(jobInfo);
+
+    expect(mockGetJobInfoService).toHaveBeenCalledWith(jobInfo.id);
+  });
+
+  it("gets one job info by id through the service", async () => {
+    const jobInfo = makeJobInfo();
+    mockGetJobInfoByIdService.mockResolvedValue(jobInfo);
+
+    await expect(getJobInfoById(jobInfo.id)).resolves.toBe(jobInfo);
+
+    expect(mockGetJobInfoByIdService).toHaveBeenCalledWith(jobInfo.id);
+  });
+
+  it("gets all job infos through the service", async () => {
+    const jobInfos = [makeJobInfo()];
+    mockGetJobInfosService.mockResolvedValue(jobInfos);
+
+    await expect(getJobInfos()).resolves.toBe(jobInfos);
+
+    expect(mockGetJobInfosService).toHaveBeenCalledWith();
+  });
+
+  it("removes a job info through the service", async () => {
+    const jobInfo = makeJobInfo();
+    const result = { success: true as const, data: jobInfo };
+    mockRemoveJobInfoService.mockResolvedValue(result);
+
+    await expect(removeJobInfoAction(jobInfo.id)).resolves.toBe(result);
+
+    expect(mockRemoveJobInfoService).toHaveBeenCalledWith(jobInfo.id);
+  });
+});

--- a/core/features/jobInfos/actions.ts
+++ b/core/features/jobInfos/actions.ts
@@ -9,6 +9,7 @@ import {
   getJobInfosService,
   removeJobInfoService,
 } from "@/core/features/jobInfos/service";
+import { JOB_INFO_ACTION_MESSAGES } from "@/core/features/jobInfos/actionMessages";
 import {
   UnauthorizedError,
   NotFoundError,
@@ -28,14 +29,14 @@ import {
  * Server action called from form submissions
  */
 export async function createJobInfoAction(
-  unsafeData: unknown
+  unsafeData: unknown,
 ): Promise<ActionResult<{ id: string }>> {
   // 1. Validate input (Action's responsibility)
   const validation = jobInfoSchema.safeParse(unsafeData);
   if (!validation.success) {
     return {
       success: false,
-      message: "Invalid job information. Please check all required fields.",
+      message: JOB_INFO_ACTION_MESSAGES.invalidInput,
     };
   }
 
@@ -55,20 +56,20 @@ export async function createJobInfoAction(
     if (error instanceof UnauthorizedError) {
       return {
         success: false,
-        message: "You must be logged in to create a job posting.",
+        message: JOB_INFO_ACTION_MESSAGES.createUnauthorized,
       };
     }
 
     if (error instanceof DatabaseError) {
       return {
         success: false,
-        message: "Failed to save job posting. Please try again.",
+        message: JOB_INFO_ACTION_MESSAGES.createDatabaseError,
       };
     }
 
     return {
       success: false,
-      message: "An unexpected error occurred. Please try again.",
+      message: JOB_INFO_ACTION_MESSAGES.unexpectedError,
     };
   }
 }
@@ -79,13 +80,13 @@ export async function createJobInfoAction(
  */
 export async function updateJobInfoAction(
   id: string,
-  unsafeData: unknown
+  unsafeData: unknown,
 ): Promise<ActionResult<{ id: string }>> {
   const validation = jobInfoSchema.safeParse(unsafeData);
   if (!validation.success) {
     return {
       success: false,
-      message: "Invalid job information. Please check all required fields.",
+      message: JOB_INFO_ACTION_MESSAGES.invalidInput,
     };
   }
 
@@ -102,14 +103,14 @@ export async function updateJobInfoAction(
     if (error instanceof UnauthorizedError) {
       return {
         success: false,
-        message: "You must be logged in to update this job posting.",
+        message: JOB_INFO_ACTION_MESSAGES.updateUnauthorized,
       };
     }
 
     if (error instanceof NotFoundError) {
       return {
         success: false,
-        message: "Job posting not found or you don't have access to it.",
+        message: JOB_INFO_ACTION_MESSAGES.updateNotFound,
       };
     }
 
@@ -123,13 +124,13 @@ export async function updateJobInfoAction(
     if (error instanceof DatabaseError) {
       return {
         success: false,
-        message: "Failed to update job posting. Please try again.",
+        message: JOB_INFO_ACTION_MESSAGES.updateDatabaseError,
       };
     }
 
     return {
       success: false,
-      message: "An unexpected error occurred. Please try again.",
+      message: JOB_INFO_ACTION_MESSAGES.unexpectedError,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Added a shared `JOB_INFO_ACTION_MESSAGES` constant for job info server action copy
- Updated `createJobInfoAction` and `updateJobInfoAction` to use the shared messages
- Added focused tests for job info action validation, success paths, error mapping, and thin service delegates
- Recorded the coverage slice and updated the test coverage plan

## Testing
- `npm.cmd test -- core/features/jobInfos/actions.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npm.cmd exec biome check core/features/jobInfos/actions.ts core/features/jobInfos/actions.test.ts core/features/jobInfos/actionMessages.ts TEST_COVERAGE_PLAN.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for job info server actions, covering create, update, read, and remove operations with error mapping validation.

* **Chores**
  * Updated test coverage plan documentation for job info actions.
  * Standardized error messaging for job info create and update operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->