### PR TITLE
Normalize feature-layer action naming and add interview action coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -234,6 +234,56 @@ Add a shared Arcjet mock helper if the allow/deny protection scenarios create
 duplication, then cover `core/features/questions/actions.ts` and
 `core/features/users/actions.ts` before moving into API routes.
 
+### Interview Server Actions Slice - 2026-05-19
+
+Files/tests added:
+
+- `core/features/interviews/actionMessages.ts`
+- `core/features/interviews/actions.test.ts`
+
+Files updated:
+
+- `core/features/interviews/actions.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/features/interviews/actions.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Initial focused test run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd ci` installed dependencies from `package-lock.json`.
+- Focused action slice passed: 1 test suite, 21 tests, 0 snapshots.
+- `npm.cmd test -- --runInBand` passed: 38 test suites, 249 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 38 test suites, 249
+  tests, 0 snapshots.
+- Updated coverage summary: 78.2% statements, 75.15% branches, 73.89%
+  functions, and 80.59% lines.
+- `core/features/interviews/actions.ts` now reports 100% statements, branches,
+  functions, and lines.
+
+Notes:
+
+- Action tests cover unauthenticated, plan-limit, Arcjet rate-limit,
+  inaccessible job info, successful create, mapped create/update/feedback
+  errors, and thin service/permission delegates.
+- Interview action messages were extracted to a feature-local constants file to
+  avoid duplicating production strings in tests.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Continue the server action slice with `core/features/questions/actions.ts`,
+then cover `core/features/users/actions.ts`. Keep API route coverage as the
+following mock-heavy slice.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/ai/questions/generate-feedback/route.ts
+++ b/app/api/ai/questions/generate-feedback/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { generateAiQuestionFeedback } from "@/core/services/ai/questions";
-import { getQuestionById } from "@/core/features/questions/actions";
+import { getQuestionByIdAction } from "@/core/features/questions/actions";
 import { UnauthorizedError, DatabaseError } from "@/core/dal/helpers";
 
 const schema = z.object({
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
   const { questionId, prompt: answer } = result.data;
 
   try {
-    const question = await getQuestionById(questionId);
+    const question = await getQuestionByIdAction(questionId);
 
     if (question == null) {
       return new Response("Question not found", { status: 404 });

--- a/app/api/ai/questions/generate-question/route.ts
+++ b/app/api/ai/questions/generate-question/route.ts
@@ -4,12 +4,12 @@ import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { questionDifficulties } from "@/core/drizzle/schema";
 import { PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { generateAiQuestion } from "@/core/services/ai/questions";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { checkQuestionsPermission } from "@/core/features/questions/permissions";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import {
-  getQuestions,
-  insertQuestion,
+  getQuestionsAction,
+  insertQuestionAction,
 } from "@/core/features/questions/actions";
 import {
   NotFoundError,
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   }
 
   const { prompt: difficulty, jobInfoId } = result.data;
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (userId == null) {
     return new Response("You are not logged in", { status: 401 });
@@ -43,15 +43,15 @@ export async function POST(req: Request) {
   }
 
   try {
-    // getJobInfo now handles auth internally and throws on error
-    const jobInfo = await getJobInfo(jobInfoId);
+    // getJobInfoAction handles auth internally and throws on error
+    const jobInfo = await getJobInfoAction(jobInfoId);
     if (jobInfo == null) {
       return new Response("You do not have permission to do this", {
         status: 403,
       });
     }
 
-    const previousQuestions = await getQuestions(jobInfoId);
+    const previousQuestions = await getQuestionsAction(jobInfoId);
 
     return createUIMessageStreamResponse({
       status: 200,
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
             jobInfo,
             difficulty,
             onFinish: async (question) => {
-              const { id } = await insertQuestion(
+              const { id } = await insertQuestionAction(
                 question,
                 jobInfoId,
                 difficulty,

--- a/app/api/ai/resumes/analyze/route.ts
+++ b/app/api/ai/resumes/analyze/route.ts
@@ -1,6 +1,6 @@
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { analyzeResumeForJob } from "@/core/services/ai/resumes/ai";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import { checkResumeAnalysisPermission } from "@/core/features/resumeAnalysis/permissions";
 import { resumeAnalysisInputSchema } from "@/core/features/resumeAnalysis/schemas";
 import {
@@ -9,7 +9,7 @@ import {
 import { NotFoundError, PermissionError } from "@/core/dal/helpers";
 
 export async function POST(req: Request) {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (userId == null) {
     return new Response("You are not logged in", { status: 401 });
@@ -29,8 +29,8 @@ export async function POST(req: Request) {
   try {
     const { resumeFile, jobInfoId } = validation.data;
 
-    // getJobInfo now handles auth internally and throws on error
-    const jobInfo = await getJobInfo(jobInfoId);
+    // getJobInfoAction handles auth internally and throws on error
+    const jobInfo = await getJobInfoAction(jobInfoId);
 
     if (jobInfo == null) {
       return new Response("You do not have permission to do this", {

--- a/app/api/stripe/cancel-subscription/route.ts
+++ b/app/api/stripe/cancel-subscription/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
   getStripeBaseUrl,
@@ -16,7 +16,7 @@ import { routes } from "@/core/data/routes";
  * subscription ends.
  */
 export async function POST(request: Request) {
-  const { userId, user } = await getCurrentUserWithProfile();
+  const { userId, user } = await getCurrentUserWithProfileAction();
   const idempotencyKey = await getIdempotencyKeyFromRequest(request);
   const wantsJson =
     request.headers

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
   getStripeBaseUrl,
@@ -13,7 +13,7 @@ import { env } from "@/core/data/env/server";
 import { routes } from "@/core/data/routes";
 
 export async function POST(request: Request) {
-  const { userId, user } = await getCurrentUserWithProfile();
+  const { userId, user } = await getCurrentUserWithProfileAction();
   const idempotencyKey = await getIdempotencyKeyFromRequest(request);
   const wantsJson =
     request.headers

--- a/app/api/stripe/create-portal-session/route.ts
+++ b/app/api/stripe/create-portal-session/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
   getStripeBaseUrl,
@@ -12,7 +12,7 @@ import {
 import { routes } from "@/core/data/routes";
 
 export async function POST(request: Request) {
-  const { userId, user } = await getCurrentUserWithProfile();
+  const { userId, user } = await getCurrentUserWithProfileAction();
   const idempotencyKey = await getIdempotencyKeyFromRequest(request);
   const wantsJson =
     request.headers

--- a/app/app/jobInfo/[jobInfoId]/edit/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/edit/page.tsx
@@ -5,8 +5,8 @@ import { Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/core/components/ui/card";
 import { JobInfoBackLink } from "@/core/features/jobInfos/components/JobInfoBackLink";
 import { JobInfoForm } from "@/core/features/jobInfos/components/JobInfoForm";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 
 export default async function JobInfoEditPage({
   params,
@@ -32,11 +32,11 @@ export default async function JobInfoEditPage({
 }
 
 async function SuspendedForm({ jobInfoId }: { jobInfoId: string }) {
-  const jobInfo = await getCurrentUser().then(
+  const jobInfo = await getCurrentUserAction().then(
     async ({ userId, redirectToSignIn }) => {
       if (userId == null) return redirectToSignIn();
 
-      const jobInfo = await getJobInfo(jobInfoId);
+      const jobInfo = await getJobInfoAction(jobInfoId);
       if (jobInfo == null) return notFound();
 
       return jobInfo;

--- a/app/app/jobInfo/[jobInfoId]/interviews/[interviewId]/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/interviews/[interviewId]/page.tsx
@@ -16,9 +16,9 @@ import { Skeleton, SkeletonButton } from "@/core/components/Skeleton";
 import { MarkdownRenderer } from "@/core/components/MarkdownRenderer";
 import {
   generateInterviewFeedbackAction,
-  getInterviewById,
+  getInterviewByIdAction,
 } from "@/core/features/interviews/actions";
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import { condenseChatMessages } from "@/core/services/hume/lib/condenseChatMessages";
 import { CondensedMessages } from "@/core/services/hume/components/CondensedMessages";
 import { fetchChatMessages } from "@/core/services/hume/lib/api";
@@ -42,11 +42,11 @@ export default async function InterviewPage({
     return <InterviewNotFound jobInfoId={jobInfoId} />;
   }
 
-  const interview = getCurrentUserWithProfile().then(
+  const interview = getCurrentUserWithProfileAction().then(
     async ({ userId, redirectToSignIn }) => {
       if (userId == null) return redirectToSignIn();
 
-      const interview = await getInterviewById(interviewId, userId);
+      const interview = await getInterviewByIdAction(interviewId, userId);
       if (interview == null) return notFound();
 
       return interview;
@@ -115,7 +115,7 @@ async function SuspendedMessages({
 }: {
   interview: Promise<{ humeChatId: string | null }>;
 }) {
-  const { user, redirectToSignIn } = await getCurrentUserWithProfile();
+  const { user, redirectToSignIn } = await getCurrentUserWithProfileAction();
   if (user == null) return redirectToSignIn();
   const { humeChatId } = await interview;
   if (humeChatId == null) return notFound();

--- a/app/app/jobInfo/[jobInfoId]/interviews/_PermissionCheckedLink.tsx
+++ b/app/app/jobInfo/[jobInfoId]/interviews/_PermissionCheckedLink.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 import { errorToast, PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
-import { canCreateInterview } from "@/core/features/interviews/actions";
+import { canCreateInterviewAction } from "@/core/features/interviews/actions";
 
 interface PermissionCheckedLinkProps {
   href: string;
@@ -30,7 +30,7 @@ export function PermissionCheckedLink({
     setIsChecking(true);
 
     try {
-      const hasPermissionForInterviews = await canCreateInterview();
+      const hasPermissionForInterviews = await canCreateInterviewAction();
       if (!hasPermissionForInterviews) {
         errorToast(PLAN_LIMIT_MESSAGE);
         return;

--- a/app/app/jobInfo/[jobInfoId]/interviews/new/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/interviews/new/page.tsx
@@ -4,9 +4,9 @@ import { fetchAccessToken } from "hume";
 
 import { FullScreenLoader } from "@/core/components/FullScreenLoader";
 import { BackLink } from "@/core/components/BackLink";
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
-import { canCreateInterview } from "@/core/features/interviews/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
+import { canCreateInterviewAction } from "@/core/features/interviews/actions";
 import { env } from "@/core/data/env/server";
 import { routes } from "@/core/data/routes";
 
@@ -34,16 +34,16 @@ export default async function NewInterviewPage({
 }
 
 async function SuspendedComponent({ jobInfoId }: { jobInfoId: string }) {
-  const { redirectToSignIn, user } = await getCurrentUserWithProfile();
+  const { redirectToSignIn, user } = await getCurrentUserWithProfileAction();
   if (user == null) return redirectToSignIn();
 
-  const hasPermissionForInterviews = await canCreateInterview();
+  const hasPermissionForInterviews = await canCreateInterviewAction();
   if (!hasPermissionForInterviews) {
     redirect(routes.interviews(jobInfoId));
   }
 
-  // getJobInfo now handles auth internally and throws on error
-  const jobInfo = await getJobInfo(jobInfoId);
+  // getJobInfoAction handles auth internally and throws on error
+  const jobInfo = await getJobInfoAction(jobInfoId);
   if (jobInfo == null) return notFound();
 
   const accessToken = await fetchAccessToken({

--- a/app/app/jobInfo/[jobInfoId]/interviews/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/interviews/page.tsx
@@ -12,11 +12,11 @@ import {
 import { Badge } from "@/core/components/ui/badge";
 import { PlanLimitAlert } from "@/core/components/PlanLimitAlert";
 import {
-  canCreateInterview,
-  getInterviews,
+  canCreateInterviewAction,
+  getInterviewsAction,
 } from "@/core/features/interviews/actions";
 import { JobInfoBackLink } from "@/core/features/jobInfos/components/JobInfoBackLink";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { formatDateTime } from "@/core/lib/formatters";
 import { routes } from "@/core/data/routes";
 
@@ -42,11 +42,11 @@ export default async function InterviewsPage({
 }
 
 async function SuspendedPage({ jobInfoId }: { jobInfoId: string }) {
-  const { userId, redirectToSignIn } = await getCurrentUser();
+  const { userId, redirectToSignIn } = await getCurrentUserAction();
   if (userId == null) return redirectToSignIn();
 
-  const interviews = await getInterviews(jobInfoId, userId);
-  const hasPermissionForInterviews = await canCreateInterview();
+  const interviews = await getInterviewsAction(jobInfoId, userId);
+  const hasPermissionForInterviews = await canCreateInterviewAction();
 
   return (
     <div className="space-y-6 w-full">

--- a/app/app/jobInfo/[jobInfoId]/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/page.tsx
@@ -11,11 +11,11 @@ import {
   CardTitle,
 } from "@/core/components/ui/card";
 import { BackLink } from "@/core/components/BackLink";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import { formatExperienceLevel } from "@/core/features/jobInfos/lib/formatters";
 import { SuspendedItem } from "@/core/components/SuspendedItem";
 import { Skeleton } from "@/core/components/Skeleton";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { routes } from "@/core/data/routes";
 import { assertUUIDor404 } from "@/core/lib/assertUUIDor404";
 
@@ -53,11 +53,11 @@ export default async function JobInfoPage({
 
   assertUUIDor404(jobInfoId);
 
-  const jobInfo = getCurrentUser().then(
+  const jobInfo = getCurrentUserAction().then(
     async ({ userId, redirectToSignIn }) => {
       if (userId == null) return redirectToSignIn();
 
-      const jobInfo = await getJobInfo(jobInfoId);
+      const jobInfo = await getJobInfoAction(jobInfoId);
       if (jobInfo == null) return notFound();
 
       return jobInfo;

--- a/app/app/jobInfo/[jobInfoId]/questions/page.tsx
+++ b/app/app/jobInfo/[jobInfoId]/questions/page.tsx
@@ -2,10 +2,10 @@ import { Suspense } from "react";
 import { notFound, redirect } from "next/navigation";
 
 import { FullScreenLoader } from "@/core/components/FullScreenLoader";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import { checkQuestionsPermission } from "@/core/features/questions/permissions";
 import { JobInfoBackLink } from "@/core/features/jobInfos/components/JobInfoBackLink";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { routes } from "@/core/data/routes";
 
 import { NewQuestionClientPage } from "./_NewQuestionClientPage";
@@ -28,13 +28,13 @@ export default async function QuestionsPage({
 }
 
 async function SuspendedComponent({ jobInfoId }: { jobInfoId: string }) {
-  const { userId, redirectToSignIn } = await getCurrentUser();
+  const { userId, redirectToSignIn } = await getCurrentUserAction();
   if (userId == null) return redirectToSignIn();
 
   if (!(await checkQuestionsPermission())) redirect(routes.upgrade);
 
-  // getJobInfo now handles auth internally and throws on error
-  const jobInfo = await getJobInfo(jobInfoId);
+  // getJobInfoAction handles auth internally and throws on error
+  const jobInfo = await getJobInfoAction(jobInfoId);
   if (jobInfo == null) return notFound();
 
   return <NewQuestionClientPage jobInfo={jobInfo} />;

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { redirect } from "next/navigation";
 
 import { FullScreenLoader } from "@/core/components/FullScreenLoader";
-import { getCurrentUserWithProfile } from "@/core/features/auth/actions";
+import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import type { AuthUser } from "@/core/features/auth/types";
 import { routes } from "@/core/data/routes";
 
@@ -19,7 +19,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 }
 
 async function AuthenticatedAppShell({ children }: { children: React.ReactNode }) {
-  const { userId, user } = await getCurrentUserWithProfile();
+  const { userId, user } = await getCurrentUserWithProfileAction();
 
   if (userId == null || user == null) return redirect(routes.landing);
 

--- a/app/app/upgrade/actions.ts
+++ b/app/app/upgrade/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { revalidateUserCache } from "@/core/features/users/dbCache";
 import { routes } from "@/core/data/routes";
 
@@ -12,6 +12,6 @@ import { routes } from "@/core/data/routes";
  */
 export async function revalidateUpgradePage() {
   revalidatePath(routes.upgrade);
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   if (userId) revalidateUserCache(userId);
 }

--- a/app/app/upgrade/checkSubscriptionSuccess.ts
+++ b/app/app/upgrade/checkSubscriptionSuccess.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { getStripe } from "@/core/features/billing/stripe";
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -19,7 +19,7 @@ export async function checkSubscriptionSuccess(searchParams: SearchParams) {
 
   if (sessionId && stripe) {
     try {
-      const { userId } = await getCurrentUser();
+      const { userId } = await getCurrentUserAction();
       const session = await stripe.checkout.sessions.retrieve(sessionId);
 
       return (

--- a/app/app/upgrade/page.tsx
+++ b/app/app/upgrade/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { BackLink } from "@/core/components/BackLink";
 import { PlanLimitAlert } from "@/core/components/PlanLimitAlert";
 import { routes } from "@/core/data/routes";
-import { canCreateInterview } from "@/core/features/interviews/actions";
+import { canCreateInterviewAction } from "@/core/features/interviews/actions";
 
 import { RevalidateOnStripeReturn } from "./_RevalidateOnStripeReturn";
 import { FAQSection } from "./_FAQSection";
@@ -101,7 +101,7 @@ export default async function UpgradePage(props: UpgradePageProps) {
 }
 
 async function SuspendedAlert() {
-  const hasPermissionForInterviews = await canCreateInterview();
+  const hasPermissionForInterviews = await canCreateInterviewAction();
   if (hasPermissionForInterviews) return null;
 
   return <PlanLimitAlert />;

--- a/app/app/upgrade/syncSubscriptionOnLoad.test.ts
+++ b/app/app/upgrade/syncSubscriptionOnLoad.test.ts
@@ -1,0 +1,96 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUserAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/db", () => ({
+  getUserByIdDb: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/stripeSync", () => ({
+  reconcileUserStripeSubscription: jest.fn(),
+}));
+
+jest.mock("@/core/features/billing/stripe", () => ({
+  getStripe: jest.fn(),
+  isStripeConfigured: jest.fn(),
+}));
+
+import { getCurrentUserAction } from "@/core/features/auth/actions";
+import { getStripe, isStripeConfigured } from "@/core/features/billing/stripe";
+import { getUserByIdDb } from "@/core/features/users/db";
+import { reconcileUserStripeSubscription } from "@/core/features/users/stripeSync";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeCurrentUser, makeUser } from "@/core/test-utils/factories";
+
+import { syncSubscriptionOnUpgradePageLoad } from "./syncSubscriptionOnLoad";
+
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
+const mockGetStripe = jest.mocked(getStripe);
+const mockIsStripeConfigured = jest.mocked(isStripeConfigured);
+const mockGetUserByIdDb = jest.mocked(getUserByIdDb);
+const mockReconcileUserStripeSubscription = jest.mocked(
+  reconcileUserStripeSubscription,
+);
+
+const stripe = {} as ReturnType<typeof getStripe>;
+
+describe("syncSubscriptionOnUpgradePageLoad", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    mockIsStripeConfigured.mockReturnValue(true);
+    mockGetStripe.mockReturnValue(stripe);
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: TEST_USER_ID }),
+    );
+    mockGetUserByIdDb.mockResolvedValue(
+      makeUser({
+        id: TEST_USER_ID,
+        stripeSubscriptionId: "sub_test_1",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("reconciles the current user's subscription when present", async () => {
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockReconcileUserStripeSubscription).toHaveBeenCalledWith(
+      stripe,
+      TEST_USER_ID,
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("swallows current user lookup failures so the page can render", async () => {
+    const error = new Error("session failed");
+    mockGetCurrentUser.mockRejectedValue(error);
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockGetUserByIdDb).not.toHaveBeenCalled();
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error syncing subscription:",
+      error,
+    );
+  });
+
+  it("swallows direct user lookup failures so the page can render", async () => {
+    const error = new Error("database failed");
+    mockGetUserByIdDb.mockRejectedValue(error);
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error syncing subscription:",
+      error,
+    );
+  });
+});

--- a/app/app/upgrade/syncSubscriptionOnLoad.ts
+++ b/app/app/upgrade/syncSubscriptionOnLoad.ts
@@ -12,26 +12,26 @@ import { getStripe, isStripeConfigured } from "@/core/features/billing/stripe";
  * still renders; Stage 1 cron remains a backstop.
  */
 export async function syncSubscriptionOnUpgradePageLoad(): Promise<void> {
-  if (!isStripeConfigured()) {
-    return;
-  }
-
-  const stripe = getStripe();
-  if (!stripe) {
-    return;
-  }
-
-  const { userId } = await getCurrentUserAction();
-  if (!userId) {
-    return;
-  }
-
-  const user = await getUserByIdDb(userId);
-  if (!user?.stripeSubscriptionId) {
-    return;
-  }
-
   try {
+    if (!isStripeConfigured()) {
+      return;
+    }
+
+    const stripe = getStripe();
+    if (!stripe) {
+      return;
+    }
+
+    const { userId } = await getCurrentUserAction();
+    if (!userId) {
+      return;
+    }
+
+    const user = await getUserByIdDb(userId);
+    if (!user?.stripeSubscriptionId) {
+      return;
+    }
+
     await reconcileUserStripeSubscription(stripe, userId);
   } catch (error) {
     console.error("Error syncing subscription:", error);

--- a/app/app/upgrade/syncSubscriptionOnLoad.ts
+++ b/app/app/upgrade/syncSubscriptionOnLoad.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { getUserByIdDb } from "@/core/features/users/db";
 import { reconcileUserStripeSubscription } from "@/core/features/users/stripeSync";
 import { getStripe, isStripeConfigured } from "@/core/features/billing/stripe";
@@ -8,7 +8,7 @@ import { getStripe, isStripeConfigured } from "@/core/features/billing/stripe";
  * Upgrade page (lazy reconciliation if webhooks were missed).
  *
  * Uses a direct DB read to detect `stripeSubscriptionId` so a stale cached
- * `getUser` result cannot skip a needed sync. Errors are swallowed so the page
+ * `getUserAction` result cannot skip a needed sync. Errors are swallowed so the page
  * still renders; Stage 1 cron remains a backstop.
  */
 export async function syncSubscriptionOnUpgradePageLoad(): Promise<void> {
@@ -21,7 +21,7 @@ export async function syncSubscriptionOnUpgradePageLoad(): Promise<void> {
     return;
   }
 
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   if (!userId) {
     return;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/core/components/ui/card";
 import { Badge } from "@/core/components/ui/badge";
 import { ThemeToggle } from "@/core/components/ThemeToggle";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { routes } from "@/core/data/routes";
 import { UserAvatar } from "@/core/features/users/components/UserAvatar";
 
@@ -64,7 +64,7 @@ function Navbar() {
 }
 
 async function SignInButton() {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   const isUserLoggedIn = userId != null;
 
   if (isUserLoggedIn) return redirect(routes.app);

--- a/core/dal/helpers.ts
+++ b/core/dal/helpers.ts
@@ -1,6 +1,6 @@
 import {
-  getCurrentUser,
-  getCurrentUserWithProfile,
+  getCurrentUserAction,
+  getCurrentUserWithProfileAction,
 } from "@/core/features/auth/actions";
 
 /**
@@ -54,7 +54,7 @@ export class DatabaseError extends Error {
  * Use this in Service layer when auth is required
  */
 export async function requireUser(): Promise<string> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     throw new UnauthorizedError();
@@ -68,7 +68,7 @@ export async function requireUser(): Promise<string> {
  * Throws UnauthorizedError if not authenticated
  */
 export async function requireUserWithData() {
-  const { userId, user } = await getCurrentUserWithProfile();
+  const { userId, user } = await getCurrentUserWithProfileAction();
 
   if (!userId || !user) {
     throw new UnauthorizedError();

--- a/core/features/auth/actions.ts
+++ b/core/features/auth/actions.ts
@@ -28,7 +28,7 @@ import {
   setOAuthErrorReturnForNextOAuth,
   type OAuthErrorReturn,
 } from "@/core/features/auth/oauth/oauthErrorReturn";
-import { getUser } from "@/core/features/users/actions";
+import { getUserAction } from "@/core/features/users/actions";
 import { routes } from "@/core/data/routes";
 import type { CurrentUser } from "@/core/features/auth/types";
 import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
@@ -226,7 +226,7 @@ const getCurrentUserCached = cache(
 
       return {
         userId,
-        user: allData ? ((await getUser(userId)) ?? undefined) : undefined,
+        user: allData ? ((await getUserAction(userId)) ?? undefined) : undefined,
         redirectToSignIn: () => redirect(routes.signIn),
       };
     } catch (error) {
@@ -248,16 +248,16 @@ const getCurrentUserCached = cache(
  *
  * @returns Object with userId, optional user data, and redirectToSignIn helper
  */
-export async function getCurrentUser(): Promise<CurrentUser> {
+export async function getCurrentUserAction(): Promise<CurrentUser> {
   return getCurrentUserCached(false);
 }
 
 /**
- * Same as {@link getCurrentUser} but loads the full user row from the database.
+ * Same as {@link getCurrentUserAction} but loads the full user row from the database.
  *
  * @returns Object with userId, user, and redirectToSignIn helper
  */
-export async function getCurrentUserWithProfile(): Promise<CurrentUser> {
+export async function getCurrentUserWithProfileAction(): Promise<CurrentUser> {
   return getCurrentUserCached(true);
 }
 

--- a/core/features/auth/permissions.test.ts
+++ b/core/features/auth/permissions.test.ts
@@ -1,12 +1,12 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/users/actions", () => ({
-  getUser: jest.fn(),
+  getUserAction: jest.fn(),
 }));
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   FREE_PLAN_LIMITS,
   getUserPlan,
@@ -15,7 +15,7 @@ import {
   hasUnlimitedAccess,
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
-import { getUser } from "@/core/features/users/actions";
+import { getUserAction } from "@/core/features/users/actions";
 import {
   makeCurrentUser,
   makeProUser,
@@ -23,8 +23,8 @@ import {
 } from "@/core/test-utils/factories/user";
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
-const mockGetUser = jest.mocked(getUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
+const mockGetUserAction = jest.mocked(getUserAction);
 
 const SIGNED_IN_USER_ID = TEST_USER_ID;
 
@@ -51,11 +51,11 @@ describe("auth permission helpers", () => {
       false,
     );
 
-    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockGetUserAction).not.toHaveBeenCalled();
   });
 
   it("denies permissions when the signed-in user cannot be loaded", async () => {
-    mockGetUser.mockResolvedValue(null);
+    mockGetUserAction.mockResolvedValue(null);
 
     await expect(hasPermission(PERMISSIONS.LIMITED.QUESTIONS)).resolves.toBe(
       false,
@@ -63,7 +63,7 @@ describe("auth permission helpers", () => {
   });
 
   it("grants limited free-plan permissions and denies pro-only permissions", async () => {
-    mockGetUser.mockResolvedValue(makeUser({ plan: "free" }));
+    mockGetUserAction.mockResolvedValue(makeUser({ plan: "free" }));
 
     await expect(hasPermission(PERMISSIONS.LIMITED.QUESTIONS)).resolves.toBe(
       true,
@@ -74,7 +74,7 @@ describe("auth permission helpers", () => {
   });
 
   it("grants unlimited permissions for pro users", async () => {
-    mockGetUser.mockResolvedValue(makeProUser());
+    mockGetUserAction.mockResolvedValue(makeProUser());
 
     await expect(hasPermission(PERMISSIONS.UNLIMITED.INTERVIEWS)).resolves.toBe(
       true,
@@ -83,7 +83,7 @@ describe("auth permission helpers", () => {
   });
 
   it("defaults missing user records to the free plan", async () => {
-    mockGetUser.mockResolvedValue(null);
+    mockGetUserAction.mockResolvedValue(null);
 
     await expect(getUserPlan()).resolves.toBe("free");
   });
@@ -95,11 +95,11 @@ describe("auth permission helpers", () => {
       plan: "free",
       hasExistingSubscription: false,
     });
-    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(mockGetUserAction).not.toHaveBeenCalled();
   });
 
   it("reports the current plan and whether a Stripe subscription exists", async () => {
-    mockGetUser.mockResolvedValue(
+    mockGetUserAction.mockResolvedValue(
       makeProUser({ stripeSubscriptionId: "sub_test_1" }),
     );
 

--- a/core/features/auth/permissions.ts
+++ b/core/features/auth/permissions.ts
@@ -1,5 +1,5 @@
-import { getCurrentUser } from "@/core/features/auth/actions";
-import { getUser } from "@/core/features/users/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
+import { getUserAction } from "@/core/features/users/actions";
 import type { UserPlan } from "@/core/drizzle/schema/user";
 
 /**
@@ -63,13 +63,13 @@ export const FREE_PLAN_LIMITS = {
  * @returns true if user has the permission, false otherwise
  */
 export async function hasPermission(permission: Permission): Promise<boolean> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     return false;
   }
 
-  const user = await getUser(userId);
+  const user = await getUserAction(userId);
 
   if (!user) {
     return false;
@@ -86,13 +86,13 @@ export async function hasPermission(permission: Permission): Promise<boolean> {
  * @returns The user's plan or "free" if not found
  */
 export async function getUserPlan(): Promise<UserPlan> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     return "free";
   }
 
-  const user = await getUser(userId);
+  const user = await getUserAction(userId);
 
   return (user?.plan as UserPlan) || "free";
 }
@@ -108,13 +108,13 @@ export type SubscriptionInfo = {
  * for users whose subscription is in a non-terminal but non-active state.
  */
 export async function getUserSubscriptionInfo(): Promise<SubscriptionInfo> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     return { plan: "free", hasExistingSubscription: false };
   }
 
-  const user = await getUser(userId);
+  const user = await getUserAction(userId);
 
   return {
     plan: (user?.plan as UserPlan) || "free",

--- a/core/features/interviews/actionMessages.ts
+++ b/core/features/interviews/actionMessages.ts
@@ -1,0 +1,12 @@
+export const INTERVIEW_ACTION_MESSAGES = {
+  createUnauthorized: "You must be logged in to create an interview.",
+  createJobInfoNotFound:
+    "Job posting not found or you don't have access to it.",
+  createDatabaseError: "Failed to create interview. Please try again.",
+  updateUnauthorized: "You must be logged in to update this interview.",
+  updateDatabaseError: "Failed to update interview. Please try again.",
+  feedbackUnauthorized: "You must be logged in to generate feedback.",
+  feedbackDatabaseError: "Failed to save feedback. Please try again.",
+  feedbackUnexpectedError: "Failed to generate feedback. Please try again.",
+  unexpectedError: "An unexpected error occurred. Please try again.",
+} as const;

--- a/core/features/interviews/actions.test.ts
+++ b/core/features/interviews/actions.test.ts
@@ -14,7 +14,7 @@ jest.mock("@/core/data/env/server", () => ({
 }));
 
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/interviews/permissions", () => ({
@@ -22,7 +22,7 @@ jest.mock("@/core/features/interviews/permissions", () => ({
 }));
 
 jest.mock("@/core/features/jobInfos/actions", () => ({
-  getJobInfo: jest.fn(),
+  getJobInfoAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/interviews/service", () => ({
@@ -39,14 +39,14 @@ import {
   UnauthorizedError,
 } from "@/core/dal/helpers";
 import arcjet, { request } from "@arcjet/next";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";
 import {
-  canCreateInterview,
+  canCreateInterviewAction,
   createInterviewAction,
   generateInterviewFeedbackAction,
-  getInterviewById,
-  getInterviews,
+  getInterviewByIdAction,
+  getInterviewsAction,
   updateInterviewAction,
 } from "@/core/features/interviews/actions";
 import { checkInterviewPermission } from "@/core/features/interviews/permissions";
@@ -57,7 +57,7 @@ import {
   getInterviewsService,
   updateInterviewService,
 } from "@/core/features/interviews/service";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import { PLAN_LIMIT_MESSAGE, RATE_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
@@ -68,9 +68,9 @@ const mockProtect = jest.mocked(
   mockArcjet.mock.results[0].value.protect as jest.Mock,
 );
 const mockRequest = jest.mocked(request);
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockCheckInterviewPermission = jest.mocked(checkInterviewPermission);
-const mockGetJobInfo = jest.mocked(getJobInfo);
+const mockGetJobInfoAction = jest.mocked(getJobInfoAction);
 const mockCreateInterviewService = jest.mocked(createInterviewService);
 const mockUpdateInterviewService = jest.mocked(updateInterviewService);
 const mockGetInterviewByIdService = jest.mocked(getInterviewByIdService);
@@ -127,7 +127,7 @@ describe("interview actions", () => {
       });
 
       expect(mockProtect).not.toHaveBeenCalled();
-      expect(mockGetJobInfo).not.toHaveBeenCalled();
+      expect(mockGetJobInfoAction).not.toHaveBeenCalled();
       expect(mockCreateInterviewService).not.toHaveBeenCalled();
     });
 
@@ -146,12 +146,14 @@ describe("interview actions", () => {
         userId: TEST_USER_ID,
         requested: 1,
       });
-      expect(mockGetJobInfo).not.toHaveBeenCalled();
+      expect(mockGetJobInfoAction).not.toHaveBeenCalled();
       expect(mockCreateInterviewService).not.toHaveBeenCalled();
     });
 
     it("returns an access message when the job info is inaccessible", async () => {
-      mockGetJobInfo.mockResolvedValue(null);
+      mockGetJobInfoAction.mockResolvedValue(
+        null as unknown as Awaited<ReturnType<typeof getJobInfoAction>>,
+      );
 
       await expect(
         createInterviewAction({ jobInfoId: "job-info-1" }),
@@ -160,14 +162,14 @@ describe("interview actions", () => {
         message: INTERVIEW_ACTION_MESSAGES.createJobInfoNotFound,
       });
 
-      expect(mockGetJobInfo).toHaveBeenCalledWith("job-info-1");
+      expect(mockGetJobInfoAction).toHaveBeenCalledWith("job-info-1");
       expect(mockCreateInterviewService).not.toHaveBeenCalled();
     });
 
     it("returns the created interview id when creation succeeds", async () => {
       const jobInfo = makeJobInfo({ id: "job-info-1" });
       const interview = makeInterview({ jobInfo, jobInfoId: jobInfo.id });
-      mockGetJobInfo.mockResolvedValue(jobInfo);
+      mockGetJobInfoAction.mockResolvedValue(jobInfo);
       mockCreateInterviewService.mockResolvedValue(interview);
 
       await expect(
@@ -182,7 +184,7 @@ describe("interview actions", () => {
     });
 
     it("maps unauthorized errors to a login message", async () => {
-      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockGetJobInfoAction.mockResolvedValue(makeJobInfo());
       mockCreateInterviewService.mockRejectedValue(new UnauthorizedError());
 
       await expect(
@@ -194,7 +196,7 @@ describe("interview actions", () => {
     });
 
     it("maps database errors to a retry message", async () => {
-      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockGetJobInfoAction.mockResolvedValue(makeJobInfo());
       mockCreateInterviewService.mockRejectedValue(
         new DatabaseError("insert failed"),
       );
@@ -208,7 +210,7 @@ describe("interview actions", () => {
     });
 
     it("maps unexpected errors to the generic retry message", async () => {
-      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockGetJobInfoAction.mockResolvedValue(makeJobInfo());
       mockCreateInterviewService.mockRejectedValue(new Error("boom"));
 
       await expect(
@@ -360,7 +362,7 @@ describe("interview actions", () => {
   it("checks interview creation permission through the permission helper", async () => {
     mockCheckInterviewPermission.mockResolvedValue(false);
 
-    await expect(canCreateInterview()).resolves.toBe(false);
+    await expect(canCreateInterviewAction()).resolves.toBe(false);
 
     expect(mockCheckInterviewPermission).toHaveBeenCalledWith();
   });
@@ -369,9 +371,9 @@ describe("interview actions", () => {
     const interview = makeInterview();
     mockGetInterviewByIdService.mockResolvedValue(interview);
 
-    await expect(getInterviewById(interview.id, TEST_USER_ID)).resolves.toBe(
-      interview,
-    );
+    await expect(
+      getInterviewByIdAction(interview.id, TEST_USER_ID),
+    ).resolves.toBe(interview);
 
     expect(mockGetInterviewByIdService).toHaveBeenCalledWith(
       interview.id,
@@ -383,7 +385,7 @@ describe("interview actions", () => {
     const interviews = [makeInterview()];
     mockGetInterviewsService.mockResolvedValue(interviews);
 
-    await expect(getInterviews("job-info-1", TEST_USER_ID)).resolves.toBe(
+    await expect(getInterviewsAction("job-info-1", TEST_USER_ID)).resolves.toBe(
       interviews,
     );
 

--- a/core/features/interviews/actions.test.ts
+++ b/core/features/interviews/actions.test.ts
@@ -1,0 +1,395 @@
+jest.mock("@arcjet/next", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    protect: jest.fn(),
+  })),
+  request: jest.fn(),
+  tokenBucket: jest.fn((config) => config),
+}));
+
+jest.mock("@/core/data/env/server", () => ({
+  env: {
+    ARCJET_KEY: "test-arcjet-key",
+  },
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/core/features/interviews/permissions", () => ({
+  checkInterviewPermission: jest.fn(),
+}));
+
+jest.mock("@/core/features/jobInfos/actions", () => ({
+  getJobInfo: jest.fn(),
+}));
+
+jest.mock("@/core/features/interviews/service", () => ({
+  createInterviewService: jest.fn(),
+  generateInterviewFeedbackService: jest.fn(),
+  getInterviewByIdService: jest.fn(),
+  getInterviewsService: jest.fn(),
+  updateInterviewService: jest.fn(),
+}));
+
+import {
+  DatabaseError,
+  PermissionError,
+  UnauthorizedError,
+} from "@/core/dal/helpers";
+import arcjet, { request } from "@arcjet/next";
+import { getCurrentUser } from "@/core/features/auth/actions";
+import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";
+import {
+  canCreateInterview,
+  createInterviewAction,
+  generateInterviewFeedbackAction,
+  getInterviewById,
+  getInterviews,
+  updateInterviewAction,
+} from "@/core/features/interviews/actions";
+import { checkInterviewPermission } from "@/core/features/interviews/permissions";
+import {
+  createInterviewService,
+  generateInterviewFeedbackService,
+  getInterviewByIdService,
+  getInterviewsService,
+  updateInterviewService,
+} from "@/core/features/interviews/service";
+import { getJobInfo } from "@/core/features/jobInfos/actions";
+import { PLAN_LIMIT_MESSAGE, RATE_LIMIT_MESSAGE } from "@/core/lib/errorToast";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeCurrentUser } from "@/core/test-utils/factories/user";
+import { makeInterview, makeJobInfo } from "@/core/test-utils/factories";
+
+const mockArcjet = jest.mocked(arcjet);
+const mockProtect = jest.mocked(
+  mockArcjet.mock.results[0].value.protect as jest.Mock,
+);
+const mockRequest = jest.mocked(request);
+const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockCheckInterviewPermission = jest.mocked(checkInterviewPermission);
+const mockGetJobInfo = jest.mocked(getJobInfo);
+const mockCreateInterviewService = jest.mocked(createInterviewService);
+const mockUpdateInterviewService = jest.mocked(updateInterviewService);
+const mockGetInterviewByIdService = jest.mocked(getInterviewByIdService);
+const mockGetInterviewsService = jest.mocked(getInterviewsService);
+const mockGenerateInterviewFeedbackService = jest.mocked(
+  generateInterviewFeedbackService,
+);
+
+const allowDecision = { isDenied: () => false };
+const denyDecision = { isDenied: () => true };
+const requestContext = { ip: "127.0.0.1" };
+
+describe("interview actions", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    mockGetCurrentUser.mockResolvedValue(
+      makeCurrentUser({ userId: TEST_USER_ID }),
+    );
+    mockCheckInterviewPermission.mockResolvedValue(true);
+    mockRequest.mockResolvedValue(requestContext);
+    mockProtect.mockResolvedValue(allowDecision);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("createInterviewAction", () => {
+    it("returns a login message when the user is unauthenticated", async () => {
+      mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.createUnauthorized,
+      });
+
+      expect(mockCheckInterviewPermission).not.toHaveBeenCalled();
+      expect(mockProtect).not.toHaveBeenCalled();
+    });
+
+    it("returns the plan limit message when permission is denied", async () => {
+      mockCheckInterviewPermission.mockResolvedValue(false);
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: PLAN_LIMIT_MESSAGE,
+      });
+
+      expect(mockProtect).not.toHaveBeenCalled();
+      expect(mockGetJobInfo).not.toHaveBeenCalled();
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
+    it("returns the rate limit message when Arcjet denies the request", async () => {
+      mockProtect.mockResolvedValue(denyDecision);
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: RATE_LIMIT_MESSAGE,
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith();
+      expect(mockProtect).toHaveBeenCalledWith(requestContext, {
+        userId: TEST_USER_ID,
+        requested: 1,
+      });
+      expect(mockGetJobInfo).not.toHaveBeenCalled();
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
+    it("returns an access message when the job info is inaccessible", async () => {
+      mockGetJobInfo.mockResolvedValue(null);
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.createJobInfoNotFound,
+      });
+
+      expect(mockGetJobInfo).toHaveBeenCalledWith("job-info-1");
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
+    it("returns the created interview id when creation succeeds", async () => {
+      const jobInfo = makeJobInfo({ id: "job-info-1" });
+      const interview = makeInterview({ jobInfo, jobInfoId: jobInfo.id });
+      mockGetJobInfo.mockResolvedValue(jobInfo);
+      mockCreateInterviewService.mockResolvedValue(interview);
+
+      await expect(
+        createInterviewAction({ jobInfoId: jobInfo.id }),
+      ).resolves.toEqual({
+        success: true,
+        data: { id: interview.id },
+      });
+
+      expect(mockCreateInterviewService).toHaveBeenCalledWith(jobInfo.id);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps unauthorized errors to a login message", async () => {
+      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockCreateInterviewService.mockRejectedValue(new UnauthorizedError());
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.createUnauthorized,
+      });
+    });
+
+    it("maps database errors to a retry message", async () => {
+      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockCreateInterviewService.mockRejectedValue(
+        new DatabaseError("insert failed"),
+      );
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.createDatabaseError,
+      });
+    });
+
+    it("maps unexpected errors to the generic retry message", async () => {
+      mockGetJobInfo.mockResolvedValue(makeJobInfo());
+      mockCreateInterviewService.mockRejectedValue(new Error("boom"));
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
+      });
+    });
+  });
+
+  describe("updateInterviewAction", () => {
+    const update = { duration: "00:12:34", humeChatId: "chat-test-1" };
+
+    it("returns success when the service succeeds", async () => {
+      mockUpdateInterviewService.mockResolvedValue(makeInterview());
+
+      await expect(
+        updateInterviewAction("interview-1", update),
+      ).resolves.toEqual({
+        success: true,
+        data: undefined,
+      });
+
+      expect(mockUpdateInterviewService).toHaveBeenCalledWith(
+        "interview-1",
+        update,
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps unauthorized errors to a login message", async () => {
+      mockUpdateInterviewService.mockRejectedValue(new UnauthorizedError());
+
+      await expect(
+        updateInterviewAction("interview-1", update),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.updateUnauthorized,
+      });
+    });
+
+    it("returns permission error messages from the service", async () => {
+      mockUpdateInterviewService.mockRejectedValue(
+        new PermissionError("Custom permission message"),
+      );
+
+      await expect(
+        updateInterviewAction("interview-1", update),
+      ).resolves.toEqual({
+        success: false,
+        message: "Custom permission message",
+      });
+    });
+
+    it("maps database errors to a retry message", async () => {
+      mockUpdateInterviewService.mockRejectedValue(
+        new DatabaseError("update failed"),
+      );
+
+      await expect(
+        updateInterviewAction("interview-1", update),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.updateDatabaseError,
+      });
+    });
+
+    it("maps unexpected errors to the generic retry message", async () => {
+      mockUpdateInterviewService.mockRejectedValue(new Error("boom"));
+
+      await expect(
+        updateInterviewAction("interview-1", update),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
+      });
+    });
+  });
+
+  describe("generateInterviewFeedbackAction", () => {
+    it("returns success when feedback generation succeeds", async () => {
+      mockGenerateInterviewFeedbackService.mockResolvedValue("Useful feedback");
+
+      await expect(
+        generateInterviewFeedbackAction("interview-1"),
+      ).resolves.toEqual({
+        success: true,
+        data: undefined,
+      });
+
+      expect(mockGenerateInterviewFeedbackService).toHaveBeenCalledWith(
+        "interview-1",
+      );
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("maps unauthorized errors to a login message", async () => {
+      mockGenerateInterviewFeedbackService.mockRejectedValue(
+        new UnauthorizedError(),
+      );
+
+      await expect(
+        generateInterviewFeedbackAction("interview-1"),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.feedbackUnauthorized,
+      });
+    });
+
+    it("returns permission error messages from the service", async () => {
+      mockGenerateInterviewFeedbackService.mockRejectedValue(
+        new PermissionError("Interview has not been completed yet"),
+      );
+
+      await expect(
+        generateInterviewFeedbackAction("interview-1"),
+      ).resolves.toEqual({
+        success: false,
+        message: "Interview has not been completed yet",
+      });
+    });
+
+    it("maps database errors to a retry message", async () => {
+      mockGenerateInterviewFeedbackService.mockRejectedValue(
+        new DatabaseError("update failed"),
+      );
+
+      await expect(
+        generateInterviewFeedbackAction("interview-1"),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.feedbackDatabaseError,
+      });
+    });
+
+    it("maps unexpected errors to the feedback retry message", async () => {
+      mockGenerateInterviewFeedbackService.mockRejectedValue(new Error("boom"));
+
+      await expect(
+        generateInterviewFeedbackAction("interview-1"),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.feedbackUnexpectedError,
+      });
+    });
+  });
+
+  it("checks interview creation permission through the permission helper", async () => {
+    mockCheckInterviewPermission.mockResolvedValue(false);
+
+    await expect(canCreateInterview()).resolves.toBe(false);
+
+    expect(mockCheckInterviewPermission).toHaveBeenCalledWith();
+  });
+
+  it("gets one interview by id through the service", async () => {
+    const interview = makeInterview();
+    mockGetInterviewByIdService.mockResolvedValue(interview);
+
+    await expect(getInterviewById(interview.id, TEST_USER_ID)).resolves.toBe(
+      interview,
+    );
+
+    expect(mockGetInterviewByIdService).toHaveBeenCalledWith(
+      interview.id,
+      TEST_USER_ID,
+    );
+  });
+
+  it("gets all interviews through the service", async () => {
+    const interviews = [makeInterview()];
+    mockGetInterviewsService.mockResolvedValue(interviews);
+
+    await expect(getInterviews("job-info-1", TEST_USER_ID)).resolves.toBe(
+      interviews,
+    );
+
+    expect(mockGetInterviewsService).toHaveBeenCalledWith(
+      "job-info-1",
+      TEST_USER_ID,
+    );
+  });
+});

--- a/core/features/interviews/actions.test.ts
+++ b/core/features/interviews/actions.test.ts
@@ -412,6 +412,17 @@ describe("interview actions", () => {
     expect(mockCheckInterviewPermission).toHaveBeenCalledWith();
   });
 
+  it("returns false when interview creation permission checks fail", async () => {
+    mockCheckInterviewPermission.mockRejectedValue(new Error("permission"));
+
+    await expect(canCreateInterviewAction()).resolves.toBe(false);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error checking interview creation permission:",
+      expect.any(Error),
+    );
+  });
+
   it("gets one interview by id through the service", async () => {
     const interview = makeInterview();
     mockGetInterviewByIdService.mockResolvedValue(interview);

--- a/core/features/interviews/actions.test.ts
+++ b/core/features/interviews/actions.test.ts
@@ -131,6 +131,21 @@ describe("interview actions", () => {
       expect(mockCreateInterviewService).not.toHaveBeenCalled();
     });
 
+    it("maps permission check failures to the generic retry message", async () => {
+      mockCheckInterviewPermission.mockRejectedValue(new Error("permission"));
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
+      });
+
+      expect(mockProtect).not.toHaveBeenCalled();
+      expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
     it("returns the rate limit message when Arcjet denies the request", async () => {
       mockProtect.mockResolvedValue(denyDecision);
 
@@ -146,6 +161,36 @@ describe("interview actions", () => {
         userId: TEST_USER_ID,
         requested: 1,
       });
+      expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
+    it("maps request failures to the generic retry message", async () => {
+      mockRequest.mockRejectedValue(new Error("request failed"));
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
+      });
+
+      expect(mockProtect).not.toHaveBeenCalled();
+      expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+      expect(mockCreateInterviewService).not.toHaveBeenCalled();
+    });
+
+    it("maps Arcjet protection failures to the generic retry message", async () => {
+      mockProtect.mockRejectedValue(new Error("arcjet failed"));
+
+      await expect(
+        createInterviewAction({ jobInfoId: "job-info-1" }),
+      ).resolves.toEqual({
+        success: false,
+        message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith();
       expect(mockGetJobInfoAction).not.toHaveBeenCalled();
       expect(mockCreateInterviewService).not.toHaveBeenCalled();
     });

--- a/core/features/interviews/actions.ts
+++ b/core/features/interviews/actions.ts
@@ -58,28 +58,28 @@ export async function createInterviewAction({
     };
   }
 
-  // Check permissions
-  const permitted = await checkInterviewPermission();
-  if (!permitted) {
-    return {
-      success: false,
-      message: PLAN_LIMIT_MESSAGE,
-    };
-  }
-
-  // Check rate limit
-  const decision = await aj.protect(await request(), {
-    userId,
-    requested: 1,
-  });
-  if (decision.isDenied()) {
-    return {
-      success: false,
-      message: RATE_LIMIT_MESSAGE,
-    };
-  }
-
   try {
+    // Check permissions
+    const permitted = await checkInterviewPermission();
+    if (!permitted) {
+      return {
+        success: false,
+        message: PLAN_LIMIT_MESSAGE,
+      };
+    }
+
+    // Check rate limit
+    const decision = await aj.protect(await request(), {
+      userId,
+      requested: 1,
+    });
+    if (decision.isDenied()) {
+      return {
+        success: false,
+        message: RATE_LIMIT_MESSAGE,
+      };
+    }
+
     // Verify job info exists and user has access
     const jobInfo = await getJobInfoAction(jobInfoId);
     if (jobInfo == null) {

--- a/core/features/interviews/actions.ts
+++ b/core/features/interviews/actions.ts
@@ -3,8 +3,8 @@
 import arcjet, { request, tokenBucket } from "@arcjet/next";
 
 import { checkInterviewPermission } from "@/core/features/interviews/permissions";
-import { getJobInfo } from "@/core/features/jobInfos/actions";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { PLAN_LIMIT_MESSAGE, RATE_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { env } from "@/core/data/env/server";
 import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";
@@ -50,7 +50,7 @@ export async function createInterviewAction({
 }: {
   jobInfoId: string;
 }): Promise<ActionResult<{ id: string }>> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   if (userId == null) {
     return {
       success: false,
@@ -81,7 +81,7 @@ export async function createInterviewAction({
 
   try {
     // Verify job info exists and user has access
-    const jobInfo = await getJobInfo(jobInfoId);
+    const jobInfo = await getJobInfoAction(jobInfoId);
     if (jobInfo == null) {
       return {
         success: false,
@@ -167,7 +167,7 @@ export async function updateInterviewAction(
  * Get interview by ID
  * Used in pages - errors bubble up to error boundary
  */
-export async function getInterviewById(id: string, userId: string) {
+export async function getInterviewByIdAction(id: string, userId: string) {
   return await getInterviewByIdService(id, userId);
 }
 
@@ -175,7 +175,7 @@ export async function getInterviewById(id: string, userId: string) {
  * Check if user can create an interview
  * Used for UI permission checks
  */
-export async function canCreateInterview(): Promise<boolean> {
+export async function canCreateInterviewAction(): Promise<boolean> {
   return await checkInterviewPermission();
 }
 
@@ -183,7 +183,7 @@ export async function canCreateInterview(): Promise<boolean> {
  * Get all interviews for a job info
  * Used in pages - errors bubble up to error boundary
  */
-export async function getInterviews(jobInfoId: string, userId: string) {
+export async function getInterviewsAction(jobInfoId: string, userId: string) {
   return await getInterviewsService(jobInfoId, userId);
 }
 

--- a/core/features/interviews/actions.ts
+++ b/core/features/interviews/actions.ts
@@ -176,7 +176,12 @@ export async function getInterviewByIdAction(id: string, userId: string) {
  * Used for UI permission checks
  */
 export async function canCreateInterviewAction(): Promise<boolean> {
-  return await checkInterviewPermission();
+  try {
+    return await checkInterviewPermission();
+  } catch (error) {
+    console.error("Error checking interview creation permission:", error);
+    return false;
+  }
 }
 
 /**

--- a/core/features/interviews/actions.ts
+++ b/core/features/interviews/actions.ts
@@ -7,6 +7,7 @@ import { getJobInfo } from "@/core/features/jobInfos/actions";
 import { getCurrentUser } from "@/core/features/auth/actions";
 import { PLAN_LIMIT_MESSAGE, RATE_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { env } from "@/core/data/env/server";
+import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";
 import {
   UnauthorizedError,
   PermissionError,
@@ -53,7 +54,7 @@ export async function createInterviewAction({
   if (userId == null) {
     return {
       success: false,
-      message: "You must be logged in to create an interview.",
+      message: INTERVIEW_ACTION_MESSAGES.createUnauthorized,
     };
   }
 
@@ -84,7 +85,7 @@ export async function createInterviewAction({
     if (jobInfo == null) {
       return {
         success: false,
-        message: "Job posting not found or you don't have access to it.",
+        message: INTERVIEW_ACTION_MESSAGES.createJobInfoNotFound,
       };
     }
 
@@ -101,20 +102,20 @@ export async function createInterviewAction({
     if (error instanceof UnauthorizedError) {
       return {
         success: false,
-        message: "You must be logged in to create an interview.",
+        message: INTERVIEW_ACTION_MESSAGES.createUnauthorized,
       };
     }
 
     if (error instanceof DatabaseError) {
       return {
         success: false,
-        message: "Failed to create interview. Please try again.",
+        message: INTERVIEW_ACTION_MESSAGES.createDatabaseError,
       };
     }
 
     return {
       success: false,
-      message: "An unexpected error occurred. Please try again.",
+      message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
     };
   }
 }
@@ -125,7 +126,7 @@ export async function createInterviewAction({
  */
 export async function updateInterviewAction(
   id: string,
-  data: { humeChatId?: string; duration?: string }
+  data: { humeChatId?: string; duration?: string },
 ): Promise<ActionResult<void>> {
   try {
     await updateInterviewService(id, data);
@@ -137,7 +138,7 @@ export async function updateInterviewAction(
     if (error instanceof UnauthorizedError) {
       return {
         success: false,
-        message: "You must be logged in to update this interview.",
+        message: INTERVIEW_ACTION_MESSAGES.updateUnauthorized,
       };
     }
 
@@ -151,13 +152,13 @@ export async function updateInterviewAction(
     if (error instanceof DatabaseError) {
       return {
         success: false,
-        message: "Failed to update interview. Please try again.",
+        message: INTERVIEW_ACTION_MESSAGES.updateDatabaseError,
       };
     }
 
     return {
       success: false,
-      message: "An unexpected error occurred. Please try again.",
+      message: INTERVIEW_ACTION_MESSAGES.unexpectedError,
     };
   }
 }
@@ -191,7 +192,7 @@ export async function getInterviews(jobInfoId: string, userId: string) {
  * Server action called from client - returns ActionResult
  */
 export async function generateInterviewFeedbackAction(
-  interviewId: string
+  interviewId: string,
 ): Promise<ActionResult<void>> {
   try {
     await generateInterviewFeedbackService(interviewId);
@@ -203,7 +204,7 @@ export async function generateInterviewFeedbackAction(
     if (error instanceof UnauthorizedError) {
       return {
         success: false,
-        message: "You must be logged in to generate feedback.",
+        message: INTERVIEW_ACTION_MESSAGES.feedbackUnauthorized,
       };
     }
 
@@ -217,13 +218,13 @@ export async function generateInterviewFeedbackAction(
     if (error instanceof DatabaseError) {
       return {
         success: false,
-        message: "Failed to save feedback. Please try again.",
+        message: INTERVIEW_ACTION_MESSAGES.feedbackDatabaseError,
       };
     }
 
     return {
       success: false,
-      message: "Failed to generate feedback. Please try again.",
+      message: INTERVIEW_ACTION_MESSAGES.feedbackUnexpectedError,
     };
   }
 }

--- a/core/features/interviews/permissions.test.ts
+++ b/core/features/interviews/permissions.test.ts
@@ -1,5 +1,5 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/auth/permissions", () => ({
@@ -26,7 +26,7 @@ jest.mock("@/core/features/interviews/db", () => ({
   getInterviewCountDb: jest.fn(),
 }));
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   FREE_PLAN_LIMITS,
   hasPermission,
@@ -38,7 +38,7 @@ import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkInterviewPermission } from "./permissions";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetInterviewCountDb = jest.mocked(getInterviewCountDb);
 

--- a/core/features/interviews/permissions.ts
+++ b/core/features/interviews/permissions.ts
@@ -1,5 +1,5 @@
 import { getInterviewCountDb } from "@/core/features/interviews/db";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   hasPermission,
   FREE_PLAN_LIMITS,
@@ -33,7 +33,7 @@ export async function checkInterviewPermission(): Promise<boolean> {
 }
 
 async function getInterviewCount() {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   if (userId == null) {
     return 0;
   }

--- a/core/features/interviews/service.test.ts
+++ b/core/features/interviews/service.test.ts
@@ -3,8 +3,8 @@ jest.mock("next/cache", () => ({
 }));
 
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
-  getCurrentUserWithProfile: jest.fn(),
+  getCurrentUserAction: jest.fn(),
+  getCurrentUserWithProfileAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/interviews/dal", () => ({
@@ -22,8 +22,8 @@ import { refresh } from "next/cache";
 
 import { PermissionError } from "@/core/dal/helpers";
 import {
-  getCurrentUser,
-  getCurrentUserWithProfile,
+  getCurrentUserAction,
+  getCurrentUserWithProfileAction,
 } from "@/core/features/auth/actions";
 import {
   getInterviewByIdDal,
@@ -49,8 +49,8 @@ import { makeInterview, makeJobInfo, makeUser } from "@/core/test-utils/factorie
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 const mockRefresh = jest.mocked(refresh);
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
-const mockGetCurrentUserWithProfile = jest.mocked(getCurrentUserWithProfile);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
+const mockGetCurrentUserWithProfile = jest.mocked(getCurrentUserWithProfileAction);
 const mockGetInterviewByIdDal = jest.mocked(getInterviewByIdDal);
 const mockGetInterviewsDal = jest.mocked(getInterviewsDal);
 const mockInsertInterviewDal = jest.mocked(insertInterviewDal);

--- a/core/features/jobInfos/actions.test.ts
+++ b/core/features/jobInfos/actions.test.ts
@@ -8,8 +8,8 @@ jest.mock("@/core/features/jobInfos/service", () => ({
 }));
 
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
-  getCurrentUserWithProfile: jest.fn(),
+  getCurrentUserAction: jest.fn(),
+  getCurrentUserWithProfileAction: jest.fn(),
 }));
 
 import {
@@ -20,9 +20,9 @@ import {
 } from "@/core/dal/helpers";
 import {
   createJobInfoAction,
-  getJobInfo,
-  getJobInfoById,
-  getJobInfos,
+  getJobInfoAction,
+  getJobInfoByIdAction,
+  getJobInfosAction,
   removeJobInfoAction,
   updateJobInfoAction,
 } from "@/core/features/jobInfos/actions";
@@ -212,7 +212,7 @@ describe("job info actions", () => {
     const jobInfo = makeJobInfo();
     mockGetJobInfoService.mockResolvedValue(jobInfo);
 
-    await expect(getJobInfo(jobInfo.id)).resolves.toBe(jobInfo);
+    await expect(getJobInfoAction(jobInfo.id)).resolves.toBe(jobInfo);
 
     expect(mockGetJobInfoService).toHaveBeenCalledWith(jobInfo.id);
   });
@@ -221,7 +221,7 @@ describe("job info actions", () => {
     const jobInfo = makeJobInfo();
     mockGetJobInfoByIdService.mockResolvedValue(jobInfo);
 
-    await expect(getJobInfoById(jobInfo.id)).resolves.toBe(jobInfo);
+    await expect(getJobInfoByIdAction(jobInfo.id)).resolves.toBe(jobInfo);
 
     expect(mockGetJobInfoByIdService).toHaveBeenCalledWith(jobInfo.id);
   });
@@ -230,7 +230,7 @@ describe("job info actions", () => {
     const jobInfos = [makeJobInfo()];
     mockGetJobInfosService.mockResolvedValue(jobInfos);
 
-    await expect(getJobInfos()).resolves.toBe(jobInfos);
+    await expect(getJobInfosAction()).resolves.toBe(jobInfos);
 
     expect(mockGetJobInfosService).toHaveBeenCalledWith();
   });

--- a/core/features/jobInfos/actions.ts
+++ b/core/features/jobInfos/actions.ts
@@ -139,7 +139,7 @@ export async function updateJobInfoAction(
  * Get a job info by ID
  * Used in pages to fetch data - throws on error for error boundary to catch
  */
-export async function getJobInfo(id: string) {
+export async function getJobInfoAction(id: string) {
   return await getJobInfoService(id);
 }
 
@@ -147,7 +147,7 @@ export async function getJobInfo(id: string) {
  * Get a job info by ID without ownership check
  * Used when ownership verification happens elsewhere
  */
-export async function getJobInfoById(id: string) {
+export async function getJobInfoByIdAction(id: string) {
   return await getJobInfoByIdService(id);
 }
 
@@ -155,7 +155,7 @@ export async function getJobInfoById(id: string) {
  * Get all job infos for current user
  * Used in pages to fetch list - throws on error for error boundary to catch
  */
-export async function getJobInfos() {
+export async function getJobInfosAction() {
   return await getJobInfosService();
 }
 

--- a/core/features/jobInfos/components/JobInfoBackLink.tsx
+++ b/core/features/jobInfos/components/JobInfoBackLink.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 
 import { BackLink } from "@/core/components/BackLink";
-import { getJobInfoById } from "@/core/features/jobInfos/actions";
+import { getJobInfoByIdAction } from "@/core/features/jobInfos/actions";
 import { routes } from "@/core/data/routes";
 
 export function JobInfoBackLink({ jobInfoId }: { jobInfoId: string }) {
@@ -15,7 +15,7 @@ export function JobInfoBackLink({ jobInfoId }: { jobInfoId: string }) {
 }
 
 async function JobInfoName({ jobInfoId }: { jobInfoId: string }) {
-  const jobInfo = await getJobInfoById(jobInfoId);
+  const jobInfo = await getJobInfoByIdAction(jobInfoId);
 
   return jobInfo?.name
     ? `Back to "${jobInfo.name}"`

--- a/core/features/jobInfos/components/JobInfos.tsx
+++ b/core/features/jobInfos/components/JobInfos.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from "@core/components/ui/button";
 import { JobInfoForm } from "@/core/features/jobInfos/components/JobInfoForm";
 import { JobInfoCard } from "@/core/features/jobInfos/components/JobInfoCard";
-import { getJobInfos } from "@/core/features/jobInfos/actions";
+import { getJobInfosAction } from "@/core/features/jobInfos/actions";
 import {
   FREE_PLAN_LIMITS,
   getUserPlan,
@@ -19,7 +19,7 @@ import {
 import { routes } from "@/core/data/routes";
 
 export async function JobInfos() {
-  const jobInfos = await getJobInfos();
+  const jobInfos = await getJobInfosAction();
   const currentPlan = await getUserPlan();
 
   if (jobInfos.length === 0) {

--- a/core/features/jobInfos/service.test.ts
+++ b/core/features/jobInfos/service.test.ts
@@ -1,5 +1,5 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/jobInfos/dal", () => ({
@@ -12,7 +12,7 @@ jest.mock("@/core/features/jobInfos/dal", () => ({
 }));
 
 import { NotFoundError, PermissionError } from "@/core/dal/helpers";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   createJobInfoDal,
   getJobInfoByIdDal,
@@ -37,7 +37,7 @@ import {
 import { makeJobInfo } from "@/core/test-utils/factories";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockCreateJobInfoDal = jest.mocked(createJobInfoDal);
 const mockGetJobInfoDal = jest.mocked(getJobInfoDal);
 const mockGetJobInfoByIdDal = jest.mocked(getJobInfoByIdDal);

--- a/core/features/questions/actions.test.ts
+++ b/core/features/questions/actions.test.ts
@@ -1,0 +1,102 @@
+jest.mock("@/core/features/questions/service", () => ({
+  getQuestionByIdService: jest.fn(),
+  getQuestionsService: jest.fn(),
+  insertQuestionService: jest.fn(),
+}));
+
+import {
+  getQuestionByIdAction,
+  getQuestionsAction,
+  insertQuestionAction,
+} from "@/core/features/questions/actions";
+import {
+  getQuestionByIdService,
+  getQuestionsService,
+  insertQuestionService,
+} from "@/core/features/questions/service";
+import { makeQuestion } from "@/core/test-utils/factories";
+
+const mockGetQuestionsService = jest.mocked(getQuestionsService);
+const mockInsertQuestionService = jest.mocked(insertQuestionService);
+const mockGetQuestionByIdService = jest.mocked(getQuestionByIdService);
+
+describe("question actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("gets questions through the service", async () => {
+    const questions = [makeQuestion({ jobInfoId: "job-info-1" })];
+    mockGetQuestionsService.mockResolvedValue(questions);
+
+    await expect(getQuestionsAction("job-info-1")).resolves.toBe(questions);
+
+    expect(mockGetQuestionsService).toHaveBeenCalledWith("job-info-1");
+  });
+
+  it("wraps get questions failures with job info context", async () => {
+    const cause = new Error("database failed");
+    mockGetQuestionsService.mockRejectedValue(cause);
+
+    await expect(getQuestionsAction("job-info-1")).rejects.toMatchObject({
+      message: 'Failed to get questions for job info "job-info-1".',
+      cause,
+    });
+  });
+
+  it("inserts a question through the service", async () => {
+    const question = makeQuestion({
+      jobInfoId: "job-info-1",
+      difficulty: "medium",
+    });
+    mockInsertQuestionService.mockResolvedValue(question);
+
+    await expect(
+      insertQuestionAction("What did you ship?", "job-info-1", "medium"),
+    ).resolves.toBe(question);
+
+    expect(mockInsertQuestionService).toHaveBeenCalledWith(
+      "What did you ship?",
+      "job-info-1",
+      "medium",
+    );
+  });
+
+  it("wraps insert failures with job info and difficulty context", async () => {
+    const cause = new Error("insert failed");
+    mockInsertQuestionService.mockRejectedValue(cause);
+
+    await expect(
+      insertQuestionAction("What did you ship?", "job-info-1", "hard"),
+    ).rejects.toMatchObject({
+      message:
+        'Failed to insert question for job info "job-info-1" with difficulty "hard".',
+      cause,
+    });
+  });
+
+  it("gets one question through the service", async () => {
+    const question = {
+      ...makeQuestion({ jobInfoId: "job-info-1" }),
+      jobInfo: {
+        id: "job-info-1",
+        userId: "user-1",
+      },
+    };
+    mockGetQuestionByIdService.mockResolvedValue(question);
+
+    await expect(getQuestionByIdAction(question.id)).resolves.toBe(question);
+
+    expect(mockGetQuestionByIdService).toHaveBeenCalledWith(question.id);
+  });
+
+  it("wraps get question failures with question context", async () => {
+    const cause = new Error("lookup failed");
+    mockGetQuestionByIdService.mockRejectedValue(cause);
+
+    await expect(getQuestionByIdAction("question-1")).rejects.toMatchObject({
+      message: 'Failed to get question "question-1".',
+      cause,
+    });
+  });
+});

--- a/core/features/questions/actions.ts
+++ b/core/features/questions/actions.ts
@@ -17,7 +17,7 @@ import {
  * Get all questions for a job info
  * Used in pages - errors bubble up to error boundary
  */
-export async function getQuestions(jobInfoId: string) {
+export async function getQuestionsAction(jobInfoId: string) {
   return await getQuestionsService(jobInfoId);
 }
 
@@ -25,10 +25,10 @@ export async function getQuestions(jobInfoId: string) {
  * Insert a new question
  * Used from AI generation - errors bubble up to caller
  */
-export async function insertQuestion(
+export async function insertQuestionAction(
   question: string,
   jobInfoId: string,
-  difficulty: QuestionDifficulty
+  difficulty: QuestionDifficulty,
 ) {
   return await insertQuestionService(question, jobInfoId, difficulty);
 }
@@ -37,6 +37,6 @@ export async function insertQuestion(
  * Get a single question by ID
  * Used in pages - errors bubble up to error boundary
  */
-export async function getQuestionById(questionId: string) {
+export async function getQuestionByIdAction(questionId: string) {
   return await getQuestionByIdService(questionId);
 }

--- a/core/features/questions/actions.ts
+++ b/core/features/questions/actions.ts
@@ -18,7 +18,13 @@ import {
  * Used in pages - errors bubble up to error boundary
  */
 export async function getQuestionsAction(jobInfoId: string) {
-  return await getQuestionsService(jobInfoId);
+  try {
+    return await getQuestionsService(jobInfoId);
+  } catch (error) {
+    throw new Error(`Failed to get questions for job info "${jobInfoId}".`, {
+      cause: error,
+    });
+  }
 }
 
 /**
@@ -30,7 +36,14 @@ export async function insertQuestionAction(
   jobInfoId: string,
   difficulty: QuestionDifficulty,
 ) {
-  return await insertQuestionService(question, jobInfoId, difficulty);
+  try {
+    return await insertQuestionService(question, jobInfoId, difficulty);
+  } catch (error) {
+    throw new Error(
+      `Failed to insert question for job info "${jobInfoId}" with difficulty "${difficulty}".`,
+      { cause: error },
+    );
+  }
 }
 
 /**
@@ -38,5 +51,11 @@ export async function insertQuestionAction(
  * Used in pages - errors bubble up to error boundary
  */
 export async function getQuestionByIdAction(questionId: string) {
-  return await getQuestionByIdService(questionId);
+  try {
+    return await getQuestionByIdService(questionId);
+  } catch (error) {
+    throw new Error(`Failed to get question "${questionId}".`, {
+      cause: error,
+    });
+  }
 }

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -87,6 +87,7 @@ describe("checkQuestionsPermission", () => {
 
     await expect(checkQuestionsPermission()).resolves.toBe(true);
 
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
     expect(mockGetQuestionCountDb).toHaveBeenCalledWith(SIGNED_IN_USER_ID);
   });
 
@@ -95,5 +96,7 @@ describe("checkQuestionsPermission", () => {
     mockGetQuestionCountDb.mockResolvedValue(FREE_PLAN_LIMITS.questions);
 
     await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
   });
 });

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -1,5 +1,5 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/auth/permissions", () => ({
@@ -26,7 +26,7 @@ jest.mock("@/core/features/questions/db", () => ({
   getQuestionCountDb: jest.fn(),
 }));
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   FREE_PLAN_LIMITS,
   hasPermission,
@@ -38,7 +38,7 @@ import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkQuestionsPermission } from "./permissions";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetQuestionCountDb = jest.mocked(getQuestionCountDb);
 

--- a/core/features/questions/permissions.test.ts
+++ b/core/features/questions/permissions.test.ts
@@ -45,12 +45,19 @@ const mockGetQuestionCountDb = jest.mocked(getQuestionCountDb);
 const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("checkQuestionsPermission", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
     mockGetCurrentUser.mockResolvedValue(
       makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
     );
     mockHasPermission.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it("denies anonymous users without checking plan permissions", async () => {
@@ -98,5 +105,42 @@ describe("checkQuestionsPermission", () => {
     await expect(checkQuestionsPermission()).resolves.toBe(false);
 
     expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when the current user lookup throws", async () => {
+    mockGetCurrentUser.mockRejectedValue(new Error("session failed"));
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(mockHasPermission).not.toHaveBeenCalled();
+    expect(mockGetQuestionCountDb).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error checking question permission:",
+      expect.any(Error),
+    );
+  });
+
+  it("returns false when the plan permission check throws", async () => {
+    mockHasPermission.mockRejectedValue(new Error("permission failed"));
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(mockGetQuestionCountDb).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error checking question permission:",
+      expect.any(Error),
+    );
+  });
+
+  it("returns false when the question count lookup throws", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockGetQuestionCountDb.mockRejectedValue(new Error("count failed"));
+
+    await expect(checkQuestionsPermission()).resolves.toBe(false);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error checking question permission:",
+      expect.any(Error),
+    );
   });
 });

--- a/core/features/questions/permissions.ts
+++ b/core/features/questions/permissions.ts
@@ -12,30 +12,35 @@ import { getQuestionCountDb } from "@/core/features/questions/db";
  * - Free users: up to FREE_PLAN_LIMITS.questions
  */
 export async function checkQuestionsPermission(): Promise<boolean> {
-  const { userId } = await getCurrentUserAction();
+  try {
+    const { userId } = await getCurrentUserAction();
 
-  if (!userId) {
+    if (!userId) {
+      return false;
+    }
+
+    // Check if user has unlimited questions (Pro plan)
+    const hasUnlimited = await hasPermission(PERMISSIONS.UNLIMITED.QUESTIONS);
+
+    if (hasUnlimited) {
+      return true;
+    }
+
+    // Check if user has limited questions permission (Free plan)
+    const hasLimited = await hasPermission(PERMISSIONS.LIMITED.QUESTIONS);
+
+    if (!hasLimited) {
+      return false;
+    }
+
+    // Check if user hasn't exceeded free plan limit
+    const questionCount = await getQuestionCount(userId);
+
+    return questionCount < FREE_PLAN_LIMITS.questions;
+  } catch (error) {
+    console.error("Error checking question permission:", error);
     return false;
   }
-
-  // Check if user has unlimited questions (Pro plan)
-  const hasUnlimited = await hasPermission(PERMISSIONS.UNLIMITED.QUESTIONS);
-
-  if (hasUnlimited) {
-    return true;
-  }
-
-  // Check if user has limited questions permission (Free plan)
-  const hasLimited = await hasPermission(PERMISSIONS.LIMITED.QUESTIONS);
-
-  if (!hasLimited) {
-    return false;
-  }
-
-  // Check if user hasn't exceeded free plan limit
-  const questionCount = await getQuestionCount(userId);
-
-  return questionCount < FREE_PLAN_LIMITS.questions;
 }
 
 async function getQuestionCount(userId: string | null) {

--- a/core/features/questions/permissions.ts
+++ b/core/features/questions/permissions.ts
@@ -3,7 +3,7 @@ import {
   FREE_PLAN_LIMITS,
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { getQuestionCountDb } from "@/core/features/questions/db";
 
 /**
@@ -12,7 +12,7 @@ import { getQuestionCountDb } from "@/core/features/questions/db";
  * - Free users: up to FREE_PLAN_LIMITS.questions
  */
 export async function checkQuestionsPermission(): Promise<boolean> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     return false;
@@ -39,7 +39,7 @@ export async function checkQuestionsPermission(): Promise<boolean> {
 }
 
 async function getQuestionCount() {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
   if (userId == null) {
     return 0;
   }

--- a/core/features/questions/permissions.ts
+++ b/core/features/questions/permissions.ts
@@ -33,15 +33,15 @@ export async function checkQuestionsPermission(): Promise<boolean> {
   }
 
   // Check if user hasn't exceeded free plan limit
-  const questionCount = await getQuestionCount();
+  const questionCount = await getQuestionCount(userId);
 
   return questionCount < FREE_PLAN_LIMITS.questions;
 }
 
-async function getQuestionCount() {
-  const { userId } = await getCurrentUserAction();
+async function getQuestionCount(userId: string | null) {
   if (userId == null) {
     return 0;
   }
+
   return getQuestionCountDb(userId);
 }

--- a/core/features/questions/service.test.ts
+++ b/core/features/questions/service.test.ts
@@ -1,5 +1,5 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/questions/dal", () => ({
@@ -8,7 +8,7 @@ jest.mock("@/core/features/questions/dal", () => ({
   insertQuestionDal: jest.fn(),
 }));
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   getQuestionByIdDal,
   getQuestionsDal,
@@ -23,7 +23,7 @@ import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeQuestion } from "@/core/test-utils/factories";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockGetQuestionsDal = jest.mocked(getQuestionsDal);
 const mockGetQuestionByIdDal = jest.mocked(getQuestionByIdDal);
 const mockInsertQuestionDal = jest.mocked(insertQuestionDal);

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -1,5 +1,5 @@
 jest.mock("@/core/features/auth/actions", () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentUserAction: jest.fn(),
 }));
 
 jest.mock("@/core/features/auth/permissions", () => ({
@@ -17,14 +17,14 @@ jest.mock("@/core/features/auth/permissions", () => ({
   hasPermission: jest.fn(),
 }));
 
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { hasPermission, PERMISSIONS } from "@/core/features/auth/permissions";
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
 import { checkResumeAnalysisPermission } from "./permissions";
 
-const mockGetCurrentUser = jest.mocked(getCurrentUser);
+const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockHasPermission = jest.mocked(hasPermission);
 
 const SIGNED_IN_USER_ID = TEST_USER_ID;

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -30,12 +30,19 @@ const mockHasPermission = jest.mocked(hasPermission);
 const SIGNED_IN_USER_ID = TEST_USER_ID;
 
 describe("checkResumeAnalysisPermission", () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
     mockGetCurrentUser.mockResolvedValue(
       makeCurrentUser({ userId: SIGNED_IN_USER_ID }),
     );
     mockHasPermission.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it("denies anonymous users without checking plan permissions", async () => {
@@ -51,6 +58,17 @@ describe("checkResumeAnalysisPermission", () => {
 
     expect(mockHasPermission).toHaveBeenCalledWith(
       PERMISSIONS.UNLIMITED.RESUME_ANALYSES,
+    );
+  });
+
+  it("returns false when the permission check throws", async () => {
+    mockHasPermission.mockRejectedValue(new Error("permission failed"));
+
+    await expect(checkResumeAnalysisPermission()).resolves.toBe(false);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error checking resume analysis permission:",
+      expect.any(Error),
     );
   });
 });

--- a/core/features/resumeAnalysis/permissions.ts
+++ b/core/features/resumeAnalysis/permissions.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser } from "@/core/features/auth/actions";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { PERMISSIONS, hasPermission } from "@/core/features/auth/permissions";
 
 /**
@@ -7,7 +7,7 @@ import { PERMISSIONS, hasPermission } from "@/core/features/auth/permissions";
  * - Free users: unlimited
  */
 export async function checkResumeAnalysisPermission(): Promise<boolean> {
-  const { userId } = await getCurrentUser();
+  const { userId } = await getCurrentUserAction();
 
   if (!userId) {
     return false;

--- a/core/features/resumeAnalysis/permissions.ts
+++ b/core/features/resumeAnalysis/permissions.ts
@@ -7,12 +7,17 @@ import { PERMISSIONS, hasPermission } from "@/core/features/auth/permissions";
  * - Free users: unlimited
  */
 export async function checkResumeAnalysisPermission(): Promise<boolean> {
-  const { userId } = await getCurrentUserAction();
+  try {
+    const { userId } = await getCurrentUserAction();
 
-  if (!userId) {
+    if (!userId) {
+      return false;
+    }
+
+    // Currently all users can analyze resumes
+    return await hasPermission(PERMISSIONS.UNLIMITED.RESUME_ANALYSES);
+  } catch (error) {
+    console.error("Error checking resume analysis permission:", error);
     return false;
   }
-
-  // Currently all users can analyze resumes
-  return hasPermission(PERMISSIONS.UNLIMITED.RESUME_ANALYSES);
 }

--- a/core/features/users/actions.ts
+++ b/core/features/users/actions.ts
@@ -1,20 +1,8 @@
 "use server";
 
-import { cacheTag } from "next/dist/server/use-cache/cache-tag";
-
-import { getUserIdTag } from "@/core/features/users/dbCache";
-import { getUserByIdDb } from "@/core/features/users/db";
-import { DatabaseError } from "@/core/dal/helpers";
 import type { AuthUser } from "@/core/features/auth/types";
+import { getUserService } from "@/core/features/users/service";
 
-export async function getUser(id: string): Promise<AuthUser | null> {
-  "use cache";
-  cacheTag(getUserIdTag(id));
-
-  try {
-    return (await getUserByIdDb(id)) ?? null;
-  } catch (error) {
-    console.error("Database error getting user:", error);
-    throw new DatabaseError("Failed to fetch user from database", error);
-  }
+export async function getUserAction(id: string): Promise<AuthUser | null> {
+  return await getUserService(id);
 }

--- a/core/features/users/service.ts
+++ b/core/features/users/service.ts
@@ -1,0 +1,18 @@
+import { cacheTag } from "next/dist/server/use-cache/cache-tag";
+
+import { DatabaseError } from "@/core/dal/helpers";
+import type { AuthUser } from "@/core/features/auth/types";
+import { getUserByIdDb } from "@/core/features/users/db";
+import { getUserIdTag } from "@/core/features/users/dbCache";
+
+export async function getUserService(id: string): Promise<AuthUser | null> {
+  "use cache";
+  cacheTag(getUserIdTag(id));
+
+  try {
+    return (await getUserByIdDb(id)) ?? null;
+  } catch (error) {
+    console.error("Database error getting user:", error);
+    throw new DatabaseError("Failed to fetch user from database", error);
+  }
+}

--- a/core/features/users/service.ts
+++ b/core/features/users/service.ts
@@ -1,4 +1,4 @@
-import { cacheTag } from "next/dist/server/use-cache/cache-tag";
+import { cacheTag } from "next/cache";
 
 import { DatabaseError } from "@/core/dal/helpers";
 import type { AuthUser } from "@/core/features/auth/types";


### PR DESCRIPTION
## Summary
- Standardize feature-layer exports so action modules use `*Action` suffixes and service modules use `*Service` suffixes.
- Add focused Jest coverage for `core/features/interviews/actions.ts`, including auth, permission, rate-limit, success, and error mappings.
- Extract interview action messages into a feature-local constants file to avoid duplicated user-facing strings.
- Update affected app, API, and test call sites to use the renamed exports.
- Record the new coverage slice in `TEST_COVERAGE_PLAN.md`.

## Testing
- Focused interview action test coverage passed.
- Full Jest suite passed.
- TypeScript and lint validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Added comprehensive test coverage for interview management actions, including permission checks, rate limiting, and error handling scenarios.

* **Refactor**
  * Standardized internal function naming conventions across auth, interview, job, and question modules for improved code consistency.
  * Reorganized service layer to centralize caching and error handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->