### PR TITLE
Add users coverage and split DAL error classes

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -284,6 +284,64 @@ Continue the server action slice with `core/features/questions/actions.ts`,
 then cover `core/features/users/actions.ts`. Keep API route coverage as the
 following mock-heavy slice.
 
+### User Action and Service Slice - 2026-05-19
+
+Files/tests added:
+
+- `core/features/users/actions.test.ts`
+- `core/features/users/service.test.ts`
+
+Files updated:
+
+- `core/dal/errors.ts`
+- `core/dal/helpers.ts`
+
+Commands run:
+
+- `npm.cmd ci`
+- `npm.cmd test -- core/features/users/actions.test.ts core/features/users/service.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/users/actions.test.ts core/features/users/service.test.ts core/dal/errors.ts core/dal/helpers.ts core/features/users/service.ts core/features/jobInfos/actions.ts core/features/jobInfos/actions.test.ts core/features/jobInfos/dal.ts core/features/jobInfos/service.ts core/features/jobInfos/service.test.ts core/features/interviews/actions.ts core/features/interviews/actions.test.ts core/features/interviews/dal.ts core/features/interviews/service.ts core/features/interviews/service.test.ts core/features/auth/session.ts core/features/questions/dal.ts app/api/ai/resumes/analyze/route.ts app/api/ai/questions/generate-question/route.ts app/api/ai/questions/generate-feedback/route.ts TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Initial focused test run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd ci` installed dependencies from `package-lock.json`.
+- Focused users slice passed: 2 test suites, 5 tests, 0 snapshots.
+- `npm.cmd test -- --runInBand` passed: 42 test suites, 271 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 42 test suites, 271
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for touched code files.
+- Updated coverage summary: 78.98% statements, 74.69% branches, 74.64%
+  functions, and 81.22% lines.
+- `core/features/users/actions.ts` and `core/features/users/service.ts` now
+  report 100% statements, branches, functions, and lines.
+
+Notes:
+
+- Action tests cover service delegation and missing-user `null` propagation.
+- Service tests cover successful lookup, missing user `null`, cache tagging,
+  and database failures mapping to `DatabaseError`.
+- Error classes now live in `core/dal/errors.ts`, allowing isolated service
+  tests to import `DatabaseError` without widening the users service mock
+  boundary.
+- User fixtures use safe synthetic `@test.local` emails and no real customer
+  emails.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Move next into API route coverage, starting with the checkout, billing portal,
+and cancel subscription routes. Keep external services mocked at module
+boundaries, especially Stripe, auth, and database modules.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/ai/questions/generate-feedback/route.ts
+++ b/app/api/ai/questions/generate-feedback/route.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { generateAiQuestionFeedback } from "@/core/services/ai/questions";
 import { getQuestionByIdAction } from "@/core/features/questions/actions";
-import { UnauthorizedError, DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError, UnauthorizedError } from "@/core/dal/errors";
 
 const schema = z.object({
   prompt: z.string().min(1),

--- a/app/api/ai/questions/generate-question/route.ts
+++ b/app/api/ai/questions/generate-question/route.ts
@@ -12,11 +12,11 @@ import {
   insertQuestionAction,
 } from "@/core/features/questions/actions";
 import {
+  DatabaseError,
   NotFoundError,
   PermissionError,
   UnauthorizedError,
-  DatabaseError,
-} from "@/core/dal/helpers";
+} from "@/core/dal/errors";
 
 const schema = z.object({
   prompt: z.enum(questionDifficulties),

--- a/app/api/ai/resumes/analyze/route.ts
+++ b/app/api/ai/resumes/analyze/route.ts
@@ -6,7 +6,7 @@ import { resumeAnalysisInputSchema } from "@/core/features/resumeAnalysis/schema
 import {
   PLAN_LIMIT_MESSAGE,
 } from "@/core/lib/errorToast";
-import { NotFoundError, PermissionError } from "@/core/dal/helpers";
+import { NotFoundError, PermissionError } from "@/core/dal/errors";
 
 export async function POST(req: Request) {
   const { userId } = await getCurrentUserAction();

--- a/core/dal/errors.ts
+++ b/core/dal/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Custom error classes for better error handling throughout the application.
+ */
+
+export class UnauthorizedError extends Error {
+  constructor(message = "You must be logged in to perform this action") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermissionError";
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+export class DatabaseError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError?: unknown,
+  ) {
+    super(message, { cause: originalError });
+    this.name = "DatabaseError";
+  }
+}

--- a/core/dal/helpers.ts
+++ b/core/dal/helpers.ts
@@ -2,48 +2,7 @@ import {
   getCurrentUserAction,
   getCurrentUserWithProfileAction,
 } from "@/core/features/auth/actions";
-
-/**
- * Custom error classes for better error handling throughout the application
- */
-
-export class UnauthorizedError extends Error {
-  constructor(message = "You must be logged in to perform this action") {
-    super(message);
-    this.name = "UnauthorizedError";
-  }
-}
-
-export class NotFoundError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NotFoundError";
-  }
-}
-
-export class PermissionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "PermissionError";
-  }
-}
-
-export class ValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ValidationError";
-  }
-}
-
-export class DatabaseError extends Error {
-  constructor(
-    message: string,
-    public readonly originalError?: unknown,
-  ) {
-    super(message, { cause: originalError });
-    this.name = "DatabaseError";
-  }
-}
+import { UnauthorizedError } from "@/core/dal/errors";
 
 /**
  * DAL Helper Functions

--- a/core/features/auth/session.ts
+++ b/core/features/auth/session.ts
@@ -3,7 +3,7 @@ import {
   SESSION_DURATION_MS,
   SESSION_REFRESH_THRESHOLD_MS,
 } from "@/core/features/auth/constants";
-import { DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError } from "@/core/dal/errors";
 import {
   createSessionDb,
   deleteAllUserSessionsDb,

--- a/core/features/interviews/actions.test.ts
+++ b/core/features/interviews/actions.test.ts
@@ -37,7 +37,7 @@ import {
   DatabaseError,
   PermissionError,
   UnauthorizedError,
-} from "@/core/dal/helpers";
+} from "@/core/dal/errors";
 import arcjet, { request } from "@arcjet/next";
 import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";

--- a/core/features/interviews/actions.ts
+++ b/core/features/interviews/actions.ts
@@ -8,12 +8,12 @@ import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { PLAN_LIMIT_MESSAGE, RATE_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { env } from "@/core/data/env/server";
 import { INTERVIEW_ACTION_MESSAGES } from "@/core/features/interviews/actionMessages";
+import { ActionResult } from "@/core/dal/helpers";
 import {
-  UnauthorizedError,
-  PermissionError,
   DatabaseError,
-  ActionResult,
-} from "@/core/dal/helpers";
+  PermissionError,
+  UnauthorizedError,
+} from "@/core/dal/errors";
 import {
   createInterviewService,
   updateInterviewService,

--- a/core/features/interviews/dal.ts
+++ b/core/features/interviews/dal.ts
@@ -1,6 +1,6 @@
 import { cacheTag } from "next/cache";
 
-import { DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError } from "@/core/dal/errors";
 import {
   getInterviewByIdDb,
   getInterviewsDb,

--- a/core/features/interviews/service.test.ts
+++ b/core/features/interviews/service.test.ts
@@ -20,7 +20,7 @@ jest.mock("@/core/services/ai/interviews", () => ({
 
 import { refresh } from "next/cache";
 
-import { PermissionError } from "@/core/dal/helpers";
+import { PermissionError } from "@/core/dal/errors";
 import {
   getCurrentUserAction,
   getCurrentUserWithProfileAction,

--- a/core/features/interviews/service.ts
+++ b/core/features/interviews/service.ts
@@ -1,10 +1,7 @@
 import { refresh } from "next/cache";
 
-import {
-  requireUser,
-  requireUserWithData,
-  PermissionError,
-} from "@/core/dal/helpers";
+import { PermissionError } from "@/core/dal/errors";
+import { requireUser, requireUserWithData } from "@/core/dal/helpers";
 import {
   getInterviewByIdDal,
   getInterviewsDal,

--- a/core/features/jobInfos/actions.test.ts
+++ b/core/features/jobInfos/actions.test.ts
@@ -17,7 +17,7 @@ import {
   NotFoundError,
   PermissionError,
   UnauthorizedError,
-} from "@/core/dal/helpers";
+} from "@/core/dal/errors";
 import {
   createJobInfoAction,
   getJobInfoAction,

--- a/core/features/jobInfos/actions.ts
+++ b/core/features/jobInfos/actions.ts
@@ -10,13 +10,13 @@ import {
   removeJobInfoService,
 } from "@/core/features/jobInfos/service";
 import { JOB_INFO_ACTION_MESSAGES } from "@/core/features/jobInfos/actionMessages";
+import { ActionResult } from "@/core/dal/helpers";
 import {
-  UnauthorizedError,
+  DatabaseError,
   NotFoundError,
   PermissionError,
-  DatabaseError,
-  ActionResult,
-} from "@/core/dal/helpers";
+  UnauthorizedError,
+} from "@/core/dal/errors";
 
 /**
  * Action Layer for JobInfo

--- a/core/features/jobInfos/dal.ts
+++ b/core/features/jobInfos/dal.ts
@@ -12,7 +12,8 @@ import {
   getJobInfoIdTag,
   getJobInfoGlobalTag,
 } from "@/core/features/jobInfos/dbCache";
-import { ActionResult, DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError } from "@/core/dal/errors";
+import { ActionResult } from "@/core/dal/helpers";
 import { JobInfoTable } from "@/core/drizzle/schema";
 
 /**

--- a/core/features/jobInfos/service.test.ts
+++ b/core/features/jobInfos/service.test.ts
@@ -11,7 +11,7 @@ jest.mock("@/core/features/jobInfos/dal", () => ({
   updateJobInfoDal: jest.fn(),
 }));
 
-import { NotFoundError, PermissionError } from "@/core/dal/helpers";
+import { NotFoundError, PermissionError } from "@/core/dal/errors";
 import { getCurrentUserAction } from "@/core/features/auth/actions";
 import {
   createJobInfoDal,

--- a/core/features/jobInfos/service.ts
+++ b/core/features/jobInfos/service.ts
@@ -10,10 +10,10 @@ import {
   removeJobInfoDal,
 } from "@/core/features/jobInfos/dal";
 import {
-  requireUser,
-  PermissionError,
   NotFoundError,
-} from "@/core/dal/helpers";
+  PermissionError,
+} from "@/core/dal/errors";
+import { requireUser } from "@/core/dal/helpers";
 import { JOB_INFO_SERVICE_ERRORS } from "@/core/features/jobInfos/serviceErrors";
 
 /**

--- a/core/features/questions/dal.ts
+++ b/core/features/questions/dal.ts
@@ -1,6 +1,6 @@
 import { cacheTag } from "next/cache";
 
-import { DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError } from "@/core/dal/errors";
 import {
   getQuestionByIdDb,
   getQuestionsDb,

--- a/core/features/users/actions.test.ts
+++ b/core/features/users/actions.test.ts
@@ -1,0 +1,33 @@
+jest.mock("@/core/features/users/service", () => ({
+  getUserService: jest.fn(),
+}));
+
+import { getUserAction } from "@/core/features/users/actions";
+import { getUserService } from "@/core/features/users/service";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeUser } from "@/core/test-utils/factories";
+
+const mockGetUserService = jest.mocked(getUserService);
+
+describe("user actions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("gets a user through the service", async () => {
+    const user = makeUser({ id: TEST_USER_ID });
+    mockGetUserService.mockResolvedValue(user);
+
+    await expect(getUserAction(TEST_USER_ID)).resolves.toBe(user);
+
+    expect(mockGetUserService).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it("returns null when the service finds no user", async () => {
+    mockGetUserService.mockResolvedValue(null);
+
+    await expect(getUserAction(TEST_USER_ID)).resolves.toBe(null);
+
+    expect(mockGetUserService).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+});

--- a/core/features/users/service.test.ts
+++ b/core/features/users/service.test.ts
@@ -1,0 +1,71 @@
+jest.mock("next/cache", () => ({
+  cacheTag: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/db", () => ({
+  getUserByIdDb: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/dbCache", () => ({
+  getUserIdTag: jest.fn(),
+}));
+
+import { cacheTag } from "next/cache";
+
+import { getUserByIdDb } from "@/core/features/users/db";
+import { getUserIdTag } from "@/core/features/users/dbCache";
+import { getUserService } from "@/core/features/users/service";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeUser } from "@/core/test-utils/factories";
+
+const mockCacheTag = jest.mocked(cacheTag);
+const mockGetUserByIdDb = jest.mocked(getUserByIdDb);
+const mockGetUserIdTag = jest.mocked(getUserIdTag);
+
+describe("user service", () => {
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserIdTag.mockReturnValue(`id:${TEST_USER_ID}:users`);
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns a user by id and marks the user cache tag", async () => {
+    const user = makeUser({ id: TEST_USER_ID });
+    mockGetUserByIdDb.mockResolvedValue(user);
+
+    await expect(getUserService(TEST_USER_ID)).resolves.toBe(user);
+
+    expect(mockGetUserIdTag).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(mockCacheTag).toHaveBeenCalledWith(`id:${TEST_USER_ID}:users`);
+    expect(mockGetUserByIdDb).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it("returns null when the user does not exist", async () => {
+    mockGetUserByIdDb.mockResolvedValue(
+      null as unknown as Awaited<ReturnType<typeof getUserByIdDb>>,
+    );
+
+    await expect(getUserService(TEST_USER_ID)).resolves.toBe(null);
+  });
+
+  it("maps database failures to DatabaseError", async () => {
+    const cause = new Error("db unavailable");
+    mockGetUserByIdDb.mockRejectedValue(cause);
+
+    const promise = getUserService(TEST_USER_ID);
+
+    await expect(promise).rejects.toMatchObject({
+      name: "DatabaseError",
+      message: "Failed to fetch user from database",
+      originalError: cause,
+      cause,
+    });
+  });
+});

--- a/core/features/users/service.ts
+++ b/core/features/users/service.ts
@@ -1,6 +1,6 @@
 import { cacheTag } from "next/cache";
 
-import { DatabaseError } from "@/core/dal/helpers";
+import { DatabaseError } from "@/core/dal/errors";
 import type { AuthUser } from "@/core/features/auth/types";
 import { getUserByIdDb } from "@/core/features/users/db";
 import { getUserIdTag } from "@/core/features/users/dbCache";


### PR DESCRIPTION
## Summary
- Added focused Jest coverage for `getUserAction` and `getUserService`
- Covered successful lookup, missing user `null`, DB error mapping, and action-to-service delegation
- Split shared DAL error classes into `core/dal/errors.ts` so service tests can import `DatabaseError` without pulling auth setup
- Updated related imports and coverage tracking notes

## Testing
- Focused users test suites passed
- Full Jest suite passed
- Coverage run passed
- TypeScript `--noEmit` passed
- Focused Biome lint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for user management features with comprehensive scenarios including null handling, cache tagging, and error conditions. All user feature tests achieved 100% coverage.
  * Updated test coverage tracking documentation.

* **Chores**
  * Reorganized error handling framework across the application for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->