### PR TITLE
test(ai): generate question route coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -467,6 +467,68 @@ Continue API route coverage with the AI routes:
 `app/api/ai/questions/generate-feedback/route.ts`. Keep AI SDK, Arcjet, auth,
 and database/service dependencies mocked at module boundaries.
 
+### AI Generate Question API Route Slice - 2026-05-20
+
+Files/tests added:
+
+- `app/api/ai/questions/generate-question/route.test.ts`
+
+Files updated:
+
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- app/api/ai/questions/generate-question/route.test.ts --runInBand`
+- `npm.cmd ci`
+- `npm.cmd test -- app/api/ai/questions/generate-question/route.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/api/ai/questions/generate-question/route.test.ts TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Initial focused test run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd ci` installed dependencies from `package-lock.json`.
+- Focused generate-question route slice passed: 1 test suite, 7 tests, 0
+  snapshots.
+- `npm.cmd test -- --runInBand` passed: 47 test suites, 294 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 47 test suites, 294
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `TEST_COVERAGE_PLAN.md` was passed to the command but not checked by Biome.
+- Updated coverage summary: 80.19% statements, 71.93% branches, 75.79%
+  functions, and 82% lines.
+- New route coverage:
+  - `app/api/ai/questions/generate-question/route.ts`: 95% statements, 87.5%
+    branches, 100% functions, and 95% lines.
+
+Notes:
+
+- Route tests cover malformed request bodies, unauthenticated users, plan-limit
+  denial, streamed success response setup, question insertion through the
+  `onFinish` callback, unauthorized service errors, inaccessible job info, and
+  database failures.
+- Auth, permission, job info, question action, AI service, and AI SDK streaming
+  modules are mocked at module boundaries; the route handler is exercised
+  directly.
+- Test fixtures use `TEST_USER_ID`, local factories, and synthetic question/job
+  data only.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd ci` reported existing dependency audit findings. They were not part
+  of this coverage slice.
+
+Recommendation:
+
+Continue the AI API route slice with
+`app/api/ai/questions/generate-feedback/route.ts`, then cover
+`app/api/ai/resumes/analyze/route.ts`. Keep AI SDK stream responses, auth/action
+boundaries, and feature permissions mocked at module boundaries.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/ai/questions/generate-question/route.test.ts
+++ b/app/api/ai/questions/generate-question/route.test.ts
@@ -1,0 +1,271 @@
+jest.mock("ai", () => ({
+  createUIMessageStream: jest.fn(({ execute }) => {
+    const writer = {
+      merge: jest.fn(),
+      write: jest.fn(),
+    };
+
+    execute({ writer });
+
+    return {
+      kind: "ui-message-stream",
+      writer,
+    };
+  }),
+  createUIMessageStreamResponse: jest.fn(
+    ({ status, statusText, stream }) =>
+      Response.json(
+        {
+          status,
+          statusText,
+          streamKind: stream.kind,
+          writes: stream.writer.write.mock.calls.map(
+            ([chunk]: [unknown]) => chunk,
+          ),
+        },
+        { status },
+      ),
+  ),
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUserAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/jobInfos/actions", () => ({
+  getJobInfoAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/questions/actions", () => ({
+  getQuestionsAction: jest.fn(),
+  insertQuestionAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/questions/permissions", () => ({
+  checkQuestionsPermission: jest.fn(),
+}));
+
+jest.mock("@/core/services/ai/questions", () => ({
+  generateAiQuestion: jest.fn(),
+}));
+
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+
+import { getCurrentUserAction } from "@/core/features/auth/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
+import {
+  getQuestionsAction,
+  insertQuestionAction,
+} from "@/core/features/questions/actions";
+import { checkQuestionsPermission } from "@/core/features/questions/permissions";
+import { generateAiQuestion } from "@/core/services/ai/questions";
+import {
+  DatabaseError,
+  NotFoundError,
+  UnauthorizedError,
+} from "@/core/dal/errors";
+import { PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import {
+  makeCurrentUser,
+  makeJobInfo,
+  makeQuestion,
+} from "@/core/test-utils/factories";
+
+import { POST } from "./route";
+
+const mockCreateUIMessageStream = jest.mocked(createUIMessageStream);
+const mockCreateUIMessageStreamResponse = jest.mocked(
+  createUIMessageStreamResponse,
+);
+const mockGetCurrentUserAction = jest.mocked(getCurrentUserAction);
+const mockGetJobInfoAction = jest.mocked(getJobInfoAction);
+const mockGetQuestionsAction = jest.mocked(getQuestionsAction);
+const mockInsertQuestionAction = jest.mocked(insertQuestionAction);
+const mockCheckQuestionsPermission = jest.mocked(checkQuestionsPermission);
+const mockGenerateAiQuestion = jest.mocked(generateAiQuestion);
+
+const jobInfoId = "00000000-0000-4000-8000-000000000101";
+
+function buildJsonRequest(body: unknown): Request {
+  return new Request(
+    "http://localhost:3000/api/ai/questions/generate-question",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function expectTextResponse(
+  response: Response,
+  status: number,
+  body: string,
+): Promise<void> {
+  expect(response.status).toBe(status);
+  await expect(response.text()).resolves.toBe(body);
+}
+
+describe("POST /api/ai/questions/generate-question", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetCurrentUserAction.mockResolvedValue(
+      makeCurrentUser({ userId: TEST_USER_ID }),
+    );
+    mockCheckQuestionsPermission.mockResolvedValue(true);
+    mockGetJobInfoAction.mockResolvedValue(
+      makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID }),
+    );
+    mockGetQuestionsAction.mockResolvedValue([
+      makeQuestion({
+        jobInfoId,
+        text: "How would you model tenant-specific billing?",
+      }),
+    ]);
+    mockInsertQuestionAction.mockResolvedValue(
+      makeQuestion({
+        id: "00000000-0000-4002-8000-000000000202",
+        jobInfoId,
+        text: "How would you stream a generated response?",
+        difficulty: "medium",
+      }),
+    );
+    mockGenerateAiQuestion.mockImplementation(({ onFinish }) => {
+      void onFinish("How would you stream a generated response?");
+
+      return {
+        toUIMessageStream: jest.fn(() => ({ kind: "model-stream" })),
+      } as unknown as ReturnType<typeof generateAiQuestion>;
+    });
+
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns 400 when the JSON body is malformed for question generation", async () => {
+    const response = await POST(
+      buildJsonRequest({ prompt: "impossible", jobInfoId }),
+    );
+
+    await expectTextResponse(response, 400, "Error generating your question");
+    expect(mockGetCurrentUserAction).not.toHaveBeenCalled();
+    expect(mockGenerateAiQuestion).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the current user is unauthenticated", async () => {
+    mockGetCurrentUserAction.mockResolvedValueOnce(
+      makeCurrentUser({ userId: null }),
+    );
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(response, 401, "You are not logged in");
+    expect(mockCheckQuestionsPermission).not.toHaveBeenCalled();
+    expect(mockGenerateAiQuestion).not.toHaveBeenCalled();
+  });
+
+  it("returns the plan limit response when question generation is not allowed", async () => {
+    mockCheckQuestionsPermission.mockResolvedValueOnce(false);
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(response, 403, PLAN_LIMIT_MESSAGE);
+    expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+    expect(mockGenerateAiQuestion).not.toHaveBeenCalled();
+  });
+
+  it("returns a streamed success response and stores the generated question", async () => {
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: 200,
+      statusText: "OK",
+      streamKind: "ui-message-stream",
+      writes: [],
+    });
+    await Promise.resolve();
+
+    expect(mockGenerateAiQuestion).toHaveBeenCalledWith({
+      previousQuestions: expect.arrayContaining([
+        expect.objectContaining({
+          text: "How would you model tenant-specific billing?",
+        }),
+      ]),
+      jobInfo: expect.objectContaining({ id: jobInfoId }),
+      difficulty: "medium",
+      onFinish: expect.any(Function),
+    });
+    expect(mockInsertQuestionAction).toHaveBeenCalledWith(
+      "How would you stream a generated response?",
+      jobInfoId,
+      "medium",
+    );
+    expect(mockCreateUIMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockCreateUIMessageStreamResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 200,
+        statusText: "OK",
+      }),
+    );
+  });
+
+  it("maps unauthorized service failures to a 401 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(new UnauthorizedError());
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(response, 401, "You are not logged in");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error generating question:",
+      expect.any(UnauthorizedError),
+    );
+  });
+
+  it("maps missing job info failures to a 403 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(
+      new NotFoundError("Job info not found"),
+    );
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+  });
+
+  it("maps database failures to a 500 response", async () => {
+    mockGetQuestionsAction.mockRejectedValueOnce(
+      new DatabaseError("Question lookup failed"),
+    );
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(
+      response,
+      500,
+      "Database error while generating question",
+    );
+  });
+});

--- a/app/api/ai/questions/generate-question/route.test.ts
+++ b/app/api/ai/questions/generate-question/route.test.ts
@@ -197,7 +197,6 @@ describe("POST /api/ai/questions/generate-question", () => {
       streamKind: "ui-message-stream",
       writes: [],
     });
-    await Promise.resolve();
 
     expect(mockGenerateAiQuestion).toHaveBeenCalledWith({
       previousQuestions: expect.arrayContaining([


### PR DESCRIPTION
## Summary
- Add focused API route coverage for app/api/ai/questions/generate-question/route.ts.
- Mock auth, permission, job info, question action, AI service, and AI SDK stream boundaries while exercising the route handler directly.
- Update TEST_COVERAGE_PLAN.md with commands, totals, coverage, notes, and next AI route recommendations.

## Verification
- npm.cmd test -- app/api/ai/questions/generate-question/route.test.ts --runInBand
- npm.cmd test -- --runInBand
- npm.cmd run test:coverage -- --runInBand
- npx.cmd tsc --noEmit
- npm.cmd run lint -- app/api/ai/questions/generate-question/route.test.ts TEST_COVERAGE_PLAN.md

## Notes / Risks
- npm.cmd ci was needed because this worktree initially had no node_modules.
- Jest still emits the existing baseline-browser-mapping age warning.
- npm.cmd ci reported existing dependency audit findings; they were not part of this coverage slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the AI question generation API endpoint, covering error handling, authentication, permissions, and successful response scenarios to ensure reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->