### PR TITLE
test(ai): generate feedback route coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -529,6 +529,69 @@ Continue the AI API route slice with
 `app/api/ai/resumes/analyze/route.ts`. Keep AI SDK stream responses, auth/action
 boundaries, and feature permissions mocked at module boundaries.
 
+### AI Generate Feedback API Route Slice - 2026-05-21
+
+Files/tests added:
+
+- `app/api/ai/questions/generate-feedback/route.test.ts`
+
+Files updated:
+
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- app/api/ai/questions/generate-feedback/route.test.ts --runInBand`
+- `npm.cmd install`
+- `npm.cmd test -- app/api/ai/questions/generate-feedback/route.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/api/ai/questions/generate-feedback/route.test.ts TEST_COVERAGE_PLAN.md`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Initial focused test run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd install` installed dependencies from
+  `package-lock.json`.
+- Focused generate-feedback route slice passed: 1 test suite, 6 tests, 0
+  snapshots.
+- `npm.cmd test -- --runInBand` passed: 48 test suites, 300 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 48 test suites, 300
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `TEST_COVERAGE_PLAN.md` was passed to the command but not checked by Biome.
+- Updated coverage summary: 80.53% statements, 72.45% branches, 75.9%
+  functions, and 82.32% lines.
+- New route coverage:
+  - `app/api/ai/questions/generate-feedback/route.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Route tests cover invalid request bodies, missing questions, streamed success
+  responses, unauthorized action failures, database action failures, and
+  unexpected AI service failures.
+- Question action and AI feedback service modules are mocked at module
+  boundaries; DAL error classes are imported as real classes to exercise the
+  route's `instanceof` handling.
+- Test fixtures use `TEST_USER_ID`, local factories, and synthetic question
+  data only.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd install` reported existing dependency audit findings. They were not
+  part of this coverage slice.
+
+Recommendation:
+
+Continue AI API route coverage with `app/api/ai/resumes/analyze/route.ts`. Keep
+AI/model behavior mocked through the service boundary where possible, and mock
+auth, permission, and database/action dependencies at module boundaries.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/ai/questions/generate-feedback/route.test.ts
+++ b/app/api/ai/questions/generate-feedback/route.test.ts
@@ -1,0 +1,169 @@
+jest.mock("@/core/features/questions/actions", () => ({
+  getQuestionByIdAction: jest.fn(),
+}));
+
+jest.mock("@/core/services/ai/questions", () => ({
+  generateAiQuestionFeedback: jest.fn(),
+}));
+
+import { getQuestionByIdAction } from "@/core/features/questions/actions";
+import { generateAiQuestionFeedback } from "@/core/services/ai/questions";
+import { DatabaseError, UnauthorizedError } from "@/core/dal/errors";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeQuestion } from "@/core/test-utils/factories";
+
+import { POST } from "./route";
+
+const mockGetQuestionByIdAction = jest.mocked(getQuestionByIdAction);
+const mockGenerateAiQuestionFeedback = jest.mocked(generateAiQuestionFeedback);
+
+const questionId = "00000000-0000-4002-8000-000000000301";
+const questionText = "How would you explain server actions in Next.js?";
+
+function buildJsonRequest(body: unknown): Request {
+  return new Request(
+    "http://localhost:3000/api/ai/questions/generate-feedback",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function expectTextResponse(
+  response: Response,
+  status: number,
+  body: string,
+): Promise<void> {
+  expect(response.status).toBe(status);
+  await expect(response.text()).resolves.toBe(body);
+}
+
+function mockQuestionFound(): void {
+  mockGetQuestionByIdAction.mockResolvedValue({
+    ...makeQuestion({
+      id: questionId,
+      text: questionText,
+    }),
+    jobInfo: {
+      id: "00000000-0000-4000-8000-000000000301",
+      userId: TEST_USER_ID,
+    },
+  });
+}
+
+function mockFeedbackStream(): void {
+  mockGenerateAiQuestionFeedback.mockReturnValue({
+    toUIMessageStreamResponse: jest.fn(
+      () =>
+        Response.json({
+          kind: "feedback-stream",
+        }) as ReturnType<
+          ReturnType<typeof generateAiQuestionFeedback>["toUIMessageStreamResponse"]
+        >,
+    ),
+  } as unknown as ReturnType<typeof generateAiQuestionFeedback>);
+}
+
+describe("POST /api/ai/questions/generate-feedback", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns 400 when the JSON body is invalid for feedback generation", async () => {
+    const response = await POST(buildJsonRequest({ prompt: "Use caching." }));
+
+    await expectTextResponse(response, 400, "Error generating feedback");
+    expect(mockGetQuestionByIdAction).not.toHaveBeenCalled();
+    expect(mockGenerateAiQuestionFeedback).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the question cannot be found", async () => {
+    mockGetQuestionByIdAction.mockResolvedValueOnce(null);
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "Use caching.", questionId }),
+    );
+
+    await expectTextResponse(response, 404, "Question not found");
+    expect(mockGetQuestionByIdAction).toHaveBeenCalledWith(questionId);
+    expect(mockGenerateAiQuestionFeedback).not.toHaveBeenCalled();
+  });
+
+  it("returns a streamed success response for generated feedback", async () => {
+    mockQuestionFound();
+    mockFeedbackStream();
+
+    const response = await POST(
+      buildJsonRequest({
+        prompt: "They can run on the server and mutate data safely.",
+        questionId,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kind: "feedback-stream",
+    });
+
+    expect(mockGenerateAiQuestionFeedback).toHaveBeenCalledWith({
+      question: questionText,
+      answer: "They can run on the server and mutate data safely.",
+    });
+  });
+
+  it("maps unauthorized action failures to a 401 response", async () => {
+    mockGetQuestionByIdAction.mockRejectedValueOnce(new UnauthorizedError());
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "Use caching.", questionId }),
+    );
+
+    await expectTextResponse(response, 401, "You are not logged in");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error generating question feedback:",
+      expect.any(UnauthorizedError),
+    );
+  });
+
+  it("maps database action failures to a 500 response", async () => {
+    mockGetQuestionByIdAction.mockRejectedValueOnce(
+      new DatabaseError("Question lookup failed"),
+    );
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "Use caching.", questionId }),
+    );
+
+    await expectTextResponse(
+      response,
+      500,
+      "Failed to fetch question from database",
+    );
+  });
+
+  it("maps unexpected model failures to a 500 response", async () => {
+    mockQuestionFound();
+    mockGenerateAiQuestionFeedback.mockImplementationOnce(() => {
+      throw new Error("Model unavailable");
+    });
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "Use caching.", questionId }),
+    );
+
+    await expectTextResponse(
+      response,
+      500,
+      "An error occurred while generating feedback",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused Jest coverage for `app/api/ai/questions/generate-feedback/route.ts`.
- Cover invalid request bodies, missing questions, streamed success responses, unauthorized failures, database failures, and unexpected AI service errors.
- Update `TEST_COVERAGE_PLAN.md` with the generate-feedback slice results and next recommendation.

## Verification

- `npm.cmd test -- app/api/ai/questions/generate-feedback/route.test.ts --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- app/api/ai/questions/generate-feedback/route.test.ts TEST_COVERAGE_PLAN.md`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`