### PR TITLE
chore(deps): upgrade arcjet security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@ai-sdk/google": "^2.0.45",
         "@ai-sdk/react": "^2.0.115",
-        "@arcjet/inspect": "^1.0.0-beta.14",
-        "@arcjet/next": "^1.0.0-beta.14",
+        "@arcjet/inspect": "^1.4.0",
+        "@arcjet/next": "^1.4.0",
         "@hookform/resolvers": "^5.2.2",
         "@humeai/voice-react": "^0.2.10",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -214,109 +214,119 @@
       }
     },
     "node_modules/@arcjet/analyze": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/analyze/-/analyze-1.0.0-beta.14.tgz",
-      "integrity": "sha512-ptpiQA43IVAwVIz0TFPJKLCVpiocEK0Cp3dfy+/6hsTiFOl/tQ914DWCTsBagMwhjTzuP+Gf4bqcrHeJvwU1Lw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze/-/analyze-1.4.0.tgz",
+      "integrity": "sha512-dKvRoAnhNRHVuHnQZ4LxL8yH7CVrP4uDhfvoN26aqDuAwjLkJZSR1PzGzj1OH91jD1Qqthn/+wzNm7lqPEjJDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/analyze-wasm": "1.0.0-beta.14",
-        "@arcjet/protocol": "1.0.0-beta.14"
+        "@arcjet/analyze-wasm": "1.4.0",
+        "@arcjet/protocol": "1.4.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/analyze-wasm": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/analyze-wasm/-/analyze-wasm-1.0.0-beta.14.tgz",
-      "integrity": "sha512-irp9TutkyS2JzoPmBh1rlzi7rIRi17BWBatlfbTknwxBGcFoM06VWfGQranZFuO93YSsZgg7/UIwDhnu1Jkg9Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze-wasm/-/analyze-wasm-1.4.0.tgz",
+      "integrity": "sha512-UHyTqz0rQqBccJIWmTPoeKreq3dvZ6Ql5loLY2S0nukA+wBMaBh1Ok88Vo8+qoT10Qkyh9FXk6famNhSiNS/nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/body": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/body/-/body-1.4.0.tgz",
+      "integrity": "sha512-feR887vz8X/jQH8EpztkIdRzY3RnfKjGNBqFIqy2cb+EhxEGmGXJxq+tb0UFndoZ0UIaby+eofDhXUy/4uiF0w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/cache": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/cache/-/cache-1.0.0-beta.14.tgz",
-      "integrity": "sha512-sOZHzrbcRv86btYfqPYdFShz14DWBggV76PPOOuV+wEqpYGt0qY/L/b7Hj1/9GnfNgksVXIxOVQZmQifNt/dQA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/cache/-/cache-1.4.0.tgz",
+      "integrity": "sha512-hRk2p2ZgZmcl1jv66VfbAXxKk7HghdMwFXWcn0wIjHa+ngaYRQFkfrEE0epWeHyTB/sI/p/3+MOT0ApbzIyY5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/duration": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/duration/-/duration-1.0.0-beta.14.tgz",
-      "integrity": "sha512-AIg0Iv2Z0KXzd5RTgk9VMUkIPWILu8/c/3bl6AuhR6upViyksBEDvGTRP8hdus2mUwWDpUO7EuK7caM3iOEtOw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/duration/-/duration-1.4.0.tgz",
+      "integrity": "sha512-5LzFCwMjaYTArKD+8ChZSUT9e2V8RJHqtHcRme/Q5k55ctjiCY+buMcxXSPcft85PpMGW229XKyO3nJSXr6t/A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/env": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/env/-/env-1.0.0-beta.14.tgz",
-      "integrity": "sha512-6lridHbdLNpY4AK++zP5JsMHRXHp6M6k82EqK8JYNPZq+CX1/T+j5Rr1gsL3KnnKgIe4FuIJJTIHYQSV27k1Sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/env/-/env-1.4.0.tgz",
+      "integrity": "sha512-zR9du8LpqdHcMQWZPhQeZr7zapf+EFNGjqHEjmAl/7tnJJUckaUGVJtFiSLBpu2mUYlhnMnwM8LRh2KF+45ecQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/headers": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/headers/-/headers-1.0.0-beta.14.tgz",
-      "integrity": "sha512-+C2qOWTfa1CqNGbiXVET2TXIr7TJousdMUw2e6YLpJZn+cy13daCmJRMI6U0UxcfvEur8Br8+VJNcfTPONl1Vw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/headers/-/headers-1.4.0.tgz",
+      "integrity": "sha512-hzK0jM+sNXZT/dnN6gPSOBiqBODnIuVgFNZG/WHT49VZec9g+nU3X6JFxX5Tm2dIRtVcgQcBpNSgSb1vbWtUiQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/inspect": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/inspect/-/inspect-1.0.0-beta.14.tgz",
-      "integrity": "sha512-Mdid5Aj0Zni6u9h0PV6dOfd/1HAHiJICu+pTY3ozlWtScMW0rxYDStyZFbLoo6cvt6T/NjEAv8OBFtrn0ZHv2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/inspect/-/inspect-1.4.0.tgz",
+      "integrity": "sha512-+YZCUerZDboIapzTRBlnTeiQFvyPTEPxlQwDhew2/TKHPLr1/Mh+T5afUJzfT98D2/XUlmIKCLT++ULPd+7jIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/protocol": "1.0.0-beta.14"
+        "@arcjet/protocol": "1.4.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/ip": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/ip/-/ip-1.0.0-beta.14.tgz",
-      "integrity": "sha512-8XvqiNF2wcK6DfSDB8u9qGYh8oyXPKWspJcTQWy2USAXFj0vrfUW8NIxNkATU0e88Y8tN/WhhFZvhkRFzB60EQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/ip/-/ip-1.4.0.tgz",
+      "integrity": "sha512-gTmtauz5tyuhTaFT8WqS5O7RhpNnJSqK2RO3Hjr1iZydGI2YFkfNoNHjIU8Jck9A281nlHyQTTj3X+ZP51LCfg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/logger": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/logger/-/logger-1.0.0-beta.14.tgz",
-      "integrity": "sha512-RZWU9SLibiWLIcckGFjkmt71fwBGLampZvpgOw0cdXOhNbJbASkgvkxcBvKHgNU0SU6/Fqv46TKCdfesPibk9w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-pAZf78iZ81IezMl5qSbPokY20ma/dNic+w6Q61yOtf7RKfyvIrjWf4ml/CBwrFXodsOLpzeX96TylUudU3/wfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/sprintf": "1.0.0-beta.14"
+        "@arcjet/sprintf": "1.4.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/next": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/next/-/next-1.0.0-beta.14.tgz",
-      "integrity": "sha512-+yMcLdXCK5T07jX1RNmy+wth/6MeT9eG2G0WzCyrk2a+djslx8LoGIomXUyn75i3GNp98baP1aTpGtQv7B16cA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/next/-/next-1.4.0.tgz",
+      "integrity": "sha512-Z2BOQtAsXpvyd1xRGcs1xyzFtX60QVxDSRAwwRbzrFXmQglapJ0LxMW7UMkwnJ5ZcXwMxooWGmkx30Q/gUPpVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/env": "1.0.0-beta.14",
-        "@arcjet/headers": "1.0.0-beta.14",
-        "@arcjet/ip": "1.0.0-beta.14",
-        "@arcjet/logger": "1.0.0-beta.14",
-        "@arcjet/protocol": "1.0.0-beta.14",
-        "@arcjet/transport": "1.0.0-beta.14",
-        "arcjet": "1.0.0-beta.14"
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -326,14 +336,14 @@
       }
     },
     "node_modules/@arcjet/protocol": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/protocol/-/protocol-1.0.0-beta.14.tgz",
-      "integrity": "sha512-TzGxpHRZq4zTllzy7a8TlELe7+mGw3crd4vLw4nEz2BUMaIzZ3o1+CiSt7N+Cb+7rGVv8dMmuXBLqkxNgzTIxg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/protocol/-/protocol-1.4.0.tgz",
+      "integrity": "sha512-CklnpCQ7WIsDa/Bw0ke46B0xs7RsAyXxflB2yRjCUb5yCw2JkfSGqCFLipDUDfI6G9dAFWJ3WZaJYidHDw9/Tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/cache": "1.0.0-beta.14",
-        "@bufbuild/protobuf": "1.10.1",
-        "@connectrpc/connect": "1.6.1",
+        "@arcjet/cache": "1.4.0",
+        "@bufbuild/protobuf": "2.11.0",
+        "@connectrpc/connect": "2.1.1",
         "typeid-js": "1.2.0"
       },
       "engines": {
@@ -341,42 +351,42 @@
       }
     },
     "node_modules/@arcjet/runtime": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/runtime/-/runtime-1.0.0-beta.14.tgz",
-      "integrity": "sha512-g5e9V2yRoNvEkLEk7XdanIFMOVfRv/pXF9xEUGz3UbJgI2COfgnyLWFCSChVm5LeO9FrnHpEe5ZZDL3j3Rzarg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/runtime/-/runtime-1.4.0.tgz",
+      "integrity": "sha512-bjhzAqGjJwJnjvsbjqR1lpHdKQgbhLwpc+uvgZj5yIhiXCnJTZF+Erq2dsyebvZ8foDasO9iy6gLuTA1Nxeayw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/sprintf": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/sprintf/-/sprintf-1.0.0-beta.14.tgz",
-      "integrity": "sha512-+HI1KRhY8N/RtDjnYXCLRADBh4jwi7VC+g8U0f0Me1f6SzUOMU2+I468AyJrDlhqN9cvO6TtSiQDXl7O6Qrn8g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/sprintf/-/sprintf-1.4.0.tgz",
+      "integrity": "sha512-FVrnyJO/0TIokkuXD+RmxK3SZrRhWQJxXnIm9af4U/2rrPzwD/X59t9ba2YW4ENIbVOhhUIUDD6sPfmsLyTl5g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/stable-hash": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/stable-hash/-/stable-hash-1.0.0-beta.14.tgz",
-      "integrity": "sha512-6sKqeP9hgfu/TwZhB5a7FFQ3yFnu8h9GrCkq+k2pIJ040WWunPsjMdZAwCYG9murpBKcN98tLCK23Eo4oDVPPg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/stable-hash/-/stable-hash-1.4.0.tgz",
+      "integrity": "sha512-8im/JZ8NgtXMx49xJM9w1x7+jzIapDD8HGPqb4JcxCjzMMymXpOCjbQINDPL5Pn5/0aG5C9wBWNuoJtWMSuFGQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@arcjet/transport": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@arcjet/transport/-/transport-1.0.0-beta.14.tgz",
-      "integrity": "sha512-UJrzohg4qQZf9gXSDPqpKf1A7naN4UbGzNVronk8cYW1OMbY02IbXfafJepo+FdUMt2+ozKUdkdwsRrqp+5LbA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/transport/-/transport-1.4.0.tgz",
+      "integrity": "sha512-EGCtY0sZwAJsYc21xbJlz6G+Cv++wPHA45WhzcKTAjJydDyhKSKgE9cM/+5EVmjGE5SHG6ctPwjqxEkV/jR4cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "1.10.1",
-        "@connectrpc/connect": "1.6.1",
-        "@connectrpc/connect-node": "1.6.1",
-        "@connectrpc/connect-web": "1.6.1"
+        "@bufbuild/protobuf": "2.11.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
+        "@connectrpc/connect-web": "2.1.1"
       },
       "engines": {
         "node": ">=20"
@@ -1073,44 +1083,41 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
-      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.6.1.tgz",
-      "integrity": "sha512-KchMDNtU4CDTdkyf0qG7ugJ6qHTOR/aI7XebYn3OTCNagaDYWiZUVKgRgwH79yeMkpNgvEUaXSK7wKjaBK9b/Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
+      "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0"
+        "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.6.1.tgz",
-      "integrity": "sha512-DxcD1wsF/aX9GegjAtl7VbpiZNjVJozy87VbaFoN6AF0Ln1Q757r5dgV59Gz0wmlk5f17txUsrEr1f2inlnnAg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.1.tgz",
+      "integrity": "sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "undici": "^5.28.4"
-      },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0",
-        "@connectrpc/connect": "1.6.1"
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.1"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.6.1.tgz",
-      "integrity": "sha512-GVfxQOmt3TtgTaKeXLS/EA2IHa3nHxwe2BCHT7X0Q/0hohM+nP5DDnIItGEjGrGdt3LTTqWqE4s70N4h+qIMlQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.1.tgz",
+      "integrity": "sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0",
-        "@connectrpc/connect": "1.6.1"
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2312,15 +2319,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6455,18 +6453,18 @@
       }
     },
     "node_modules/arcjet": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/arcjet/-/arcjet-1.0.0-beta.14.tgz",
-      "integrity": "sha512-EeD3HBqHZNm4tCUcL0bpfEVQy8solcO/QZgjYZZEfs2a59x1XO8gixyGGt3xiI5bDsRdRKYa24hS7Pv8Hx0+8A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/arcjet/-/arcjet-1.4.0.tgz",
+      "integrity": "sha512-x7nRRdV1IEYJHotTBZatBuwha8kjKrv7azOLM6HPpjRMY0nutZBe9PBs8RGAPiaCVl0EFG8VLaYieFbX4X8nMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@arcjet/analyze": "1.0.0-beta.14",
-        "@arcjet/cache": "1.0.0-beta.14",
-        "@arcjet/duration": "1.0.0-beta.14",
-        "@arcjet/headers": "1.0.0-beta.14",
-        "@arcjet/protocol": "1.0.0-beta.14",
-        "@arcjet/runtime": "1.0.0-beta.14",
-        "@arcjet/stable-hash": "1.0.0-beta.14"
+        "@arcjet/analyze": "1.4.0",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/duration": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/runtime": "1.4.0",
+        "@arcjet/stable-hash": "1.4.0"
       },
       "engines": {
         "node": ">=20"
@@ -14732,18 +14730,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -14976,6 +14962,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@ai-sdk/google": "^2.0.45",
     "@ai-sdk/react": "^2.0.115",
-    "@arcjet/inspect": "^1.0.0-beta.14",
-    "@arcjet/next": "^1.0.0-beta.14",
+    "@arcjet/inspect": "^1.4.0",
+    "@arcjet/next": "^1.4.0",
     "@hookform/resolvers": "^5.2.2",
     "@humeai/voice-react": "^0.2.10",
     "@radix-ui/react-accordion": "^1.2.12",


### PR DESCRIPTION
## Summary

- Upgraded `@arcjet/next` from `^1.0.0-beta.14` to `^1.4.0`
- Upgraded `@arcjet/inspect` from `^1.0.0-beta.14` to `^1.4.0`
- Refreshed `package-lock.json` with Arcjet transitive updates
- Confirmed existing Arcjet usage in `proxy.ts` and `core/features/interviews/actions.ts` still matches the current API

## Verification

- `npm.cmd install`
- `npm.cmd test -- core/features/interviews/actions.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint`
- `npm.cmd audit`

## Notes / Risks

- No application code changes were required.
- The Arcjet/Connect/Undici audit chain is resolved.
- `npm audit` still reports unrelated advisories outside this focused Arcjet upgrade.