### PR TITLE
chore(deps): upgrade drizzle orm security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "drizzle-orm": "^0.44.7",
+        "drizzle-orm": "^0.45.2",
         "hume": "^0.15.7",
         "lucide-react": "^0.553.0",
         "next": "16.2.6",
@@ -7634,9 +7634,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
-      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "drizzle-orm": "^0.44.7",
+    "drizzle-orm": "^0.45.2",
     "hume": "^0.15.7",
     "lucide-react": "^0.553.0",
     "next": "16.2.6",


### PR DESCRIPTION
## Summary

- Upgraded `drizzle-orm` from `^0.44.7` to `^0.45.2` to pick up the security fix for the high-severity Drizzle ORM advisory.
- Left `drizzle-kit` unchanged at `0.31.10`.
- Inspected Drizzle schema, DB setup, DAL usage, transactions, relations, and config; no code changes were required.

## Verification

- `npm.cmd install`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint`
- `npm.cmd audit`
- `npm.cmd audit --omit=dev`
- `npx.cmd drizzle-kit check` with dummy local env values

## Notes / Risks

- `npm audit` no longer reports the Drizzle ORM advisory.
- Remaining audit advisories are outside this focused Drizzle upgrade.
- `drizzle-kit check` requires project env vars because `drizzle.config.ts` imports server env; it passed with dummy local values and did not generate migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to their latest compatible versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->