### PR TITLE
test(ai): resume analyze route coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -592,6 +592,71 @@ Continue AI API route coverage with `app/api/ai/resumes/analyze/route.ts`. Keep
 AI/model behavior mocked through the service boundary where possible, and mock
 auth, permission, and database/action dependencies at module boundaries.
 
+### AI Resume Analyze API Route Slice - 2026-05-21
+
+Files/tests added:
+
+- `app/api/ai/resumes/analyze/route.test.ts`
+
+Files updated:
+
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- app/api/ai/resumes/analyze/route.test.ts --runInBand`
+- `npm.cmd install`
+- `npm.cmd test -- app/api/ai/resumes/analyze/route.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/api/ai/resumes/analyze/route.test.ts TEST_COVERAGE_PLAN.md`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Initial focused test run could not find `jest` because this worktree had no
+  `node_modules`; `npm.cmd install` installed dependencies from
+  `package-lock.json`.
+- Focused resume-analyze route slice passed: 1 test suite, 9 tests, 0
+  snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 49 test suites, 309 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 49 test suites, 309
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `TEST_COVERAGE_PLAN.md` was passed to the command but not checked by Biome.
+- Updated coverage summary: 81.08% statements, 73.09% branches, 76.23%
+  functions, and 82.9% lines.
+- New route coverage:
+  - `app/api/ai/resumes/analyze/route.ts`: 100% statements, 92.85%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Route tests cover invalid multipart form data, unauthenticated users,
+  inaccessible job info, plan-limit denial, streamed success responses,
+  not-found and permission action failures, database action failures, and
+  unexpected AI service failures.
+- Auth, job info action, resume-analysis permission, and resume AI service
+  modules are mocked at module boundaries; DAL error classes are imported as
+  real classes to exercise the route's `instanceof` handling.
+- Test fixtures use `TEST_USER_ID`, local factories, and synthetic resume/job
+  data only.
+- Jest continues to emit the existing `baseline-browser-mapping` warning that
+  the local data is over two months old.
+- `npm.cmd install` reported existing dependency audit findings. They were not
+  part of this coverage slice.
+
+Recommendation:
+
+Continue API route coverage with the remaining cron and OAuth routes, starting
+with the smallest cron handlers before moving into the more mock-heavy OAuth
+provider route.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/ai/resumes/analyze/route.test.ts
+++ b/app/api/ai/resumes/analyze/route.test.ts
@@ -1,0 +1,244 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUserAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/jobInfos/actions", () => ({
+  getJobInfoAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/resumeAnalysis/permissions", () => ({
+  checkResumeAnalysisPermission: jest.fn(),
+}));
+
+jest.mock("@/core/services/ai/resumes/ai", () => ({
+  analyzeResumeForJob: jest.fn(),
+}));
+
+import { getCurrentUserAction } from "@/core/features/auth/actions";
+import { getJobInfoAction } from "@/core/features/jobInfos/actions";
+import { checkResumeAnalysisPermission } from "@/core/features/resumeAnalysis/permissions";
+import { analyzeResumeForJob } from "@/core/services/ai/resumes/ai";
+import { DatabaseError, NotFoundError, PermissionError } from "@/core/dal/errors";
+import { PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeCurrentUser, makeJobInfo } from "@/core/test-utils/factories";
+
+import { POST } from "./route";
+
+const mockGetCurrentUserAction = jest.mocked(getCurrentUserAction);
+const mockGetJobInfoAction = jest.mocked(getJobInfoAction);
+const mockCheckResumeAnalysisPermission = jest.mocked(
+  checkResumeAnalysisPermission,
+);
+const mockAnalyzeResumeForJob = jest.mocked(analyzeResumeForJob);
+
+const jobInfoId = "00000000-0000-4000-8000-000000000401";
+
+function makeResumeFile(overrides: Partial<FilePropertyBag> = {}): File {
+  return new File(["Synthetic resume content"], "resume.txt", {
+    type: "text/plain",
+    ...overrides,
+  });
+}
+
+function buildFormRequest({
+  resumeFile = makeResumeFile(),
+  requestedJobInfoId = jobInfoId,
+}: {
+  resumeFile?: File | null;
+  requestedJobInfoId?: string | null;
+} = {}): Request {
+  const formData = new FormData();
+
+  if (resumeFile != null) {
+    formData.set("resumeFile", resumeFile);
+  }
+
+  if (requestedJobInfoId != null) {
+    formData.set("jobInfoId", requestedJobInfoId);
+  }
+
+  return new Request("http://localhost:3000/api/ai/resumes/analyze", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+async function expectTextResponse(
+  response: Response,
+  status: number,
+  body: string,
+): Promise<void> {
+  expect(response.status).toBe(status);
+  await expect(response.text()).resolves.toBe(body);
+}
+
+function mockAnalyzeStream(): void {
+  mockAnalyzeResumeForJob.mockResolvedValue({
+    toTextStreamResponse: jest.fn(
+      () =>
+        Response.json({
+          kind: "resume-analysis-stream",
+        }) as ReturnType<
+          Awaited<ReturnType<typeof analyzeResumeForJob>>["toTextStreamResponse"]
+        >,
+    ),
+  } as unknown as Awaited<ReturnType<typeof analyzeResumeForJob>>);
+}
+
+describe("POST /api/ai/resumes/analyze", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetCurrentUserAction.mockResolvedValue(
+      makeCurrentUser({ userId: TEST_USER_ID }),
+    );
+    mockGetJobInfoAction.mockResolvedValue(
+      makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID }),
+    );
+    mockCheckResumeAnalysisPermission.mockResolvedValue(true);
+    mockAnalyzeStream();
+
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns 400 when the form data is invalid for resume analysis", async () => {
+    const response = await POST(buildFormRequest({ resumeFile: null }));
+
+    await expectTextResponse(response, 400, "Missing resume or job info id");
+    expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+    expect(mockCheckResumeAnalysisPermission).not.toHaveBeenCalled();
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the current user is unauthenticated", async () => {
+    mockGetCurrentUserAction.mockResolvedValueOnce(
+      makeCurrentUser({ userId: null }),
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(response, 401, "You are not logged in");
+    expect(mockGetJobInfoAction).not.toHaveBeenCalled();
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the job info is inaccessible", async () => {
+    mockGetJobInfoAction.mockImplementationOnce(
+      async () =>
+        null as unknown as Awaited<ReturnType<typeof getJobInfoAction>>,
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+    expect(mockCheckResumeAnalysisPermission).not.toHaveBeenCalled();
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+  });
+
+  it("returns the plan limit response when resume analysis is not allowed", async () => {
+    mockCheckResumeAnalysisPermission.mockResolvedValueOnce(false);
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(response, 403, PLAN_LIMIT_MESSAGE);
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+  });
+
+  it("returns a streamed success response for resume analysis", async () => {
+    const resumeFile = makeResumeFile();
+    const jobInfo = makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID });
+    mockGetJobInfoAction.mockResolvedValueOnce(jobInfo);
+
+    const response = await POST(buildFormRequest({ resumeFile }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kind: "resume-analysis-stream",
+    });
+
+    expect(mockGetJobInfoAction).toHaveBeenCalledWith(jobInfoId);
+    expect(mockAnalyzeResumeForJob).toHaveBeenCalledWith({
+      resumeFile: expect.objectContaining({
+        name: resumeFile.name,
+        size: resumeFile.size,
+        type: resumeFile.type,
+      }),
+      jobInfo,
+    });
+  });
+
+  it("maps not found action failures to a 403 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(
+      new NotFoundError("Job info not found"),
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps permission action failures to a 403 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(
+      new PermissionError("Job info is not available"),
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps database action failures to a 500 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(
+      new DatabaseError("Job info lookup failed"),
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      500,
+      "An error occurred while analyzing your resume",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error analyzing resume:",
+      expect.any(DatabaseError),
+    );
+  });
+
+  it("maps unexpected AI service failures to a 500 response", async () => {
+    mockAnalyzeResumeForJob.mockRejectedValueOnce(new Error("Model failed"));
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      500,
+      "An error occurred while analyzing your resume",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error analyzing resume:",
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused Jest coverage for the resume analysis API route.

- Added `app/api/ai/resumes/analyze/route.test.ts`
- Covered invalid form data, unauthenticated requests, inaccessible job info, plan-limit denial, streamed success, DAL permission/not-found errors, database failures, and unexpected AI service failures
- Updated `TEST_COVERAGE_PLAN.md` with the latest verification results and coverage totals

## Verification

- `npm.cmd test -- app/api/ai/resumes/analyze/route.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- app/api/ai/resumes/analyze/route.test.ts TEST_COVERAGE_PLAN.md`