### PR TITLE
test(oauth): add provider callback route coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -721,6 +721,65 @@ Continue API route coverage with `app/api/oauth/[provider]/route.ts`, or deepen
 remaining Stripe branch coverage in the checkout, portal, and cancel routes if
 keeping the slice billing-focused.
 
+### OAuth Provider Callback Route Slice - 2026-05-22
+
+Files/tests added:
+
+- `app/api/oauth/[provider]/route.test.ts`
+
+Files updated:
+
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- --runTestsByPath app/api/oauth/[provider]/route.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/api/oauth/[provider]/route.test.ts TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused OAuth route slice passed: 1 test suite, 10 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 51 test suites, 327 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 51 test suites, 327
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `TEST_COVERAGE_PLAN.md` was passed to the command but not checked by Biome.
+- Updated coverage summary: 82.57% statements, 74.89% branches, 77.19%
+  functions, and 84.34% lines.
+- New route coverage:
+  - `app/api/oauth/[provider]/route.ts`: 100% statements, 100% branches, 100%
+    functions, and 100% lines.
+
+Notes:
+
+- Route tests cover unsupported providers, missing callback `code` / `state`,
+  unconfigured providers, successful OAuth account connection, session and
+  cookie side effects, known OAuth email error redirects, unexpected callback
+  failures, and stored error-return paths.
+- OAuth client/config, account connection, session, cookie, and Next redirect
+  boundaries are mocked at module boundaries; the route handler is exercised
+  directly.
+- Test fixtures use `TEST_USER_ID` and synthetic `@test.local` OAuth email data
+  only.
+- Jest did not emit the earlier `baseline-browser-mapping` warning during this
+  slice.
+
+Recommendation:
+
+Deepen the remaining Stripe API branch coverage in
+`app/api/stripe/create-checkout-session/route.ts`,
+`app/api/stripe/create-portal-session/route.ts`, and
+`app/api/stripe/cancel-subscription/route.ts`; after that, move into focused
+component tests for auth and billing flows.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/oauth/[provider]/route.test.ts
+++ b/app/api/oauth/[provider]/route.test.ts
@@ -117,7 +117,7 @@ async function expectRedirectTo(
   location: string,
 ): Promise<void> {
   await expect(promise).rejects.toMatchObject({
-    digest: `NEXT_REDIRECT;${location}`,
+    digest: expect.stringContaining(location),
   });
   expect(mockRedirect).toHaveBeenCalledWith(location);
 }

--- a/app/api/oauth/[provider]/route.test.ts
+++ b/app/api/oauth/[provider]/route.test.ts
@@ -1,25 +1,17 @@
 jest.mock("next/navigation", () => {
-  return {
-    redirect: jest.fn((url: string) => {
-      const error = new Error(`NEXT_REDIRECT ${url}`);
-      Object.assign(error, { digest: `NEXT_REDIRECT;${url}` });
-      throw error;
-    }),
-  };
+  const { createNextNavigationMock } = jest.requireActual<
+    typeof import("@core/test-utils/mocks/next")
+  >("@core/test-utils/mocks/next");
+
+  return createNextNavigationMock();
 });
 
 jest.mock("next/headers", () => {
-  const cookieStore = {
-    get: jest.fn(),
-    getAll: jest.fn(() => []),
-    has: jest.fn(() => false),
-    set: jest.fn(),
-    delete: jest.fn(),
-  };
+  const { createNextHeadersMock } = jest.requireActual<
+    typeof import("@core/test-utils/mocks/next")
+  >("@core/test-utils/mocks/next");
 
-  return {
-    cookies: jest.fn(async () => cookieStore),
-  };
+  return createNextHeadersMock();
 });
 
 jest.mock("@/core/features/auth/oauth/base", () => ({
@@ -92,8 +84,8 @@ const mockSetSessionCookie = jest.mocked(setSessionCookie);
 const mockCreateSession = jest.mocked(createSession);
 
 const mockFetchUser = jest.fn();
-const provider = "google" as const;
-const oAuthUser = {
+const PROVIDER = "google" as const;
+const OAUTH_USER = {
   id: "oauth-user-1",
   email: "oauth-user-1@test.local",
   emailVerified: true,
@@ -101,14 +93,20 @@ const oAuthUser = {
   image: null,
 };
 
-function buildRequest(searchParams = "code=test_code&state=test_state") {
+function buildRequest({
+  rawProvider = PROVIDER,
+  searchParams = "code=test_code&state=test_state",
+}: {
+  rawProvider?: string;
+  searchParams?: string;
+} = {}) {
   return new NextRequest(
-    `http://localhost:3000/api/oauth/${provider}?${searchParams}`,
+    `http://localhost:3000/api/oauth/${rawProvider}?${searchParams}`,
     { method: "GET" },
   );
 }
 
-function buildContext(rawProvider: string = provider) {
+function buildContext(rawProvider: string = PROVIDER) {
   return {
     params: Promise.resolve({ provider: rawProvider }),
   };
@@ -138,7 +136,7 @@ describe("GET /api/oauth/[provider]", () => {
       createAuthUrl: jest.fn(),
       fetchUser: mockFetchUser,
     } as unknown as ReturnType<typeof getOAuthClient>);
-    mockFetchUser.mockResolvedValue(oAuthUser);
+    mockFetchUser.mockResolvedValue(OAUTH_USER);
     mockConnectUserToAccount.mockResolvedValue({ id: TEST_USER_ID });
     mockCreateSession.mockResolvedValue(makeSession({ userId: TEST_USER_ID }));
     mockGetOAuthErrorReturnPathAndClear.mockResolvedValue(routes.signIn);
@@ -154,7 +152,7 @@ describe("GET /api/oauth/[provider]", () => {
 
   it("redirects with oauth_invalid_provider when the provider is unsupported", async () => {
     await expectRedirectTo(
-      GET(buildRequest(), buildContext("facebook")),
+      GET(buildRequest({ rawProvider: "facebook" }), buildContext("facebook")),
       `${routes.signIn}?oauthError=oauth_invalid_provider`,
     );
 
@@ -165,7 +163,7 @@ describe("GET /api/oauth/[provider]", () => {
 
   it("redirects with oauth_failed when the callback code is missing", async () => {
     await expectRedirectTo(
-      GET(buildRequest("state=test_state"), buildContext()),
+      GET(buildRequest({ searchParams: "state=test_state" }), buildContext()),
       `${routes.signIn}?oauthError=oauth_failed`,
     );
 
@@ -175,7 +173,7 @@ describe("GET /api/oauth/[provider]", () => {
 
   it("redirects with oauth_failed when the callback state is missing", async () => {
     await expectRedirectTo(
-      GET(buildRequest("code=test_code"), buildContext()),
+      GET(buildRequest({ searchParams: "code=test_code" }), buildContext()),
       `${routes.signIn}?oauthError=oauth_failed`,
     );
 
@@ -191,7 +189,7 @@ describe("GET /api/oauth/[provider]", () => {
       `${routes.signIn}?oauthError=oauth_not_configured`,
     );
 
-    expect(mockGetOAuthConfig).toHaveBeenCalledWith(provider);
+    expect(mockGetOAuthConfig).toHaveBeenCalledWith(PROVIDER);
     expect(mockGetOAuthClient).not.toHaveBeenCalled();
   });
 
@@ -201,19 +199,19 @@ describe("GET /api/oauth/[provider]", () => {
 
     await expectRedirectTo(GET(buildRequest(), buildContext()), routes.app);
 
-    expect(mockGetOAuthClient).toHaveBeenCalledWith(provider);
+    expect(mockGetOAuthClient).toHaveBeenCalledWith(PROVIDER);
     expect(mockFetchUser).toHaveBeenCalledWith(
       "test_code",
       "test_state",
       await mockCookies.mock.results[0].value,
     );
-    expect(mockConnectUserToAccount).toHaveBeenCalledWith(oAuthUser, provider);
+    expect(mockConnectUserToAccount).toHaveBeenCalledWith(OAUTH_USER, PROVIDER);
     expect(mockCreateSession).toHaveBeenCalledWith(TEST_USER_ID);
     expect(mockSetSessionCookie).toHaveBeenCalledWith(
       session.token,
       session.expiresAt,
     );
-    expect(mockSetLastUsedOAuthProviderCookie).toHaveBeenCalledWith(provider);
+    expect(mockSetLastUsedOAuthProviderCookie).toHaveBeenCalledWith(PROVIDER);
     expect(mockClearOAuthErrorReturnCookie).toHaveBeenCalledTimes(1);
     expect(mockGetOAuthErrorReturnPathAndClear).not.toHaveBeenCalled();
   });
@@ -221,15 +219,15 @@ describe("GET /api/oauth/[provider]", () => {
   it.each([
     [
       "oauth_missing_email",
-      new OAuthMissingEmailError(provider),
+      new OAuthMissingEmailError(PROVIDER),
     ],
     [
       "oauth_unverified_email",
-      new OAuthUnverifiedEmailError(provider),
+      new OAuthUnverifiedEmailError(PROVIDER),
     ],
     [
       "oauth_no_verified_email",
-      new OAuthNoVerifiedEmailError(provider),
+      new OAuthNoVerifiedEmailError(PROVIDER),
     ],
   ])("redirects with %s for known OAuth email errors", async (key, error) => {
     mockFetchUser.mockRejectedValueOnce(error);
@@ -260,7 +258,7 @@ describe("GET /api/oauth/[provider]", () => {
   it("uses the stored OAuth error return path for callback failures", async () => {
     mockGetOAuthErrorReturnPathAndClear.mockResolvedValueOnce(routes.signUp);
     mockConnectUserToAccount.mockRejectedValueOnce(
-      new OAuthUnverifiedEmailError(provider),
+      new OAuthUnverifiedEmailError(PROVIDER),
     );
 
     await expectRedirectTo(

--- a/app/api/oauth/[provider]/route.test.ts
+++ b/app/api/oauth/[provider]/route.test.ts
@@ -1,0 +1,271 @@
+jest.mock("next/navigation", () => {
+  return {
+    redirect: jest.fn((url: string) => {
+      const error = new Error(`NEXT_REDIRECT ${url}`);
+      Object.assign(error, { digest: `NEXT_REDIRECT;${url}` });
+      throw error;
+    }),
+  };
+});
+
+jest.mock("next/headers", () => {
+  const cookieStore = {
+    get: jest.fn(),
+    getAll: jest.fn(() => []),
+    has: jest.fn(() => false),
+    set: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  return {
+    cookies: jest.fn(async () => cookieStore),
+  };
+});
+
+jest.mock("@/core/features/auth/oauth/base", () => ({
+  getOAuthClient: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/oauth/connectUser", () => ({
+  connectUserToAccount: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/oauth/config", () => ({
+  getOAuthConfig: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/oauth/oauthErrorReturn", () => ({
+  clearOAuthErrorReturnCookie: jest.fn(),
+  getOAuthErrorReturnPathAndClear: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/oauth/oauthLastUsed", () => ({
+  setLastUsedOAuthProviderCookie: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/session", () => ({
+  createSession: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/cookies", () => ({
+  setSessionCookie: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+
+import { routes } from "@/core/data/routes";
+import { getOAuthClient } from "@/core/features/auth/oauth/base";
+import { connectUserToAccount } from "@/core/features/auth/oauth/connectUser";
+import { getOAuthConfig } from "@/core/features/auth/oauth/config";
+import {
+  OAuthMissingEmailError,
+  OAuthNoVerifiedEmailError,
+  OAuthUnverifiedEmailError,
+} from "@/core/features/auth/oauth/errors";
+import {
+  clearOAuthErrorReturnCookie,
+  getOAuthErrorReturnPathAndClear,
+} from "@/core/features/auth/oauth/oauthErrorReturn";
+import { setLastUsedOAuthProviderCookie } from "@/core/features/auth/oauth/oauthLastUsed";
+import { setSessionCookie } from "@/core/features/auth/cookies";
+import { createSession } from "@/core/features/auth/session";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeSession } from "@/core/test-utils/factories";
+
+import { GET } from "./route";
+
+const mockRedirect = jest.mocked(redirect);
+const mockCookies = jest.mocked(cookies);
+const mockGetOAuthClient = jest.mocked(getOAuthClient);
+const mockConnectUserToAccount = jest.mocked(connectUserToAccount);
+const mockGetOAuthConfig = jest.mocked(getOAuthConfig);
+const mockClearOAuthErrorReturnCookie = jest.mocked(clearOAuthErrorReturnCookie);
+const mockGetOAuthErrorReturnPathAndClear = jest.mocked(
+  getOAuthErrorReturnPathAndClear,
+);
+const mockSetLastUsedOAuthProviderCookie = jest.mocked(
+  setLastUsedOAuthProviderCookie,
+);
+const mockSetSessionCookie = jest.mocked(setSessionCookie);
+const mockCreateSession = jest.mocked(createSession);
+
+const mockFetchUser = jest.fn();
+const provider = "google" as const;
+const oAuthUser = {
+  id: "oauth-user-1",
+  email: "oauth-user-1@test.local",
+  emailVerified: true,
+  name: "OAuth User",
+  image: null,
+};
+
+function buildRequest(searchParams = "code=test_code&state=test_state") {
+  return new NextRequest(
+    `http://localhost:3000/api/oauth/${provider}?${searchParams}`,
+    { method: "GET" },
+  );
+}
+
+function buildContext(rawProvider: string = provider) {
+  return {
+    params: Promise.resolve({ provider: rawProvider }),
+  };
+}
+
+async function expectRedirectTo(
+  promise: Promise<unknown>,
+  location: string,
+): Promise<void> {
+  await expect(promise).rejects.toMatchObject({
+    digest: `NEXT_REDIRECT;${location}`,
+  });
+  expect(mockRedirect).toHaveBeenCalledWith(location);
+}
+
+describe("GET /api/oauth/[provider]", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetOAuthConfig.mockReturnValue({
+      clientId: "client_id",
+      clientSecret: "client_secret",
+    });
+    mockGetOAuthClient.mockReturnValue({
+      createAuthUrl: jest.fn(),
+      fetchUser: mockFetchUser,
+    } as unknown as ReturnType<typeof getOAuthClient>);
+    mockFetchUser.mockResolvedValue(oAuthUser);
+    mockConnectUserToAccount.mockResolvedValue({ id: TEST_USER_ID });
+    mockCreateSession.mockResolvedValue(makeSession({ userId: TEST_USER_ID }));
+    mockGetOAuthErrorReturnPathAndClear.mockResolvedValue(routes.signIn);
+
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("redirects with oauth_invalid_provider when the provider is unsupported", async () => {
+    await expectRedirectTo(
+      GET(buildRequest(), buildContext("facebook")),
+      `${routes.signIn}?oauthError=oauth_invalid_provider`,
+    );
+
+    expect(mockGetOAuthErrorReturnPathAndClear).toHaveBeenCalledTimes(1);
+    expect(mockGetOAuthConfig).not.toHaveBeenCalled();
+    expect(mockGetOAuthClient).not.toHaveBeenCalled();
+  });
+
+  it("redirects with oauth_failed when the callback code is missing", async () => {
+    await expectRedirectTo(
+      GET(buildRequest("state=test_state"), buildContext()),
+      `${routes.signIn}?oauthError=oauth_failed`,
+    );
+
+    expect(mockGetOAuthClient).not.toHaveBeenCalled();
+    expect(mockConnectUserToAccount).not.toHaveBeenCalled();
+  });
+
+  it("redirects with oauth_failed when the callback state is missing", async () => {
+    await expectRedirectTo(
+      GET(buildRequest("code=test_code"), buildContext()),
+      `${routes.signIn}?oauthError=oauth_failed`,
+    );
+
+    expect(mockGetOAuthClient).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it("redirects with oauth_not_configured when the provider lacks credentials", async () => {
+    mockGetOAuthConfig.mockReturnValueOnce(null);
+
+    await expectRedirectTo(
+      GET(buildRequest(), buildContext()),
+      `${routes.signIn}?oauthError=oauth_not_configured`,
+    );
+
+    expect(mockGetOAuthConfig).toHaveBeenCalledWith(provider);
+    expect(mockGetOAuthClient).not.toHaveBeenCalled();
+  });
+
+  it("connects the OAuth account, creates a session, stores cookies, and redirects to the app", async () => {
+    const session = makeSession({ userId: TEST_USER_ID });
+    mockCreateSession.mockResolvedValueOnce(session);
+
+    await expectRedirectTo(GET(buildRequest(), buildContext()), routes.app);
+
+    expect(mockGetOAuthClient).toHaveBeenCalledWith(provider);
+    expect(mockFetchUser).toHaveBeenCalledWith(
+      "test_code",
+      "test_state",
+      await mockCookies.mock.results[0].value,
+    );
+    expect(mockConnectUserToAccount).toHaveBeenCalledWith(oAuthUser, provider);
+    expect(mockCreateSession).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(mockSetSessionCookie).toHaveBeenCalledWith(
+      session.token,
+      session.expiresAt,
+    );
+    expect(mockSetLastUsedOAuthProviderCookie).toHaveBeenCalledWith(provider);
+    expect(mockClearOAuthErrorReturnCookie).toHaveBeenCalledTimes(1);
+    expect(mockGetOAuthErrorReturnPathAndClear).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "oauth_missing_email",
+      new OAuthMissingEmailError(provider),
+    ],
+    [
+      "oauth_unverified_email",
+      new OAuthUnverifiedEmailError(provider),
+    ],
+    [
+      "oauth_no_verified_email",
+      new OAuthNoVerifiedEmailError(provider),
+    ],
+  ])("redirects with %s for known OAuth email errors", async (key, error) => {
+    mockFetchUser.mockRejectedValueOnce(error);
+
+    await expectRedirectTo(
+      GET(buildRequest(), buildContext()),
+      `${routes.signIn}?oauthError=${key}`,
+    );
+
+    expect(mockGetOAuthErrorReturnPathAndClear).toHaveBeenCalledTimes(1);
+    expect(mockSetSessionCookie).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs unexpected callback failures and redirects with oauth_failed", async () => {
+    const error = new Error("token exchange failed");
+    mockFetchUser.mockRejectedValueOnce(error);
+
+    await expectRedirectTo(
+      GET(buildRequest(), buildContext()),
+      `${routes.signIn}?oauthError=oauth_failed`,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("OAuth error:", error);
+    expect(mockClearOAuthErrorReturnCookie).not.toHaveBeenCalled();
+  });
+
+  it("uses the stored OAuth error return path for callback failures", async () => {
+    mockGetOAuthErrorReturnPathAndClear.mockResolvedValueOnce(routes.signUp);
+    mockConnectUserToAccount.mockRejectedValueOnce(
+      new OAuthUnverifiedEmailError(provider),
+    );
+
+    await expectRedirectTo(
+      GET(buildRequest(), buildContext()),
+      `${routes.signUp}?oauthError=oauth_unverified_email`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Added route-level Jest coverage for `app/api/oauth/[provider]/route.ts`
- Covered unsupported providers, missing callback params, unconfigured providers, success flow, OAuth email errors, unexpected failures, and stored error-return redirects
- Updated the coverage plan with the OAuth route slice results

## Verification

- `npm.cmd test -- --runTestsByPath app/api/oauth/[provider]/route.test.ts --runInBand`
- `npm test` attempted, blocked by unsigned `npm.ps1` PowerShell policy
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- app/api/oauth/[provider]/route.test.ts TEST_COVERAGE_PLAN.md`

## Notes / Risks

- No production behavior changes
- OAuth route coverage is now 100% statements, branches, functions, and lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for OAuth callback route covering unsupported providers, missing credentials, successful authentication flows, and error recovery scenarios.

* **Documentation**
  * Updated test coverage plan documenting OAuth callback API route testing completion with coverage metrics and recommendations for future testing efforts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->