### PR TITLE
test(stripe): deepen API branch coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -780,6 +780,64 @@ Deepen the remaining Stripe API branch coverage in
 `app/api/stripe/cancel-subscription/route.ts`; after that, move into focused
 component tests for auth and billing flows.
 
+### Stripe API Branch Coverage Slice - 2026-05-22
+
+Files/tests updated:
+
+- `app/api/stripe/create-checkout-session/route.test.ts`
+- `app/api/stripe/create-portal-session/route.test.ts`
+- `app/api/stripe/cancel-subscription/route.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused Stripe route slice passed: 3 test suites, 29 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 51 test suites, 344 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 51 test suites, 344
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the three touched TypeScript test files.
+  `TEST_COVERAGE_PLAN.md` was passed to the command but not checked by Biome.
+- Updated coverage summary: 83.71% statements, 81.74% branches, 77.19%
+  functions, and 85.55% lines.
+- Updated route coverage:
+  - `app/api/stripe/create-checkout-session/route.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+  - `app/api/stripe/create-portal-session/route.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+  - `app/api/stripe/cancel-subscription/route.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Added focused branch coverage for Stripe configuration failures, missing
+  Stripe clients, checkout price fallback/config failures, already-Pro and
+  existing-subscription redirects, customer email fallback, missing Stripe
+  session URLs, non-JSON 302 redirects, request-origin base URL fallback, and
+  omitted idempotency options.
+- Stripe, auth, env, and billing helper modules remain mocked at module
+  boundaries; route handlers are exercised directly.
+- Test user fixtures use `TEST_USER_ID` and synthetic `@test.local` billing
+  emails only.
+
+Recommendation:
+
+Move next into focused component tests for auth and billing flows, or into
+OAuth service internals if improving the lowest remaining coverage areas is the
+priority.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/stripe/cancel-subscription/route.test.ts
+++ b/app/api/stripe/cancel-subscription/route.test.ts
@@ -57,6 +57,12 @@ function buildJsonRequest(): Request {
   });
 }
 
+function buildFormRequest(): Request {
+  return new Request("http://localhost:3000/api/stripe/cancel-subscription", {
+    method: "POST",
+  });
+}
+
 async function expectJsonRedirect(
   response: Response,
   redirectUrl: string,
@@ -143,6 +149,31 @@ describe("POST /api/stripe/cancel-subscription", () => {
     expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
   });
 
+  it("redirects when Stripe billing is not configured", async () => {
+    mockIsStripeConfigured.mockReturnValueOnce(false);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockGetStripe).not.toHaveBeenCalled();
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the Stripe client is unavailable", async () => {
+    mockGetStripe.mockReturnValueOnce(null);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
   it("sets the current subscription to cancel at period end", async () => {
     mockStripe.subscriptions.update.mockResolvedValueOnce({});
 
@@ -156,6 +187,24 @@ describe("POST /api/stripe/cancel-subscription", () => {
       "sub_test_cancel",
       { cancel_at_period_end: true },
       { idempotencyKey: "idem_test_cancel" },
+    );
+  });
+
+  it("redirects with 302 when JSON is not requested", async () => {
+    mockGetStripeBaseUrl.mockReturnValueOnce(null);
+    mockGetIdempotencyKeyFromRequest.mockResolvedValueOnce(undefined);
+    mockStripe.subscriptions.update.mockResolvedValueOnce({});
+
+    const response = await POST(buildFormRequest());
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/app/upgrade?canceled_subscription=true",
+    );
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith(
+      "sub_test_cancel",
+      { cancel_at_period_end: true },
+      undefined,
     );
   });
 

--- a/app/api/stripe/create-checkout-session/route.test.ts
+++ b/app/api/stripe/create-checkout-session/route.test.ts
@@ -74,6 +74,13 @@ function buildJsonRequest(): Request {
   );
 }
 
+function buildFormRequest(): Request {
+  return new Request(
+    "http://localhost:3000/api/stripe/create-checkout-session",
+    { method: "POST" },
+  );
+}
+
 async function expectJsonRedirect(
   response: Response,
   redirectUrl: string,
@@ -158,6 +165,138 @@ describe("POST /api/stripe/create-checkout-session", () => {
     expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
+  it("redirects when Stripe billing is not configured", async () => {
+    mockIsStripeConfigured.mockReturnValueOnce(false);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockGetStripe).not.toHaveBeenCalled();
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the Stripe client is unavailable", async () => {
+    mockGetStripe.mockReturnValueOnce(null);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when no checkout price can be resolved", async () => {
+    mockEnv = createTestServerEnv({
+      STRIPE_PRO_PRICE_ID: "",
+      STRIPE_PRO_PRODUCT_ID: "",
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=config",
+    );
+    expect(mockStripe.products.retrieve).not.toHaveBeenCalled();
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the configured product has no default price", async () => {
+    mockEnv = createTestServerEnv({
+      STRIPE_PRO_PRICE_ID: "",
+      STRIPE_PRO_PRODUCT_ID: "prod_test_pro",
+    });
+    mockStripe.products.retrieve.mockResolvedValueOnce({
+      default_price: null,
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=config",
+    );
+    expect(mockStripe.products.retrieve).toHaveBeenCalledWith("prod_test_pro", {
+      expand: ["default_price"],
+    });
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured product's string default price", async () => {
+    mockEnv = createTestServerEnv({
+      STRIPE_PRO_PRICE_ID: "",
+      STRIPE_PRO_PRODUCT_ID: "prod_test_pro",
+    });
+    mockStripe.products.retrieve.mockResolvedValueOnce({
+      default_price: "price_test_product",
+    });
+    mockStripe.checkout.sessions.create.mockResolvedValueOnce({
+      url: "https://stripe.test/checkout/product-price",
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://stripe.test/checkout/product-price",
+    );
+    expect(mockStripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: "price_test_product", quantity: 1 }],
+      }),
+      { idempotencyKey: "idem_test_checkout" },
+    );
+  });
+
+  it("redirects users who already have a Pro plan", async () => {
+    mockGetCurrentUserWithProfile.mockResolvedValueOnce({
+      userId: TEST_USER_ID,
+      user: makeUser({
+        id: TEST_USER_ID,
+        email: "billing-checkout-pro@test.local",
+        plan: "pro",
+      }),
+      redirectToSignIn: jest.fn(() => {
+        throw new Error("redirect");
+      }),
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=already_pro",
+    );
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects users who already have a Stripe subscription", async () => {
+    mockGetCurrentUserWithProfile.mockResolvedValueOnce({
+      userId: TEST_USER_ID,
+      user: makeUser({
+        id: TEST_USER_ID,
+        email: "billing-checkout-subscribed@test.local",
+        stripeSubscriptionId: "sub_test_existing",
+      }),
+      redirectToSignIn: jest.fn(() => {
+        throw new Error("redirect");
+      }),
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=existing_subscription",
+    );
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
   it("creates a checkout session for an eligible user", async () => {
     mockStripe.checkout.sessions.create.mockResolvedValueOnce({
       url: "https://stripe.test/checkout/session",
@@ -180,6 +319,56 @@ describe("POST /api/stripe/create-checkout-session", () => {
     );
   });
 
+  it("redirects with 302 when JSON is not requested", async () => {
+    mockGetStripeBaseUrl.mockReturnValueOnce(null);
+    mockGetIdempotencyKeyFromRequest.mockResolvedValueOnce(undefined);
+    mockStripe.checkout.sessions.create.mockResolvedValueOnce({
+      url: "https://stripe.test/checkout/redirect",
+    });
+
+    const response = await POST(buildFormRequest());
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://stripe.test/checkout/redirect",
+    );
+    expect(mockStripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url:
+          "http://localhost:3000/app/upgrade?success=true&session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: "http://localhost:3000/app/upgrade?canceled=true",
+      }),
+      undefined,
+    );
+  });
+
+  it("creates a checkout session with the user's email when no Stripe customer exists", async () => {
+    mockGetCurrentUserWithProfile.mockResolvedValueOnce({
+      userId: TEST_USER_ID,
+      user: makeUser({
+        id: TEST_USER_ID,
+        email: "billing-checkout-email@test.local",
+        stripeCustomerId: null,
+      }),
+      redirectToSignIn: jest.fn(() => {
+        throw new Error("redirect");
+      }),
+    });
+    mockStripe.checkout.sessions.create.mockResolvedValueOnce({
+      url: "https://stripe.test/checkout/email",
+    });
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(response, "https://stripe.test/checkout/email");
+    expect(mockStripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer_email: "billing-checkout-email@test.local",
+      }),
+      { idempotencyKey: "idem_test_checkout" },
+    );
+  });
+
   it("redirects when Stripe rejects checkout session creation", async () => {
     mockStripe.checkout.sessions.create.mockRejectedValueOnce(
       new Error("stripe unavailable"),
@@ -194,6 +383,17 @@ describe("POST /api/stripe/create-checkout-session", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Stripe checkout session creation failed:",
       expect.any(Error),
+    );
+  });
+
+  it("redirects when Stripe creates a checkout session without a URL", async () => {
+    mockStripe.checkout.sessions.create.mockResolvedValueOnce({});
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=checkout_failed",
     );
   });
 });

--- a/app/api/stripe/create-portal-session/route.test.ts
+++ b/app/api/stripe/create-portal-session/route.test.ts
@@ -59,6 +59,12 @@ function buildJsonRequest(): Request {
   });
 }
 
+function buildFormRequest(): Request {
+  return new Request("http://localhost:3000/api/stripe/create-portal-session", {
+    method: "POST",
+  });
+}
+
 async function expectJsonRedirect(
   response: Response,
   redirectUrl: string,
@@ -145,6 +151,31 @@ describe("POST /api/stripe/create-portal-session", () => {
     expect(mockStripe.billingPortal.sessions.create).not.toHaveBeenCalled();
   });
 
+  it("redirects when Stripe billing is not configured", async () => {
+    mockIsStripeConfigured.mockReturnValueOnce(false);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockGetStripe).not.toHaveBeenCalled();
+    expect(mockStripe.billingPortal.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the Stripe client is unavailable", async () => {
+    mockGetStripe.mockReturnValueOnce(null);
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=stripe_not_configured",
+    );
+    expect(mockStripe.billingPortal.sessions.create).not.toHaveBeenCalled();
+  });
+
   it("creates a billing portal session for a user with a Stripe customer", async () => {
     mockStripe.billingPortal.sessions.create.mockResolvedValueOnce({
       url: "https://stripe.test/billing/portal",
@@ -162,6 +193,28 @@ describe("POST /api/stripe/create-portal-session", () => {
     );
   });
 
+  it("redirects with 302 when JSON is not requested", async () => {
+    mockGetStripeBaseUrl.mockReturnValueOnce(null);
+    mockGetIdempotencyKeyFromRequest.mockResolvedValueOnce(undefined);
+    mockStripe.billingPortal.sessions.create.mockResolvedValueOnce({
+      url: "https://stripe.test/billing/redirect",
+    });
+
+    const response = await POST(buildFormRequest());
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://stripe.test/billing/redirect",
+    );
+    expect(mockStripe.billingPortal.sessions.create).toHaveBeenCalledWith(
+      {
+        customer: "cus_test_portal",
+        return_url: "http://localhost:3000/app/upgrade",
+      },
+      undefined,
+    );
+  });
+
   it("redirects when Stripe rejects billing portal session creation", async () => {
     mockStripe.billingPortal.sessions.create.mockRejectedValueOnce(
       new Error("stripe unavailable"),
@@ -176,6 +229,17 @@ describe("POST /api/stripe/create-portal-session", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Stripe portal session creation failed:",
       expect.any(Error),
+    );
+  });
+
+  it("redirects when Stripe creates a billing portal session without a URL", async () => {
+    mockStripe.billingPortal.sessions.create.mockResolvedValueOnce({});
+
+    const response = await POST(buildJsonRequest());
+
+    await expectJsonRedirect(
+      response,
+      "https://app.test/app/upgrade?error=portal_failed",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Added focused branch coverage for Stripe checkout, billing portal, and cancel subscription API routes.
- Covered configuration/client failures, checkout price fallback paths, existing subscription redirects, missing Stripe session URLs, non-JSON redirects, origin fallback, and omitted idempotency options.
- Updated `TEST_COVERAGE_PLAN.md` with verification results and coverage summary.

## Verification

- `npm.cmd test -- app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts TEST_COVERAGE_PLAN.md`

## Notes

- The three targeted Stripe routes now report 100% statements, branches, functions, and lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configuration to enable stricter type-checking rules, improving code quality and error detection during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->