### PR TITLE
test(auth): cover OAuth component states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Avoid inline styling.
 - Follow best practices, reference implementation and apply epistemic reasoning.
 - All code should be formatted for readability with logical parts separated by empty lines.
+- In tests, place module-level `jest.mock(...)` calls before imports when mocking imported modules.
 
 ## General Rules
 

--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -838,6 +838,67 @@ Move next into focused component tests for auth and billing flows, or into
 OAuth service internals if improving the lowest remaining coverage areas is the
 priority.
 
+### Auth OAuth Components Slice - 2026-05-22
+
+Files/tests added:
+
+- `core/features/auth/components/OAuthQueryErrorBanner.test.tsx`
+- `core/features/auth/components/OAuthSignInSection.test.tsx`
+
+Files updated:
+
+- `AGENTS.md`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/auth/components/OAuthQueryErrorBanner.test.tsx core/features/auth/components/OAuthSignInSection.test.tsx --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/auth/components/OAuthQueryErrorBanner.test.tsx core/features/auth/components/OAuthSignInSection.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused auth component slice passed: 2 test suites, 6 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 54 test suites, 354 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 54 test suites, 354
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the two touched TypeScript test files.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 83.22% statements, 79.31% branches, 78.45%
+  functions, and 84.97% lines.
+- New component coverage:
+  - `core/features/auth/components/OAuthQueryErrorBanner.tsx`: 100%
+    statements, 100% branches, 100% functions, and 100% lines.
+  - `core/features/auth/components/OAuthSignInSection.tsx`: 88.23%
+    statements, 90% branches, 87.5% functions, and 88.23% lines.
+
+Notes:
+
+- Component tests cover empty OAuth states, mapped OAuth query errors, form
+  error precedence, configured provider rendering, last-used provider labeling,
+  and OAuth action invocation with the sign-up error-return target.
+- Next navigation and auth action dependencies are mocked at module boundaries.
+- `AGENTS.md` now documents the local convention to place module-level
+  `jest.mock(...)` calls before imports when mocking imported modules.
+- No user email fixtures were needed for this slice.
+- This worktree is currently based on merged `main`; the recorded coverage
+  summary reflects the local post-merge state at verification time.
+
+Recommendation:
+
+Continue focused auth component coverage with `SignInForm` and `SignUpForm`,
+mocking only `useActionState`/action boundaries as needed. If lowest remaining
+coverage is the priority, move into `core/features/auth/oauth/base.ts` and the
+cookie helpers in `oauthErrorReturn.ts` / `oauthLastUsed.ts`.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/components/OAuthQueryErrorBanner.test.tsx
+++ b/core/features/auth/components/OAuthQueryErrorBanner.test.tsx
@@ -1,0 +1,52 @@
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { useSearchParams } from "next/navigation";
+
+import { OAuthQueryErrorBanner } from "./OAuthQueryErrorBanner";
+
+const mockUseSearchParams = jest.mocked(useSearchParams);
+
+function mockOAuthError(oauthError?: string) {
+  mockUseSearchParams.mockReturnValue({
+    get: jest.fn((key: string) => (key === "oauthError" ? oauthError : null)),
+  } as unknown as ReturnType<typeof useSearchParams>);
+}
+
+describe("OAuthQueryErrorBanner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOAuthError(undefined);
+  });
+
+  it("renders nothing without form or OAuth errors", () => {
+    const { container } = render(<OAuthQueryErrorBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the OAuth query error message", () => {
+    mockOAuthError("oauth_missing_email");
+
+    render(<OAuthQueryErrorBanner />);
+
+    expect(
+      screen.getByText(
+        "Sign-in did not return an email. Add or verify an email with that provider, or sign in another way.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers a form error over an OAuth query error", () => {
+    mockOAuthError("oauth_failed");
+
+    render(<OAuthQueryErrorBanner formError="Invalid credentials" />);
+
+    expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Failed to connect. Please try again."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/core/features/auth/components/OAuthSignInSection.test.tsx
+++ b/core/features/auth/components/OAuthSignInSection.test.tsx
@@ -1,0 +1,61 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  signInWithOAuthAction: jest.fn(),
+}));
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { signInWithOAuthAction } from "@/core/features/auth/actions";
+
+import { OAuthSignInSection } from "./OAuthSignInSection";
+
+const mockSignInWithOAuthAction = jest.mocked(signInWithOAuthAction);
+
+describe("OAuthSignInSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSignInWithOAuthAction.mockResolvedValue(undefined as never);
+  });
+
+  it("renders nothing when no OAuth providers are configured", () => {
+    const { container } = render(
+      <OAuthSignInSection configuredOAuthProviders={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders configured providers and marks the last used provider", () => {
+    render(
+      <OAuthSignInSection
+        configuredOAuthProviders={["google", "github"]}
+        lastUsedOAuthProvider="github"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Google" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Github Last used" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Or continue with email")).toBeInTheDocument();
+  });
+
+  it("starts OAuth with the configured error return target", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <OAuthSignInSection
+        configuredOAuthProviders={["discord"]}
+        oauthErrorReturn="sign-up"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Discord" }));
+
+    expect(mockSignInWithOAuthAction).toHaveBeenCalledWith("discord", {
+      errorReturn: "sign-up",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused tests for `OAuthQueryErrorBanner` OAuth/form error rendering
- Add focused tests for `OAuthSignInSection` provider rendering, last-used labeling, and OAuth action invocation
- Document the local Jest convention that module-level `jest.mock(...)` calls should come before imports when mocking imported modules
- Update `TEST_COVERAGE_PLAN.md` with verification results and next recommendations

## Verification

- `npm.cmd test -- core/features/auth/components/OAuthQueryErrorBanner.test.tsx core/features/auth/components/OAuthSignInSection.test.tsx --runInBand`
- `npm test` attempted, blocked by unsigned `npm.ps1` PowerShell policy
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/auth/components/OAuthQueryErrorBanner.test.tsx core/features/auth/components/OAuthSignInSection.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- Coverage summary after this slice: 83.22% statements, 79.31% branches, 78.45% functions, 84.97% lines
- No user email fixtures were needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance documentation with mock ordering requirements.
  * Extended test coverage plan with newly added auth component test files, execution commands, and updated coverage summaries.

* **Tests**
  * Added comprehensive test coverage for OAuth error handling scenarios and OAuth sign-in provider functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->