### PR TITLE
test(auth): cover auth form component states

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -899,6 +899,70 @@ mocking only `useActionState`/action boundaries as needed. If lowest remaining
 coverage is the priority, move into `core/features/auth/oauth/base.ts` and the
 cookie helpers in `oauthErrorReturn.ts` / `oauthLastUsed.ts`.
 
+### Auth Form Components Slice - 2026-05-22
+
+Files/tests added:
+
+- `core/features/auth/components/SignInForm.test.tsx`
+- `core/features/auth/components/SignUpForm.test.tsx`
+
+Files updated:
+
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/auth/components/SignInForm.test.tsx --runInBand`
+- `npm.cmd test -- core/features/auth/components/SignUpForm.test.tsx --runInBand`
+- `npm.cmd test -- core/features/auth/components/SignInForm.test.tsx core/features/auth/components/SignUpForm.test.tsx --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/auth/components/SignInForm.test.tsx core/features/auth/components/SignUpForm.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused auth form slice passed: 2 test suites, 6 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 56 test suites, 360 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 56 test suites, 360
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the two touched TypeScript test files.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 83.5% statements, 79.29% branches, 78.07%
+  functions, and 85.26% lines.
+- New component coverage:
+  - `core/features/auth/components/SignInForm.tsx`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+  - `core/features/auth/components/SignUpForm.tsx`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Component tests cover default field rendering, action-state wiring, OAuth
+  child component props, preserved invalid field values, field error rendering,
+  form error banner handoff, pending button copy, and disabled pending controls.
+- React `useActionState`, auth action modules, and OAuth child components are
+  mocked at module boundaries with module-level `jest.mock(...)` calls before
+  imports.
+- Test email fixtures use synthetic `@test.local` addresses only.
+- The first SignInForm focused run failed because `CardTitle` is a styled `div`,
+  not a semantic heading; the assertion was updated to verify stable visible
+  copy instead.
+
+Recommendation:
+
+Move next into the lowest remaining auth coverage areas:
+`core/features/auth/oauth/base.ts` and the cookie helpers in
+`oauthErrorReturn.ts` / `oauthLastUsed.ts`. Keep provider/client behavior mocked
+at module boundaries and cover cookie read/write/delete branches in a small
+focused slice.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/components/SignInForm.test.tsx
+++ b/core/features/auth/components/SignInForm.test.tsx
@@ -1,0 +1,141 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  signInAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/components/OAuthQueryErrorBanner", () => ({
+  OAuthQueryErrorBanner: jest.fn(({ formError }: { formError?: string }) =>
+    formError == null ? null : <div data-testid="oauth-error">{formError}</div>,
+  ),
+}));
+
+jest.mock("@/core/features/auth/components/OAuthSignInSection", () => ({
+  OAuthSignInSection: jest.fn(
+    ({
+      configuredOAuthProviders,
+      lastUsedOAuthProvider,
+    }: {
+      configuredOAuthProviders: string[];
+      lastUsedOAuthProvider?: string;
+    }) => (
+      <div
+        data-last-used-provider={lastUsedOAuthProvider}
+        data-provider-count={configuredOAuthProviders.length}
+        data-testid="oauth-section"
+      />
+    ),
+  ),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { useActionState } from "react";
+
+import { routes } from "@/core/data/routes";
+import { signInAction } from "@/core/features/auth/actions";
+import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQueryErrorBanner";
+import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInSection";
+
+import { SignInForm } from "./SignInForm";
+
+const mockUseActionState = jest.mocked(useActionState);
+const mockOAuthQueryErrorBanner = jest.mocked(OAuthQueryErrorBanner);
+const mockOAuthSignInSection = jest.mocked(OAuthSignInSection);
+
+const submitAction = jest.fn();
+
+function mockSignInState(
+  state: Parameters<typeof mockUseActionState>[1],
+  isPending = false,
+) {
+  mockUseActionState.mockReturnValue([state, submitAction, isPending]);
+}
+
+describe("SignInForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSignInState(null);
+  });
+
+  it("renders sign-in fields and passes OAuth provider state to the OAuth section", () => {
+    render(
+      <SignInForm
+        configuredOAuthProviders={["google", "github"]}
+        lastUsedOAuthProvider="github"
+      />,
+    );
+
+    expect(mockUseActionState).toHaveBeenCalledWith(signInAction, null);
+    expect(
+      screen.getByText("Enter your email and password to sign in to your account"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+    expect(screen.getByLabelText("Password")).toHaveAttribute(
+      "autocomplete",
+      "current-password",
+    );
+    expect(screen.getByRole("button", { name: "Sign In" })).toBeEnabled();
+    expect(screen.getByRole("link", { name: "Sign up" })).toHaveAttribute(
+      "href",
+      routes.signUp,
+    );
+    expect(screen.getByTestId("oauth-section")).toHaveAttribute(
+      "data-provider-count",
+      "2",
+    );
+    expect(screen.getByTestId("oauth-section")).toHaveAttribute(
+      "data-last-used-provider",
+      "github",
+    );
+    expect(mockOAuthSignInSection).toHaveBeenCalledWith(
+      {
+        configuredOAuthProviders: ["google", "github"],
+        lastUsedOAuthProvider: "github",
+      },
+      undefined,
+    );
+  });
+
+  it("renders returned field values and validation errors", () => {
+    mockSignInState({
+      error: "Please correct the highlighted fields.",
+      fields: { email: "candidate@test.local" },
+      fieldErrors: {
+        email: "Enter a valid email",
+        password: "Password is required",
+      },
+    });
+
+    render(<SignInForm configuredOAuthProviders={[]} />);
+
+    expect(screen.getByLabelText("Email")).toHaveValue("candidate@test.local");
+    expect(screen.getByLabelText("Email")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("Password")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByText("Enter a valid email")).toBeInTheDocument();
+    expect(screen.getByText("Password is required")).toBeInTheDocument();
+    expect(screen.getByTestId("oauth-error")).toHaveTextContent(
+      "Please correct the highlighted fields.",
+    );
+    expect(mockOAuthQueryErrorBanner).toHaveBeenCalledWith(
+      { formError: "Please correct the highlighted fields." },
+      undefined,
+    );
+  });
+
+  it("disables controls and shows pending copy while signing in", () => {
+    mockSignInState(null, true);
+
+    render(<SignInForm configuredOAuthProviders={[]} />);
+
+    expect(screen.getByLabelText("Email")).toBeDisabled();
+    expect(screen.getByLabelText("Password")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Show password" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Signing in..." })).toBeDisabled();
+  });
+});

--- a/core/features/auth/components/SignUpForm.test.tsx
+++ b/core/features/auth/components/SignUpForm.test.tsx
@@ -1,0 +1,164 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useActionState: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/actions", () => ({
+  signUpAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/components/OAuthQueryErrorBanner", () => ({
+  OAuthQueryErrorBanner: jest.fn(({ formError }: { formError?: string }) =>
+    formError == null ? null : <div data-testid="oauth-error">{formError}</div>,
+  ),
+}));
+
+jest.mock("@/core/features/auth/components/OAuthSignInSection", () => ({
+  OAuthSignInSection: jest.fn(
+    ({
+      configuredOAuthProviders,
+      lastUsedOAuthProvider,
+      oauthErrorReturn,
+    }: {
+      configuredOAuthProviders: string[];
+      lastUsedOAuthProvider?: string;
+      oauthErrorReturn?: string;
+    }) => (
+      <div
+        data-error-return={oauthErrorReturn}
+        data-last-used-provider={lastUsedOAuthProvider}
+        data-provider-count={configuredOAuthProviders.length}
+        data-testid="oauth-section"
+      />
+    ),
+  ),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { useActionState } from "react";
+
+import { routes } from "@/core/data/routes";
+import { signUpAction } from "@/core/features/auth/actions";
+import { OAuthQueryErrorBanner } from "@/core/features/auth/components/OAuthQueryErrorBanner";
+import { OAuthSignInSection } from "@/core/features/auth/components/OAuthSignInSection";
+
+import { SignUpForm } from "./SignUpForm";
+
+const mockUseActionState = jest.mocked(useActionState);
+const mockOAuthQueryErrorBanner = jest.mocked(OAuthQueryErrorBanner);
+const mockOAuthSignInSection = jest.mocked(OAuthSignInSection);
+
+const submitAction = jest.fn();
+
+function mockSignUpState(
+  state: Parameters<typeof mockUseActionState>[1],
+  isPending = false,
+) {
+  mockUseActionState.mockReturnValue([state, submitAction, isPending]);
+}
+
+describe("SignUpForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSignUpState(null);
+  });
+
+  it("renders sign-up fields and passes sign-up OAuth state to the OAuth section", () => {
+    render(
+      <SignUpForm
+        configuredOAuthProviders={["google", "discord"]}
+        lastUsedOAuthProvider="google"
+      />,
+    );
+
+    expect(mockUseActionState).toHaveBeenCalledWith(signUpAction, null);
+    expect(
+      screen.getByText("Enter your information to create a new account"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveAttribute("type", "text");
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+    expect(screen.getByLabelText("Password")).toHaveAttribute(
+      "autocomplete",
+      "new-password",
+    );
+    expect(screen.getByLabelText("Password")).toHaveAttribute("minlength", "8");
+    expect(
+      screen.getByText("Must be at least 8 characters with a letter and number"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create Account" })).toBeEnabled();
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      routes.signIn,
+    );
+    expect(screen.getByTestId("oauth-section")).toHaveAttribute(
+      "data-provider-count",
+      "2",
+    );
+    expect(screen.getByTestId("oauth-section")).toHaveAttribute(
+      "data-last-used-provider",
+      "google",
+    );
+    expect(screen.getByTestId("oauth-section")).toHaveAttribute(
+      "data-error-return",
+      "sign-up",
+    );
+    expect(mockOAuthSignInSection).toHaveBeenCalledWith(
+      {
+        configuredOAuthProviders: ["google", "discord"],
+        lastUsedOAuthProvider: "google",
+        oauthErrorReturn: "sign-up",
+      },
+      undefined,
+    );
+  });
+
+  it("renders returned field values and validation errors", () => {
+    mockSignUpState({
+      error: "Please correct the highlighted fields.",
+      fields: {
+        name: "Ada",
+        email: "candidate@test.local",
+      },
+      fieldErrors: {
+        name: "Name is required",
+        email: "Enter a valid email",
+        password: "Password must include a number",
+      },
+    });
+
+    render(<SignUpForm configuredOAuthProviders={[]} />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Ada");
+    expect(screen.getByLabelText("Email")).toHaveValue("candidate@test.local");
+    expect(screen.getByLabelText("Name")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("Email")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("Password")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+    expect(screen.getByText("Enter a valid email")).toBeInTheDocument();
+    expect(screen.getByText("Password must include a number")).toBeInTheDocument();
+    expect(screen.getByTestId("oauth-error")).toHaveTextContent(
+      "Please correct the highlighted fields.",
+    );
+    expect(mockOAuthQueryErrorBanner).toHaveBeenCalledWith(
+      { formError: "Please correct the highlighted fields." },
+      undefined,
+    );
+  });
+
+  it("disables controls and shows pending copy while creating an account", () => {
+    mockSignUpState(null, true);
+
+    render(<SignUpForm configuredOAuthProviders={[]} />);
+
+    expect(screen.getByLabelText("Name")).toBeDisabled();
+    expect(screen.getByLabelText("Email")).toBeDisabled();
+    expect(screen.getByLabelText("Password")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Show password" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Creating account..." }),
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused component tests for `SignInForm` and `SignUpForm`
- Cover action-state wiring, OAuth child props, validation errors, preserved field values, and pending disabled states
- Update `TEST_COVERAGE_PLAN.md` with verification results and next recommendations

## Verification

- `npm.cmd test -- core/features/auth/components/SignInForm.test.tsx core/features/auth/components/SignUpForm.test.tsx --runInBand`
- `npm test` blocked by unsigned `npm.ps1` PowerShell execution policy before Jest starts
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/auth/components/SignInForm.test.tsx core/features/auth/components/SignUpForm.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- Both auth form components now report 100% coverage.
- No production code changes.
- Uses synthetic `@test.local` email fixtures only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for sign-in and sign-up authentication forms, covering form rendering, field validation, error handling, and pending submission states.

* **Documentation**
  * Updated test coverage plan with new test metrics and progress tracking for authentication form components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->