### PR TITLE
fix(stripe): preserve active replacement subscriptions

### DIFF
--- a/core/features/users/stripeSync.test.ts
+++ b/core/features/users/stripeSync.test.ts
@@ -33,12 +33,18 @@ const mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb = jest.mocked(
 
 function makeStripeList(
   subscriptions: Stripe.Subscription[],
+  autoPagingSubscriptions = subscriptions,
 ): Stripe.ApiList<Stripe.Subscription> {
   return {
     object: "list",
     data: subscriptions,
     has_more: false,
     url: "/v1/subscriptions",
+    async *[Symbol.asyncIterator]() {
+      for (const subscription of autoPagingSubscriptions) {
+        yield subscription;
+      }
+    },
   };
 }
 
@@ -56,14 +62,16 @@ function makeMissingSubscriptionError(): Stripe.errors.StripeInvalidRequestError
 describe("syncSubscriptionFromStripe", () => {
   let stripe: Stripe;
   let mockRetrieve: jest.Mock;
+  let mockList: jest.Mock;
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     mockRetrieve = jest.fn();
+    mockList = jest.fn().mockReturnValue(makeStripeList([]));
     stripe = {
       subscriptions: {
         retrieve: mockRetrieve,
-        list: jest.fn(),
+        list: mockList,
       },
     } as unknown as Stripe;
 
@@ -78,18 +86,26 @@ describe("syncSubscriptionFromStripe", () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it("skips stale subscription events when the user already references a newer subscription", async () => {
+  it("skips stale non-active subscription events when the user already references another subscription", async () => {
     const user = makeProUser({
       stripeCustomerId: "cus_test_current",
       stripeSubscriptionId: "sub_test_current",
+    });
+    const currentSubscription = makeStripeSubscription({
+      id: "sub_test_current",
+      customer: "cus_test_current",
+      status: "active",
+      created: 200,
     });
     const staleSubscription = makeStripeSubscription({
       id: "sub_test_stale",
       customer: "cus_test_current",
       status: "canceled",
+      created: 100,
     });
     mockGetUserByStripeCustomerIdDb.mockResolvedValue(user);
     mockRetrieve.mockResolvedValue(staleSubscription);
+    mockList.mockReturnValue(makeStripeList([currentSubscription]));
 
     await syncSubscriptionFromStripe(
       stripe,
@@ -98,30 +114,38 @@ describe("syncSubscriptionFromStripe", () => {
     );
 
     expect(mockRetrieve).toHaveBeenCalledWith("sub_test_stale");
+    expect(mockList).toHaveBeenCalledWith({
+      customer: "cus_test_current",
+      status: "all",
+      limit: 100,
+    });
     expect(
       mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
     ).not.toHaveBeenCalled();
   });
 
-  it("attaches a newer active subscription when the stored subscription is stale", async () => {
+  it("updates to a newer active subscription when the row still references an older subscription", async () => {
     const user = makeProUser({
       stripeCustomerId: "cus_test_current",
       stripeSubscriptionId: "sub_test_old",
+    });
+    const oldSubscription = makeStripeSubscription({
+      id: "sub_test_old",
+      customer: "cus_test_current",
+      status: "active",
+      created: 100,
     });
     const newSubscription = makeStripeSubscription({
       id: "sub_test_new",
       customer: "cus_test_current",
       status: "active",
-    });
-    const oldSubscription = makeStripeSubscription({
-      id: "sub_test_old",
-      customer: "cus_test_current",
-      status: "canceled",
+      created: 200,
     });
     mockGetUserByStripeCustomerIdDb.mockResolvedValue(user);
-    mockRetrieve
-      .mockResolvedValueOnce(newSubscription)
-      .mockResolvedValueOnce(oldSubscription);
+    mockRetrieve.mockResolvedValue(newSubscription);
+    mockList.mockReturnValue(
+      makeStripeList([oldSubscription, newSubscription]),
+    );
 
     await syncSubscriptionFromStripe(
       stripe,
@@ -129,8 +153,6 @@ describe("syncSubscriptionFromStripe", () => {
       "cus_test_current",
     );
 
-    expect(mockRetrieve).toHaveBeenNthCalledWith(1, "sub_test_new");
-    expect(mockRetrieve).toHaveBeenNthCalledWith(2, "sub_test_old");
     expect(
       mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
     ).toHaveBeenCalledWith(user.id, "sub_test_old", {
@@ -139,35 +161,108 @@ describe("syncSubscriptionFromStripe", () => {
     });
   });
 
-  it("skips a mismatched active event when the stored subscription is still active", async () => {
+  it("uses auto-pagination when searching for an active replacement subscription", async () => {
     const user = makeProUser({
-      stripeCustomerId: "cus_test_current",
-      stripeSubscriptionId: "sub_test_current",
+      stripeCustomerId: "cus_test_paginated",
+      stripeSubscriptionId: "sub_test_old",
     });
-    const eventSubscription = makeStripeSubscription({
-      id: "sub_test_other",
-      customer: "cus_test_current",
-      status: "active",
+    const canceledSubscription = makeStripeSubscription({
+      id: "sub_test_old",
+      customer: "cus_test_paginated",
+      status: "canceled",
+      created: 100,
     });
-    const currentSubscription = makeStripeSubscription({
-      id: "sub_test_current",
-      customer: "cus_test_current",
+    const activeSubscription = makeStripeSubscription({
+      id: "sub_test_active_after_first_page",
+      customer: "cus_test_paginated",
       status: "active",
+      created: 200,
     });
     mockGetUserByStripeCustomerIdDb.mockResolvedValue(user);
-    mockRetrieve
-      .mockResolvedValueOnce(eventSubscription)
-      .mockResolvedValueOnce(currentSubscription);
+    mockRetrieve.mockResolvedValue(canceledSubscription);
+    mockList.mockReturnValue(makeStripeList([], [activeSubscription]));
 
     await syncSubscriptionFromStripe(
       stripe,
-      "sub_test_other",
+      "sub_test_old",
+      "cus_test_paginated",
+    );
+
+    expect(
+      mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
+    ).toHaveBeenCalledWith(user.id, "sub_test_old", {
+      plan: "pro",
+      stripeSubscriptionId: "sub_test_active_after_first_page",
+    });
+  });
+
+  it("does not let an older active subscription replace a newer stored subscription", async () => {
+    const user = makeProUser({
+      stripeCustomerId: "cus_test_current",
+      stripeSubscriptionId: "sub_test_new",
+    });
+    const oldSubscription = makeStripeSubscription({
+      id: "sub_test_old",
+      customer: "cus_test_current",
+      status: "active",
+      created: 100,
+    });
+    const newSubscription = makeStripeSubscription({
+      id: "sub_test_new",
+      customer: "cus_test_current",
+      status: "active",
+      created: 200,
+    });
+    mockGetUserByStripeCustomerIdDb.mockResolvedValue(user);
+    mockRetrieve.mockResolvedValue(oldSubscription);
+    mockList.mockReturnValue(
+      makeStripeList([oldSubscription, newSubscription]),
+    );
+
+    await syncSubscriptionFromStripe(
+      stripe,
+      "sub_test_old",
       "cus_test_current",
     );
 
     expect(
       mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
     ).not.toHaveBeenCalled();
+  });
+
+  it("switches to a newer active subscription instead of downgrading a terminal stored subscription", async () => {
+    const user = makeProUser({
+      stripeCustomerId: "cus_test_current",
+      stripeSubscriptionId: "sub_test_old",
+    });
+    const canceledSubscription = makeStripeSubscription({
+      id: "sub_test_old",
+      customer: "cus_test_current",
+      status: "canceled",
+      created: 100,
+    });
+    const newSubscription = makeStripeSubscription({
+      id: "sub_test_new",
+      customer: "cus_test_current",
+      status: "active",
+      created: 200,
+    });
+    mockGetUserByStripeCustomerIdDb.mockResolvedValue(user);
+    mockRetrieve.mockResolvedValue(canceledSubscription);
+    mockList.mockReturnValue(makeStripeList([newSubscription]));
+
+    await syncSubscriptionFromStripe(
+      stripe,
+      "sub_test_old",
+      "cus_test_current",
+    );
+
+    expect(
+      mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
+    ).toHaveBeenCalledWith(user.id, "sub_test_old", {
+      plan: "pro",
+      stripeSubscriptionId: "sub_test_new",
+    });
   });
 
   it("uses a conditional update so concurrent checkout fulfillment cannot be overwritten", async () => {
@@ -244,7 +339,7 @@ describe("reconcileUserStripeSubscription", () => {
     });
     mockGetUserByIdDb.mockResolvedValueOnce(user).mockResolvedValueOnce(user);
     mockRetrieve.mockRejectedValue(makeMissingSubscriptionError());
-    mockList.mockResolvedValue(makeStripeList([activeSubscription]));
+    mockList.mockReturnValue(makeStripeList([activeSubscription]));
 
     await expect(
       reconcileUserStripeSubscription(stripe, user.id),
@@ -284,7 +379,7 @@ describe("reconcileUserStripeSubscription", () => {
     });
     mockGetUserByIdDb.mockResolvedValue(user);
     mockRetrieve.mockResolvedValue(inactiveSubscription);
-    mockList.mockResolvedValue(makeStripeList([activeSubscription]));
+    mockList.mockReturnValue(makeStripeList([activeSubscription]));
 
     await expect(
       reconcileUserStripeSubscription(stripe, user.id),
@@ -306,6 +401,51 @@ describe("reconcileUserStripeSubscription", () => {
     });
   });
 
+  it("repairs a terminal stored subscription by attaching the newest active customer subscription", async () => {
+    const user = makeProUser({
+      id: "user_test_terminal_repair",
+      stripeCustomerId: "cus_test_terminal_repair",
+      stripeSubscriptionId: "sub_test_old",
+    });
+    const canceledSubscription = makeStripeSubscription({
+      id: "sub_test_old",
+      customer: "cus_test_terminal_repair",
+      status: "canceled",
+      created: 100,
+    });
+    const olderActiveSubscription = makeStripeSubscription({
+      id: "sub_test_older_active",
+      customer: "cus_test_terminal_repair",
+      status: "active",
+      created: 150,
+    });
+    const newestActiveSubscription = makeStripeSubscription({
+      id: "sub_test_newest_active",
+      customer: "cus_test_terminal_repair",
+      status: "active",
+      created: 200,
+    });
+    mockGetUserByIdDb.mockResolvedValue(user);
+    mockRetrieve.mockResolvedValue(canceledSubscription);
+    mockList.mockReturnValue(
+      makeStripeList([olderActiveSubscription, newestActiveSubscription]),
+    );
+
+    await expect(
+      reconcileUserStripeSubscription(stripe, user.id),
+    ).resolves.toEqual({
+      kind: "ok",
+      updated: true,
+    });
+
+    expect(
+      mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
+    ).toHaveBeenCalledWith(user.id, "sub_test_old", {
+      plan: "pro",
+      stripeSubscriptionId: "sub_test_newest_active",
+    });
+  });
+
   it("downgrades a missing stored subscription only while the row still references it", async () => {
     const user = makeProUser({
       id: "user_test_downgrade",
@@ -314,7 +454,7 @@ describe("reconcileUserStripeSubscription", () => {
     });
     mockGetUserByIdDb.mockResolvedValueOnce(user).mockResolvedValueOnce(user);
     mockRetrieve.mockRejectedValue(makeMissingSubscriptionError());
-    mockList.mockResolvedValue(makeStripeList([]));
+    mockList.mockReturnValue(makeStripeList([]));
 
     await expect(
       reconcileUserStripeSubscription(stripe, user.id),

--- a/core/features/users/stripeSync.ts
+++ b/core/features/users/stripeSync.ts
@@ -32,6 +32,21 @@ function isTerminalSubscriptionStatus(
   );
 }
 
+function getLatestActiveSubscription(
+  latest: Stripe.Subscription | null,
+  subscription: Stripe.Subscription,
+): Stripe.Subscription | null {
+  if (!isActiveSubscriptionStatus(subscription.status)) {
+    return latest;
+  }
+
+  if (!latest || subscription.created > latest.created) {
+    return subscription;
+  }
+
+  return latest;
+}
+
 function getSubscriptionState(subscription: Stripe.Subscription): {
   plan: UserPlan;
   stripeSubscriptionId: string | null;
@@ -47,42 +62,71 @@ function getSubscriptionState(subscription: Stripe.Subscription): {
   };
 }
 
-async function isStripeSubscriptionActive(
-  stripe: Stripe,
-  subscriptionId: string,
-): Promise<boolean> {
-  try {
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-
-    return isActiveSubscriptionStatus(subscription.status);
-  } catch (err) {
-    if (isStripeSubscriptionMissingError(err)) {
-      return false;
-    }
-
-    throw err;
-  }
-}
-
 async function findActiveCustomerSubscription(
   stripe: Stripe,
   customerId: string,
 ): Promise<Stripe.Subscription | null> {
-  const subscriptions = await stripe.subscriptions.list({
+  const subscriptions = stripe.subscriptions.list({
     customer: customerId,
     status: "all",
     limit: CUSTOMER_SUBSCRIPTION_LIST_LIMIT,
   });
+  let latestSubscription: Stripe.Subscription | null = null;
 
-  return (
-    subscriptions.data.find((subscription) =>
-      isActiveSubscriptionStatus(subscription.status),
-    ) ?? null
+  for await (const subscription of subscriptions) {
+    latestSubscription = getLatestActiveSubscription(
+      latestSubscription,
+      subscription,
+    );
+  }
+
+  return latestSubscription;
+}
+
+async function getSubscriptionForSync(
+  stripe: Stripe,
+  subscription: Stripe.Subscription,
+  customerId: string,
+  currentStripeSubscriptionId: string | null,
+): Promise<Stripe.Subscription | null> {
+  if (
+    currentStripeSubscriptionId !== null &&
+    currentStripeSubscriptionId !== subscription.id
+  ) {
+    const activeSubscription = await findActiveCustomerSubscription(
+      stripe,
+      customerId,
+    );
+
+    if (activeSubscription?.id === subscription.id) {
+      return activeSubscription;
+    }
+
+    console.warn("[stripeSync] Skipped stale subscription webhook", {
+      currentStripeSubscriptionId,
+      eventStripeSubscriptionId: subscription.id,
+      activeStripeSubscriptionId: activeSubscription?.id ?? null,
+    });
+
+    return null;
+  }
+
+  if (isActiveSubscriptionStatus(subscription.status)) {
+    return subscription;
+  }
+
+  const activeSubscription = await findActiveCustomerSubscription(
+    stripe,
+    customerId,
   );
+
+  return activeSubscription && activeSubscription.id !== subscription.id
+    ? activeSubscription
+    : subscription;
 }
 
 /**
- * Updates plan and subscription ids in DB based on Stripe’s subscription data for the given customer.
+ * Updates plan and subscription ids in DB based on Stripe's subscription data for the given customer.
  *
  * @param stripe - Stripe client instance.
  * @param subscriptionId - Subscription id to retrieve corresponding subscription state.
@@ -97,45 +141,24 @@ export async function syncSubscriptionFromStripe(
   const user = await getUserByStripeCustomerIdDb(customerId);
   if (!user) {
     throw new Error(
-      `syncSubscriptionFromStripe: no user for customer ${customerId} — will retry`,
+      `syncSubscriptionFromStripe: no user for customer ${customerId} - will retry`,
     );
   }
 
   const stripeSubscription =
     await stripe.subscriptions.retrieve(subscriptionId);
+  const subscriptionForSync = await getSubscriptionForSync(
+    stripe,
+    stripeSubscription,
+    customerId,
+    user.stripeSubscriptionId,
+  );
 
-  if (
-    user.stripeSubscriptionId !== null &&
-    user.stripeSubscriptionId !== subscriptionId
-  ) {
-    if (!isActiveSubscriptionStatus(stripeSubscription.status)) {
-      console.warn("[stripeSync] Skipped stale subscription webhook", {
-        userId: user.id,
-        currentStripeSubscriptionId: user.stripeSubscriptionId,
-        eventStripeSubscriptionId: subscriptionId,
-      });
-      return;
-    }
-
-    const currentSubscriptionIsActive = await isStripeSubscriptionActive(
-      stripe,
-      user.stripeSubscriptionId,
-    );
-
-    if (currentSubscriptionIsActive) {
-      console.warn(
-        "[stripeSync] Skipped active subscription webhook because the user already references an active subscription",
-        {
-          userId: user.id,
-          currentStripeSubscriptionId: user.stripeSubscriptionId,
-          eventStripeSubscriptionId: subscriptionId,
-        },
-      );
-      return;
-    }
+  if (!subscriptionForSync) {
+    return;
   }
 
-  const subscriptionState = getSubscriptionState(stripeSubscription);
+  const subscriptionState = getSubscriptionState(subscriptionForSync);
 
   const updated = await updateUserPlanAndStripeIdsIfSubscriptionMatchesDb(
     user.id,
@@ -149,7 +172,7 @@ export async function syncSubscriptionFromStripe(
       {
         userId: user.id,
         priorStripeSubscriptionId: user.stripeSubscriptionId,
-        eventStripeSubscriptionId: subscriptionId,
+        eventStripeSubscriptionId: subscriptionForSync.id,
       },
     );
   }
@@ -168,7 +191,7 @@ type ReconcileStripeSubscriptionResult =
   | { kind: "error"; message: string };
 
 /**
- * Periodic backstop when webhooks were missed: brings one user’s row in line with Stripe.
+ * Periodic backstop when webhooks were missed: brings one user's row in line with Stripe.
  *
  * @param stripe - Stripe client instance.
  * @param userId - User id.
@@ -204,19 +227,13 @@ export async function reconcileUserStripeSubscription(
       return { kind: "skipped", reason: "customer_mismatch" };
     }
 
-    let subscriptionState = getSubscriptionState(stripeSubscription);
+    const subscriptionForSync =
+      !isActiveSubscriptionStatus(stripeSubscription.status) && stripeCustomerId
+        ? ((await findActiveCustomerSubscription(stripe, stripeCustomerId)) ??
+          stripeSubscription)
+        : stripeSubscription;
 
-    if (!isActiveSubscriptionStatus(stripeSubscription.status)) {
-      const activeSubscription = await findActiveCustomerSubscription(
-        stripe,
-        stripeCustomerId,
-      );
-
-      if (activeSubscription) {
-        subscriptionState = getSubscriptionState(activeSubscription);
-      }
-    }
-
+    const subscriptionState = getSubscriptionState(subscriptionForSync);
     const isUpdated =
       user.plan !== subscriptionState.plan ||
       user.stripeSubscriptionId !== subscriptionState.stripeSubscriptionId;

--- a/core/test-utils/factories/stripeEvent.ts
+++ b/core/test-utils/factories/stripeEvent.ts
@@ -34,14 +34,14 @@ function nextSubscriptionIndex(): number {
 }
 
 export type MakeStripeSubscriptionOverrides = Partial<
-  Pick<Stripe.Subscription, "id" | "customer" | "status">
+  Pick<Stripe.Subscription, "id" | "customer" | "status" | "created">
 > & {
   cancelAtPeriodEnd?: boolean;
 };
 
 /**
  * Builds a minimal `Stripe.Subscription` fixture. Only the fields the app's
- * sync logic reads (`id`, `customer`, `status`) are meaningful.
+ * sync logic reads (`id`, `customer`, `status`, `created`) are meaningful.
  */
 export function makeStripeSubscription(
   overrides: MakeStripeSubscriptionOverrides = {},
@@ -53,6 +53,7 @@ export function makeStripeSubscription(
     object: "subscription" as const,
     customer: overrides.customer ?? `cus_test_${index}`,
     status: overrides.status ?? "active",
+    created: overrides.created ?? index,
     cancel_at_period_end: overrides.cancelAtPeriodEnd ?? false,
   };
 


### PR DESCRIPTION
## Summary
- Resolves the conflicted PR #55 on top of current `main`.
- Preserves active/trialing replacement subscriptions instead of treating newer valid subscription events as stale.
- Uses Stripe subscription list auto-pagination to choose the newest active/trialing customer subscription, so replacement detection is not limited to the first page.
- Keeps the cron/webhook reconciliation safeguards from `main` and expands regression coverage.

## Root Cause
Stripe webhook events can arrive out of order. The previous stale-event guard could treat a valid newer active subscription event as stale when the user row still referenced an older subscription, leaving a paying customer downgraded or unrepaired.

## Verification
- `npm.cmd test -- core/features/users/stripeSync.test.ts`
- `npm.cmd test`
- `npm.cmd run lint -- core/features/users/stripeSync.ts core/features/users/stripeSync.test.ts core/test-utils/factories/stripeEvent.ts`
- `git diff --check`

## Notes / Risks
- Supersedes #55, which currently conflicts with `main`.
- Assumes the app’s intended billing model is one canonical Pro subscription per Stripe customer, selecting the newest `active`/`trialing` subscription as authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe subscription reconciliation to handle multiple active subscriptions and paginated customer lists more reliably.

* **Refactor**
  * Streamlined subscription synchronization logic for better selection of active subscriptions and handling of stale webhook events.

* **Tests**
  * Enhanced test coverage for subscription update scenarios, including pagination, auto-selection of newest active subscriptions, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->