### PR TITLE
test(auth): cover OAuth cookie helpers

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -963,6 +963,71 @@ Move next into the lowest remaining auth coverage areas:
 at module boundaries and cover cookie read/write/delete branches in a small
 focused slice.
 
+## Slice: Auth OAuth Cookie Helpers
+
+Branch suggestion: `test/auth-oauth-cookie-helpers`
+
+PR title suggestion: `test(auth): cover OAuth cookie helpers`
+
+Files added/updated:
+
+- `core/features/auth/oauth/oauthErrorReturn.test.ts`
+- `core/features/auth/oauth/oauthLastUsed.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/auth/oauth/oauthErrorReturn.test.ts core/features/auth/oauth/oauthLastUsed.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/auth/oauth/oauthErrorReturn.test.ts core/features/auth/oauth/oauthLastUsed.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused OAuth helper slice passed after tightening the expected shared cookie
+  options: 2 test suites, 15 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 58 test suites, 382 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed after rerunning with
+  permission to write Jest's Windows temp cache: 58 test suites, 382 tests, 0
+  snapshots.
+- `npx.cmd tsc --noEmit` fails on an existing unrelated type issue in
+  `core/features/users/stripeSync.test.ts`: `[Symbol.asyncIterator]` is not a
+  known property on `ApiList<Subscription>`.
+- Focused `biome lint` passed for the two touched TypeScript test files.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 83.92% statements, 78.19% branches, 78.81%
+  functions, and 85.52% lines.
+- Updated auth OAuth cookie helper coverage:
+  - `core/features/auth/oauth/oauthErrorReturn.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+  - `core/features/auth/oauth/oauthLastUsed.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Tests now cover setting, reading, defaulting, and deleting the OAuth
+  error-return cookie through the async `next/headers` cookie store.
+- Tests now cover setting and reading the last-used OAuth provider cookie,
+  including missing and invalid values.
+- `next/headers` is mocked at the module boundary with module-level
+  `jest.mock(...)` calls before imports.
+- The first focused run failed because `oauthLastUsed.ts` intentionally spreads
+  the shared auth `COOKIE_OPTIONS`, which include `secure: false` in the test
+  environment and `path: "/"`; the test now asserts that shared contract.
+
+Recommendation:
+
+Move next into `core/features/auth/oauth/base.ts`, focusing on `OAuthClient`
+state/code-verifier cookie behavior and token/user error branches. Keep
+provider-specific clients mocked or use a small local `OAuthClient` fixture with
+mocked `fetch`.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/oauth/oauthErrorReturn.test.ts
+++ b/core/features/auth/oauth/oauthErrorReturn.test.ts
@@ -1,5 +1,39 @@
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+
 import { routes } from "@/core/data/routes";
-import { oauthErrorReturnToPath } from "@/core/features/auth/oauth/oauthErrorReturn";
+import {
+  OAUTH_ERROR_RETURN_COOKIE_KEY,
+  clearOAuthErrorReturnCookie,
+  getOAuthErrorReturnPathAndClear,
+  oauthErrorReturnToPath,
+  setOAuthErrorReturnForNextOAuth,
+} from "@/core/features/auth/oauth/oauthErrorReturn";
+
+const mockCookies = jest.mocked(cookies);
+
+function mockCookieStore(rawValue?: string) {
+  const store = {
+    get: jest.fn(() =>
+      rawValue === undefined ? undefined : { value: rawValue },
+    ),
+    set: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  mockCookies.mockResolvedValue(
+    store as unknown as Awaited<ReturnType<typeof cookies>>,
+  );
+
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("oauthErrorReturnToPath", () => {
   it("maps sign-up to routes.signUp", () => {
@@ -18,5 +52,67 @@ describe("oauthErrorReturnToPath", () => {
     expect(oauthErrorReturnToPath("https://evil.example")).toBe(routes.signIn);
     expect(oauthErrorReturnToPath("sign-up ")).toBe(routes.signIn);
     expect(oauthErrorReturnToPath("")).toBe(routes.signIn);
+  });
+});
+
+describe("setOAuthErrorReturnForNextOAuth", () => {
+  it("sets a short-lived sign-up return cookie", async () => {
+    const store = mockCookieStore();
+
+    await setOAuthErrorReturnForNextOAuth("sign-up");
+
+    expect(store.set).toHaveBeenCalledWith(
+      OAUTH_ERROR_RETURN_COOKIE_KEY,
+      "sign-up",
+      expect.objectContaining({
+        secure: true,
+        httpOnly: true,
+        sameSite: "lax",
+        expires: expect.any(Date),
+      }),
+    );
+    expect(store.delete).not.toHaveBeenCalled();
+  });
+
+  it("clears stale return cookies when starting from sign-in", async () => {
+    const store = mockCookieStore();
+
+    await setOAuthErrorReturnForNextOAuth("sign-in");
+
+    expect(store.delete).toHaveBeenCalledWith(OAUTH_ERROR_RETURN_COOKIE_KEY);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOAuthErrorReturnPathAndClear", () => {
+  it("returns the stored path and clears the cookie", async () => {
+    const store = mockCookieStore("sign-up");
+
+    await expect(getOAuthErrorReturnPathAndClear()).resolves.toBe(
+      routes.signUp,
+    );
+
+    expect(store.get).toHaveBeenCalledWith(OAUTH_ERROR_RETURN_COOKIE_KEY);
+    expect(store.delete).toHaveBeenCalledWith(OAUTH_ERROR_RETURN_COOKIE_KEY);
+  });
+
+  it("defaults tampered values to sign-in after clearing the cookie", async () => {
+    const store = mockCookieStore("https://evil.example");
+
+    await expect(getOAuthErrorReturnPathAndClear()).resolves.toBe(
+      routes.signIn,
+    );
+
+    expect(store.delete).toHaveBeenCalledWith(OAUTH_ERROR_RETURN_COOKIE_KEY);
+  });
+});
+
+describe("clearOAuthErrorReturnCookie", () => {
+  it("deletes the return cookie", async () => {
+    const store = mockCookieStore();
+
+    await clearOAuthErrorReturnCookie();
+
+    expect(store.delete).toHaveBeenCalledWith(OAUTH_ERROR_RETURN_COOKIE_KEY);
   });
 });

--- a/core/features/auth/oauth/oauthLastUsed.test.ts
+++ b/core/features/auth/oauth/oauthLastUsed.test.ts
@@ -1,7 +1,37 @@
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+
+import { COOKIE_OPTIONS } from "@/core/features/auth/constants";
 import {
   OAUTH_LAST_USED_COOKIE_KEY,
+  getLastUsedOAuthProvider,
   parseOAuthLastUsedCookieValue,
+  setLastUsedOAuthProviderCookie,
 } from "@/core/features/auth/oauth/oauthLastUsed";
+
+const mockCookies = jest.mocked(cookies);
+
+function mockCookieStore(rawValue?: string) {
+  const store = {
+    get: jest.fn(() =>
+      rawValue === undefined ? undefined : { value: rawValue },
+    ),
+    set: jest.fn(),
+  };
+
+  mockCookies.mockResolvedValue(
+    store as unknown as Awaited<ReturnType<typeof cookies>>,
+  );
+
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("parseOAuthLastUsedCookieValue", () => {
   it("returns undefined for undefined, empty, or invalid values", () => {
@@ -24,5 +54,44 @@ describe("parseOAuthLastUsedCookieValue", () => {
 describe("OAUTH_LAST_USED_COOKIE_KEY", () => {
   it("is stable for callers and tests", () => {
     expect(OAUTH_LAST_USED_COOKIE_KEY).toBe("oauth_last_used");
+  });
+});
+
+describe("setLastUsedOAuthProviderCookie", () => {
+  it("stores the allowlisted provider with auth cookie options", async () => {
+    const store = mockCookieStore();
+
+    await setLastUsedOAuthProviderCookie("github");
+
+    expect(store.set).toHaveBeenCalledWith(
+      OAUTH_LAST_USED_COOKIE_KEY,
+      "github",
+      expect.objectContaining({
+        ...COOKIE_OPTIONS,
+        expires: expect.any(Date),
+      }),
+    );
+  });
+});
+
+describe("getLastUsedOAuthProvider", () => {
+  it("returns the stored allowlisted provider", async () => {
+    const store = mockCookieStore("discord");
+
+    await expect(getLastUsedOAuthProvider()).resolves.toBe("discord");
+
+    expect(store.get).toHaveBeenCalledWith(OAUTH_LAST_USED_COOKIE_KEY);
+  });
+
+  it("returns undefined for missing or invalid cookie values", async () => {
+    const missingStore = mockCookieStore();
+
+    await expect(getLastUsedOAuthProvider()).resolves.toBeUndefined();
+    expect(missingStore.get).toHaveBeenCalledWith(OAUTH_LAST_USED_COOKIE_KEY);
+
+    const invalidStore = mockCookieStore("linkedin");
+
+    await expect(getLastUsedOAuthProvider()).resolves.toBeUndefined();
+    expect(invalidStore.get).toHaveBeenCalledWith(OAUTH_LAST_USED_COOKIE_KEY);
   });
 });

--- a/core/features/users/stripeSync.test.ts
+++ b/core/features/users/stripeSync.test.ts
@@ -31,10 +31,13 @@ const mockUpdateUserPlanAndStripeIdsIfSubscriptionMatchesDb = jest.mocked(
   updateUserPlanAndStripeIdsIfSubscriptionMatchesDb,
 );
 
+type StripeSubscriptionList = Stripe.ApiList<Stripe.Subscription> &
+  AsyncIterable<Stripe.Subscription>;
+
 function makeStripeList(
   subscriptions: Stripe.Subscription[],
   autoPagingSubscriptions = subscriptions,
-): Stripe.ApiList<Stripe.Subscription> {
+): StripeSubscriptionList {
   return {
     object: "list",
     data: subscriptions,


### PR DESCRIPTION
## Summary

- Add focused coverage for OAuth error-return cookie set/read/delete behavior.
- Add focused coverage for last-used OAuth provider cookie set/read behavior.
- Fix the Stripe sync test fixture type so `tsc --noEmit` passes.

## Verification

- `npm.cmd test -- core/features/auth/oauth/oauthErrorReturn.test.ts core/features/auth/oauth/oauthLastUsed.test.ts --runInBand`
- `npm.cmd test -- core/features/users/stripeSync.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/auth/oauth/oauthErrorReturn.test.ts core/features/auth/oauth/oauthLastUsed.test.ts core/features/users/stripeSync.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- Raw `npm test` is blocked locally by the unsigned PowerShell `npm.ps1` shim before Jest starts.
- Coverage after this slice: 83.92% statements, 78.19% branches, 78.81% functions, 85.52% lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for OAuth authentication cookie operations, including tests for setting, retrieving, and clearing error return cookies and tracking last-used provider information.
  * Enhanced test typing for Stripe subscription handling to improve type safety.

* **Documentation**
  * Updated test coverage documentation with detailed test suites and coverage metrics for OAuth cookie helper functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->