### PR TITLE
test(auth): cover GitHub OAuth resolver

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1087,6 +1087,71 @@ Continue the OAuth internals slice with provider-specific client gaps in
 `core/features/auth/oauth/github.ts`, `google.ts`, and `discord.ts`, keeping
 network behavior mocked through `OAuthClient` or direct resolver helpers.
 
+## Slice: Auth OAuth GitHub Provider
+
+Branch suggestion: `test/auth-oauth-github-provider`
+
+PR title suggestion: `test(auth): cover GitHub OAuth resolver`
+
+Files added/updated:
+
+- `core/features/auth/oauth/github.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/auth/oauth/github.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/auth/oauth/github.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused GitHub OAuth provider slice passed: 1 test suite, 8 tests, 0
+  snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 59 test suites, 399 tests, 0
+  snapshots.
+- Initial `npm.cmd run test:coverage -- --runInBand` failed with `EPERM`
+  writing Jest's Windows temp haste-map cache; rerunning with permission to
+  write that cache passed: 59 test suites, 399 tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 91.01% statements, 84.42% branches, 85.92%
+  functions, and 92.99% lines.
+- Updated auth OAuth provider coverage:
+  - `core/features/auth/oauth/github.ts`: 100% statements, 100% branches, 100%
+    functions, and 100% lines.
+  - `core/features/auth/oauth/base.ts`: 97.91% statements, 92.85% branches,
+    100% functions, and 97.91% lines.
+  - `core/features/auth/oauth/google.ts`: 62.5% statements, 100% branches, 50%
+    functions, and 71.42% lines.
+  - `core/features/auth/oauth/discord.ts`: 78.57% statements, 100% branches,
+    50% functions, and 76.92% lines.
+
+Notes:
+
+- Added resolver-path tests for GitHub's secondary `/user/emails` request,
+  covering verified email success, invalid email payload wrapping, no verified
+  email handling, and email endpoint fetch failures.
+- Tests exercise the real `createGithubOAuthClient` through
+  `OAuthClient.fetchUser` while mocking only `fetch` and using a local cookie
+  store fixture.
+- Test email fixtures use synthetic `@test.local` addresses only.
+
+Recommendation:
+
+Continue the provider internals slice with small factory/client coverage for
+`core/features/auth/oauth/google.ts` and `core/features/auth/oauth/discord.ts`.
+Target client creation behavior through `OAuthClient.fetchUser` or
+`createAuthUrl`, keeping base client branches out of scope unless a provider
+specific gap requires them.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/oauth/github.test.ts
+++ b/core/features/auth/oauth/github.test.ts
@@ -4,7 +4,63 @@ jest.mock("@/core/data/env/server", () => ({
   },
 }));
 
-import { selectGithubEmailFromVerifiedList } from "@/core/features/auth/oauth/github";
+import {
+  createGithubOAuthClient,
+  selectGithubEmailFromVerifiedList,
+} from "@/core/features/auth/oauth/github";
+import { OAuthNoVerifiedEmailError } from "@/core/features/auth/oauth/errors";
+import type { Cookies } from "@/core/features/auth/oauth/types";
+
+function createCookieStore(values: Record<string, string> = {}) {
+  const store = {
+    get: jest.fn((key: string) => {
+      const value = values[key];
+      return value === undefined ? undefined : { name: key, value };
+    }),
+    delete: jest.fn(),
+    set: jest.fn(),
+  } satisfies Cookies;
+
+  return store;
+}
+
+function createCallbackCookieStore() {
+  return createCookieStore({
+    "__Host-oauth_state": "stored-state",
+    "__Host-oauth_code_verifier": "code-verifier",
+  });
+}
+
+function createClient() {
+  return createGithubOAuthClient({
+    clientId: "github-client-id",
+    clientSecret: "github-client-secret",
+  });
+}
+
+function mockTokenAndGithubUser() {
+  return jest
+    .mocked(fetch)
+    .mockResolvedValueOnce(
+      Response.json({
+        access_token: "github-access-token",
+        token_type: "Bearer",
+      }),
+    )
+    .mockResolvedValueOnce(
+      Response.json({
+        id: 123456,
+        name: null,
+        login: "octo-candidate",
+        email: null,
+      }),
+    );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
 
 describe("selectGithubEmailFromVerifiedList", () => {
   it("prefers primary and verified", () => {
@@ -40,5 +96,117 @@ describe("selectGithubEmailFromVerifiedList", () => {
         { email: "User@Example.COM", primary: true, verified: true },
       ]),
     ).toBe("user@example.com");
+  });
+});
+
+describe("createGithubOAuthClient", () => {
+  it("resolves a GitHub user from the verified emails endpoint", async () => {
+    const fetchMock = mockTokenAndGithubUser().mockResolvedValueOnce(
+      Response.json([
+        {
+          email: "secondary@test.local",
+          primary: false,
+          verified: true,
+        },
+        {
+          email: "Primary@Test.Local",
+          primary: true,
+          verified: true,
+        },
+      ]),
+    );
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).resolves.toEqual({
+      id: "123456",
+      email: "primary@test.local",
+      name: "octo-candidate",
+      emailVerified: true,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.github.com/user/emails",
+      {
+        headers: {
+          Authorization: "Bearer github-access-token",
+          Accept: "application/vnd.github+json",
+        },
+      },
+    );
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
+  });
+
+  it("rejects invalid GitHub email payloads with wrapped resolver context", async () => {
+    const fetchMock = mockTokenAndGithubUser().mockResolvedValueOnce(
+      Response.json([{ email: "not-an-email", primary: true, verified: true }]),
+    );
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).rejects.toMatchObject({
+      message: "Failed to fetch user",
+      cause: expect.objectContaining({
+        message: "Failed to fetch GitHub user emails",
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
+  });
+
+  it("throws OAuthNoVerifiedEmailError when GitHub has no verified emails", async () => {
+    mockTokenAndGithubUser().mockResolvedValueOnce(
+      Response.json([
+        {
+          email: "unverified@test.local",
+          primary: true,
+          verified: false,
+        },
+      ]),
+    );
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).rejects.toMatchObject({
+      cause: expect.any(OAuthNoVerifiedEmailError),
+    });
+
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
+  });
+
+  it("wraps GitHub email endpoint fetch failures", async () => {
+    const cause = new Error("GitHub emails unavailable");
+
+    mockTokenAndGithubUser().mockRejectedValueOnce(cause);
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).rejects.toMatchObject({
+      message: "Failed to fetch user",
+      cause: expect.objectContaining({
+        message: "Failed to fetch GitHub user emails",
+        cause,
+      }),
+    });
+
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add GitHub OAuth provider tests for the secondary `/user/emails` resolver flow
- Cover verified email success, invalid email payload wrapping, no verified email handling, and email endpoint fetch failures
- Update the coverage plan with the latest commands, results, coverage numbers, and next recommendation

## Verification

- `npm.cmd test -- core/features/auth/oauth/github.test.ts --runInBand`
- `npm test` blocked by unsigned `npm.ps1` before Jest starts
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/auth/oauth/github.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- `core/features/auth/oauth/github.ts` now reports 100% statements, branches, functions, and lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded GitHub OAuth test coverage with new test suite for OAuth client creation, including email verification, error handling, and token/cookie management scenarios.

* **Documentation**
  * Updated test coverage documentation to track GitHub OAuth provider test additions and coverage metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->