### PR TITLE
test(auth): add OAuth provider client coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1152,6 +1152,65 @@ Target client creation behavior through `OAuthClient.fetchUser` or
 `createAuthUrl`, keeping base client branches out of scope unless a provider
 specific gap requires them.
 
+### OAuth Google and Discord Factory Slice - 2026-05-26
+
+Files/tests updated:
+
+- `core/features/auth/oauth/google.test.ts`
+- `core/features/auth/oauth/discord.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/auth/oauth/google.test.ts core/features/auth/oauth/discord.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/auth/oauth/google.test.ts core/features/auth/oauth/discord.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused Google/Discord OAuth provider slice passed: 2 test suites, 18 tests,
+  0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 59 test suites, 403 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 59 test suites, 403
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test files.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 91.29% statements, 84.42% branches, 87.03%
+  functions, and 93.29% lines.
+- Updated auth OAuth provider coverage:
+  - `core/features/auth/oauth/google.ts`: 87.5% statements, 100% branches,
+    100% functions, and 100% lines.
+  - `core/features/auth/oauth/discord.ts`: 100% statements, 100% branches,
+    100% functions, and 100% lines.
+  - `core/features/auth/oauth/github.ts`: 100% statements, 100% branches, 100%
+    functions, and 100% lines.
+  - `core/features/auth/oauth/base.ts`: 97.91% statements, 92.85% branches,
+    100% functions, and 97.91% lines.
+
+Notes:
+
+- Added provider-factory coverage through the real Google and Discord OAuth
+  clients using `createAuthUrl` and `OAuthClient.fetchUser`.
+- Tests mock only `fetch` and assert provider-specific auth URLs, scopes, user
+  endpoints, user mapping, and callback cookie cleanup.
+- Updated Discord test email fixtures to synthetic `@test.local` addresses.
+- The known Windows temp-cache permission retry was not needed in this
+  coverage run.
+
+Recommendation:
+
+Continue with a small OAuth config/client edge slice if useful, especially
+`core/features/auth/oauth/config.ts`, or move back to the broader plan with
+`core/features/billing/webhookHelpers.ts` and `core/lib/errorToast.tsx`.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/auth/oauth/discord.test.ts
+++ b/core/features/auth/oauth/discord.test.ts
@@ -5,16 +5,50 @@ jest.mock("@/core/data/env/server", () => ({
 }));
 
 import {
+  createDiscordOAuthClient,
   discordUserSchema,
   resolveDiscordOAuthUser,
 } from "@/core/features/auth/oauth/discord";
 import { OAuthMissingEmailError } from "@/core/features/auth/oauth/errors";
+import type { Cookies } from "@/core/features/auth/oauth/types";
 
 const basePayload = {
   id: "80351110224678912",
   username: "Nelly",
   global_name: null as string | null,
 };
+
+function createCookieStore(values: Record<string, string> = {}) {
+  const store = {
+    get: jest.fn((key: string) => {
+      const value = values[key];
+      return value === undefined ? undefined : { name: key, value };
+    }),
+    delete: jest.fn(),
+    set: jest.fn(),
+  } satisfies Cookies;
+
+  return store;
+}
+
+function createCallbackCookieStore() {
+  return createCookieStore({
+    "__Host-oauth_state": "stored-state",
+    "__Host-oauth_code_verifier": "code-verifier",
+  });
+}
+
+function createClient() {
+  return createDiscordOAuthClient({
+    clientId: "discord-client-id",
+    clientSecret: "discord-client-secret",
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
 
 describe("discordUserSchema", () => {
   it("accepts payload without email field", () => {
@@ -41,7 +75,7 @@ describe("discordUserSchema", () => {
   it("accepts valid email", () => {
     const result = discordUserSchema.safeParse({
       ...basePayload,
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
     });
 
     expect(result.success).toBe(true);
@@ -94,14 +128,14 @@ describe("resolveDiscordOAuthUser", () => {
   it("returns normalized user when email is present", async () => {
     const parsed = discordUserSchema.parse({
       ...basePayload,
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
       verified: true,
       global_name: "Display",
     });
 
     await expect(resolveDiscordOAuthUser(parsed)).resolves.toEqual({
       id: "80351110224678912",
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
       name: "Display",
       emailVerified: true,
     });
@@ -110,7 +144,7 @@ describe("resolveDiscordOAuthUser", () => {
   it("sets emailVerified false when Discord verified is false", async () => {
     const parsed = discordUserSchema.parse({
       ...basePayload,
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
       verified: false,
     });
 
@@ -122,7 +156,7 @@ describe("resolveDiscordOAuthUser", () => {
   it("uses username when global_name is null", async () => {
     const parsed = discordUserSchema.parse({
       ...basePayload,
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
       verified: true,
       global_name: null,
     });
@@ -136,13 +170,88 @@ describe("resolveDiscordOAuthUser", () => {
   it("lowercases email", async () => {
     const parsed = discordUserSchema.parse({
       ...basePayload,
-      email: "Nelly@Discord.COM",
+      email: "Candidate@Test.Local",
       verified: true,
     });
 
     await expect(resolveDiscordOAuthUser(parsed)).resolves.toMatchObject({
-      email: "nelly@discord.com",
+      email: "candidate@test.local",
       emailVerified: true,
     });
+  });
+});
+
+describe("createDiscordOAuthClient", () => {
+  it("creates a Discord authorization URL with provider scopes", () => {
+    const cookies = createCookieStore();
+
+    const redirect = createClient().createAuthUrl(cookies);
+
+    const url = new URL(redirect);
+    const [, state] = cookies.set.mock.calls[0];
+
+    expect(url.origin + url.pathname).toBe(
+      "https://discord.com/oauth2/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe("discord-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/discord",
+    );
+    expect(url.searchParams.get("scope")).toBe("identify email");
+    expect(url.searchParams.get("state")).toBe(state);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(cookies.set).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+      expect.any(String),
+      expect.objectContaining({
+        secure: true,
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+      }),
+    );
+  });
+
+  it("fetches and resolves a Discord user through the provider endpoints", async () => {
+    const fetchMock = jest
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        Response.json({
+          access_token: "discord-access-token",
+          token_type: "Bearer",
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          ...basePayload,
+          email: "Candidate@Test.Local",
+          verified: true,
+          global_name: "Display",
+        }),
+      );
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).resolves.toEqual({
+      id: "80351110224678912",
+      email: "candidate@test.local",
+      name: "Display",
+      emailVerified: true,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/users/@me",
+      {
+        headers: {
+          Authorization: "Bearer discord-access-token",
+        },
+      },
+    );
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
   });
 });

--- a/core/features/auth/oauth/google.test.ts
+++ b/core/features/auth/oauth/google.test.ts
@@ -4,20 +4,56 @@ jest.mock("@/core/data/env/server", () => ({
   },
 }));
 
-import { mapGoogleUserToResolved } from "@/core/features/auth/oauth/google";
+import {
+  createGoogleOAuthClient,
+  mapGoogleUserToResolved,
+} from "@/core/features/auth/oauth/google";
+import type { Cookies } from "@/core/features/auth/oauth/types";
+
+function createCookieStore(values: Record<string, string> = {}) {
+  const store = {
+    get: jest.fn((key: string) => {
+      const value = values[key];
+      return value === undefined ? undefined : { name: key, value };
+    }),
+    delete: jest.fn(),
+    set: jest.fn(),
+  } satisfies Cookies;
+
+  return store;
+}
+
+function createCallbackCookieStore() {
+  return createCookieStore({
+    "__Host-oauth_state": "stored-state",
+    "__Host-oauth_code_verifier": "code-verifier",
+  });
+}
+
+function createClient() {
+  return createGoogleOAuthClient({
+    clientId: "google-client-id",
+    clientSecret: "google-client-secret",
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
 
 describe("mapGoogleUserToResolved", () => {
   it("maps email_verified true to emailVerified true", () => {
     expect(
       mapGoogleUserToResolved({
         sub: "sub-id",
-        email: "a@b.com",
+        email: "candidate@test.local",
         name: "A",
         email_verified: true,
       }),
     ).toEqual({
       id: "sub-id",
-      email: "a@b.com",
+      email: "candidate@test.local",
       name: "A",
       emailVerified: true,
     });
@@ -27,7 +63,7 @@ describe("mapGoogleUserToResolved", () => {
     expect(
       mapGoogleUserToResolved({
         sub: "sub-id",
-        email: "a@b.com",
+        email: "candidate@test.local",
         name: "A",
       }),
     ).toMatchObject({
@@ -39,12 +75,87 @@ describe("mapGoogleUserToResolved", () => {
     expect(
       mapGoogleUserToResolved({
         sub: "sub-id",
-        email: "a@b.com",
+        email: "candidate@test.local",
         name: "A",
         email_verified: false,
       }),
     ).toMatchObject({
       emailVerified: false,
     });
+  });
+});
+
+describe("createGoogleOAuthClient", () => {
+  it("creates a Google authorization URL with provider scopes", () => {
+    const cookies = createCookieStore();
+
+    const redirect = createClient().createAuthUrl(cookies);
+
+    const url = new URL(redirect);
+    const [, state] = cookies.set.mock.calls[0];
+
+    expect(url.origin + url.pathname).toBe(
+      "https://accounts.google.com/o/oauth2/auth",
+    );
+    expect(url.searchParams.get("client_id")).toBe("google-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:3000/google",
+    );
+    expect(url.searchParams.get("scope")).toBe("profile email");
+    expect(url.searchParams.get("state")).toBe(state);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(cookies.set).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+      expect.any(String),
+      expect.objectContaining({
+        secure: true,
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+      }),
+    );
+  });
+
+  it("fetches and maps a Google user through the provider endpoints", async () => {
+    const fetchMock = jest
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        Response.json({
+          access_token: "google-access-token",
+          token_type: "Bearer",
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          sub: "google-user-id",
+          email: "candidate@test.local",
+          name: "Test Candidate",
+          email_verified: true,
+        }),
+      );
+    const cookies = createCallbackCookieStore();
+
+    await expect(
+      createClient().fetchUser("oauth-code", "stored-state", cookies),
+    ).resolves.toEqual({
+      id: "google-user-id",
+      email: "candidate@test.local",
+      name: "Test Candidate",
+      emailVerified: true,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://www.googleapis.com/oauth2/v3/userinfo",
+      {
+        headers: {
+          Authorization: "Bearer google-access-token",
+        },
+      },
+    );
+    expect(cookies.delete).toHaveBeenCalledWith("__Host-oauth_state");
+    expect(cookies.delete).toHaveBeenCalledWith(
+      "__Host-oauth_code_verifier",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add Google and Discord OAuth provider factory/client tests through real `createAuthUrl` and `fetchUser` flows
- Assert provider-specific scopes, auth URLs, userinfo endpoints, user mapping, and callback cookie cleanup
- Update `TEST_COVERAGE_PLAN.md` with the latest verification and coverage results

## Verification

- `npm.cmd test -- core/features/auth/oauth/google.test.ts core/features/auth/oauth/discord.test.ts --runInBand`
- `npm test` blocked by unsigned PowerShell `npm.ps1`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/auth/oauth/google.test.ts core/features/auth/oauth/discord.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- Uses only synthetic `@test.local` email fixtures
- No production dependencies added