### PR TITLE
test(billing): add webhook helper coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1271,6 +1271,65 @@ Move next to the broader uncovered areas:
 with `webhookHelpers.ts` if branch coverage is the priority, or
 `errorToast.tsx` for a small UI utility slice.
 
+## Slice: Billing Webhook Helpers
+
+Files added/updated:
+
+- `core/features/billing/webhookHelpers.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/billing/webhookHelpers.test.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/features/billing/webhookHelpers.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused billing helper slice passed: 1 test suite, 12 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 59 test suites, 416 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 59 test suites, 416
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 93.24% statements, 86.71% branches, 89.25%
+  functions, and 95.22% lines.
+- Updated billing helper coverage:
+  - `core/features/billing/webhookHelpers.ts`: 88.88% statements, 65%
+    branches, 100% functions, and 88.7% lines.
+- Related billing coverage:
+  - `core/features/billing/stripeEventTypes.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+
+Notes:
+
+- Added focused coverage for processed-event marking, remediation marking with
+  512-character detail truncation, missing remediation-column rollout fallback,
+  unexpected remediation write failures, first-writer event claiming, duplicate
+  processed/remediation/processing states, repeatedly missing claim rows, and
+  unclaim deletion.
+- The known unsigned `npm.ps1` PowerShell blocker remains the only verification
+  issue; the working `.cmd` test, coverage, type-check, and lint paths passed.
+- No customer email fixtures were used in this slice.
+
+Recommendation:
+
+Continue with the remaining uncovered `webhookHelpers.ts` checkout fulfillment
+branches if maximizing billing helper coverage is still the goal: missing
+`metadata.userId`, incomplete session customer/subscription payloads, missing
+Stripe client, expanded customer/subscription object IDs, trialing subscription
+status, mismatched subscription customer, and the non-`Error` remediation
+fallback guard. Otherwise, move to `core/lib/errorToast.tsx` for the next small,
+high-gap utility slice.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/features/billing/webhookHelpers.test.ts
+++ b/core/features/billing/webhookHelpers.test.ts
@@ -3,7 +3,12 @@ jest.mock("@/core/features/billing/stripe", () => ({
 }));
 
 jest.mock("@/core/drizzle/db", () => ({
-  db: {},
+  db: {
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    select: jest.fn(),
+  },
 }));
 
 jest.mock("@/core/features/users/db", () => ({
@@ -12,14 +17,32 @@ jest.mock("@/core/features/users/db", () => ({
 
 import type Stripe from "stripe";
 
+import { db } from "@/core/drizzle/db";
 import { getStripe } from "@/core/features/billing/stripe";
 import { updateUserPlanAndStripeIdsDb } from "@/core/features/users/db";
 import {
   makeStripeCheckoutSession,
   makeStripeSubscription,
 } from "@/core/test-utils/factories";
+import {
+  createDrizzleMutationChainMock,
+  type DrizzleMutationChainMock,
+} from "@/core/test-utils/mocks/db";
 
-import { fulfillCheckoutSession } from "./webhookHelpers";
+import {
+  claimEvent,
+  fulfillCheckoutSession,
+  markStripeEventProcessed,
+  markStripeEventRemediationRequired,
+  unclaimEvent,
+} from "./webhookHelpers";
+
+type MockWebhookDb = {
+  insert: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+  select: jest.Mock;
+};
 
 const retrieveSubscription = jest.fn<
   Promise<Stripe.Subscription>,
@@ -36,13 +59,38 @@ const mockGetStripe = jest.mocked(getStripe);
 const mockUpdateUserPlanAndStripeIdsDb = jest.mocked(
   updateUserPlanAndStripeIdsDb,
 );
+const mockDb = db as unknown as MockWebhookDb;
+
+function primeInsertReturning(
+  rows: Array<{ id: string }>,
+): DrizzleMutationChainMock<Array<{ id: string }>> {
+  const insertChain = createDrizzleMutationChainMock(rows);
+  mockDb.insert.mockReturnValueOnce(insertChain);
+
+  return insertChain;
+}
+
+function primeSelectRows(
+  rows: Array<{ state: "processed" | "processing" | "remediation_required" }>,
+): DrizzleMutationChainMock<typeof rows> {
+  const selectChain = createDrizzleMutationChainMock(rows);
+  mockDb.select.mockReturnValueOnce(selectChain);
+
+  return selectChain;
+}
+
+function makeCodedError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`database error ${code}`), { code });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("fulfillCheckoutSession", () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-
     mockGetStripe.mockReturnValue(stripe);
     mockUpdateUserPlanAndStripeIdsDb.mockResolvedValue(undefined);
     consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -94,5 +142,125 @@ describe("fulfillCheckoutSession", () => {
 
     expect(retrieveSubscription).toHaveBeenCalledWith("sub_test_canceled");
     expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+  });
+});
+
+describe("markStripeEventProcessed", () => {
+  it("marks a claimed Stripe event as processed", async () => {
+    const updateChain = createDrizzleMutationChainMock();
+    mockDb.update.mockReturnValueOnce(updateChain);
+
+    await expect(
+      markStripeEventProcessed("evt_test_processed"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(updateChain.set).toHaveBeenCalledWith({ state: "processed" });
+    expect(updateChain.where).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("markStripeEventRemediationRequired", () => {
+  it("marks a claimed Stripe event as needing remediation with a bounded detail", async () => {
+    const updateChain = createDrizzleMutationChainMock();
+    mockDb.update.mockReturnValueOnce(updateChain);
+    const longDetail = "x".repeat(600);
+
+    await expect(
+      markStripeEventRemediationRequired("evt_test_remediation", longDetail),
+    ).resolves.toBeUndefined();
+
+    const setPayload = updateChain.set.mock.calls[0]?.[0];
+    expect(setPayload).toEqual({
+      state: "remediation_required",
+      remediationDetail: `${"x".repeat(509)}...`,
+    });
+    expect(String(setPayload?.remediationDetail)).toHaveLength(512);
+    expect(updateChain.where).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves rollout compatibility when the remediation column is missing", async () => {
+    const updateChain = createDrizzleMutationChainMock();
+    updateChain.where.mockImplementationOnce(() => {
+      throw makeCodedError("42703");
+    });
+    mockDb.update.mockReturnValueOnce(updateChain);
+
+    await expect(
+      markStripeEventRemediationRequired("evt_test_old_schema", "unclaim boom"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rethrows unexpected database errors", async () => {
+    const updateChain = createDrizzleMutationChainMock();
+    const error = makeCodedError("40001");
+    updateChain.where.mockImplementationOnce(() => {
+      throw error;
+    });
+    mockDb.update.mockReturnValueOnce(updateChain);
+
+    await expect(
+      markStripeEventRemediationRequired("evt_test_db_error", "unclaim boom"),
+    ).rejects.toBe(error);
+  });
+});
+
+describe("claimEvent", () => {
+  it("claims a new Stripe event when the insert wins", async () => {
+    const insertChain = primeInsertReturning([{ id: "evt_test_claimed" }]);
+
+    await expect(
+      claimEvent("evt_test_claimed", "checkout.session.completed"),
+    ).resolves.toBe("claimed");
+
+    expect(insertChain.values).toHaveBeenCalledWith({
+      id: "evt_test_claimed",
+      type: "checkout.session.completed",
+      state: "processing",
+    });
+    expect(insertChain.onConflictDoNothing).toHaveBeenCalledTimes(1);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["processed", "duplicate_processed"],
+    ["remediation_required", "duplicate_remediation"],
+    ["processing", "duplicate_in_progress"],
+  ] as const)(
+    "returns %s duplicate state when the event row already exists",
+    async (state, expectedResult) => {
+      primeInsertReturning([]);
+      primeSelectRows([{ state }]);
+
+      await expect(
+        claimEvent("evt_test_duplicate", "customer.subscription.updated"),
+      ).resolves.toBe(expectedResult);
+    },
+  );
+
+  it("treats repeatedly missing rows as an in-progress duplicate", async () => {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      primeInsertReturning([]);
+      primeSelectRows([]);
+    }
+
+    await expect(
+      claimEvent("evt_test_missing", "checkout.session.completed"),
+    ).resolves.toBe("duplicate_in_progress");
+
+    expect(mockDb.insert).toHaveBeenCalledTimes(5);
+    expect(mockDb.select).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("unclaimEvent", () => {
+  it("deletes the claimed Stripe event row so Stripe can retry it", async () => {
+    const deleteChain = createDrizzleMutationChainMock();
+    mockDb.delete.mockReturnValueOnce(deleteChain);
+
+    await expect(unclaimEvent("evt_test_retry")).resolves.toBeUndefined();
+
+    expect(mockDb.delete).toHaveBeenCalledTimes(1);
+    expect(deleteChain.where).toHaveBeenCalledTimes(1);
   });
 });

--- a/core/features/billing/webhookHelpers.test.ts
+++ b/core/features/billing/webhookHelpers.test.ts
@@ -84,7 +84,7 @@ function makeCodedError(code: string): Error & { code: string } {
 }
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  jest.resetAllMocks();
 });
 
 describe("fulfillCheckoutSession", () => {


### PR DESCRIPTION
## Summary
- Add focused tests for billing webhook helper idempotency paths
- Cover processed/remediation marking, remediation detail truncation, duplicate event states, missing claim rows, and unclaim deletion
- Update the test coverage plan with verification results and next recommendations

## Verification
- `npm.cmd test -- core/features/billing/webhookHelpers.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/billing/webhookHelpers.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for billing webhook processing with comprehensive scenarios covering event lifecycle management and error handling.

* **Documentation**
  * Updated test coverage documentation for billing webhook functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->