### PR TITLE
test(billing): cover webhook fulfillment branches

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1271,7 +1271,7 @@ Move next to the broader uncovered areas:
 with `webhookHelpers.ts` if branch coverage is the priority, or
 `errorToast.tsx` for a small UI utility slice.
 
-## Slice: Billing Webhook Helpers
+## Slice: Billing Webhook Helpers - 2026-05-26
 
 Files added/updated:
 
@@ -1289,22 +1289,22 @@ Commands run:
 
 Result:
 
-- Focused billing helper slice passed: 1 test suite, 12 tests, 0 snapshots.
+- Focused billing helper slice passed: 1 test suite, 20 tests, 0 snapshots.
 - `npm test` still fails in PowerShell before Jest starts because the unsigned
   `npm.ps1` shim is blocked by the local execution policy.
-- `npm.cmd test -- --runInBand` passed: 59 test suites, 416 tests, 0
+- `npm.cmd test -- --runInBand` passed: 59 test suites, 424 tests, 0
   snapshots.
-- `npm.cmd run test:coverage -- --runInBand` passed: 59 test suites, 416
+- `npm.cmd run test:coverage -- --runInBand` passed: 59 test suites, 424
   tests, 0 snapshots.
 - `npx.cmd tsc --noEmit` passed.
 - Focused `biome lint` passed for the touched TypeScript test file.
   `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
   checked by Biome.
-- Updated coverage summary: 93.24% statements, 86.71% branches, 89.25%
-  functions, and 95.22% lines.
+- Updated coverage summary: 93.64% statements, 88.75% branches, 89.25%
+  functions, and 95.65% lines.
 - Updated billing helper coverage:
-  - `core/features/billing/webhookHelpers.ts`: 88.88% statements, 65%
-    branches, 100% functions, and 88.7% lines.
+  - `core/features/billing/webhookHelpers.ts`: 100% statements, 97.5%
+    branches, 100% functions, and 100% lines.
 - Related billing coverage:
   - `core/features/billing/stripeEventTypes.ts`: 100% statements, 100%
     branches, 100% functions, and 100% lines.
@@ -1313,22 +1313,22 @@ Notes:
 
 - Added focused coverage for processed-event marking, remediation marking with
   512-character detail truncation, missing remediation-column rollout fallback,
-  unexpected remediation write failures, first-writer event claiming, duplicate
-  processed/remediation/processing states, repeatedly missing claim rows, and
-  unclaim deletion.
+  unexpected remediation write failures, non-`Error` remediation failure
+  handling, first-writer event claiming, duplicate processed/remediation/
+  processing states, repeatedly missing claim rows, and unclaim deletion.
+- Added checkout fulfillment branch coverage for unpaid sessions, missing
+  `metadata.userId`, incomplete customer/subscription payloads, missing Stripe
+  client, expanded checkout customer/subscription object IDs, `trialing`
+  subscription status, and mismatched subscription customers.
 - The known unsigned `npm.ps1` PowerShell blocker remains the only verification
   issue; the working `.cmd` test, coverage, type-check, and lint paths passed.
 - No customer email fixtures were used in this slice.
 
 Recommendation:
 
-Continue with the remaining uncovered `webhookHelpers.ts` checkout fulfillment
-branches if maximizing billing helper coverage is still the goal: missing
-`metadata.userId`, incomplete session customer/subscription payloads, missing
-Stripe client, expanded customer/subscription object IDs, trialing subscription
-status, mismatched subscription customer, and the non-`Error` remediation
-fallback guard. Otherwise, move to `core/lib/errorToast.tsx` for the next small,
-high-gap utility slice.
+Move to `core/lib/errorToast.tsx` for the next small, high-gap utility slice.
+Focus on error message selection and toast invocation behavior while mocking
+only the toast boundary.
 
 ## Coverage Priorities
 

--- a/core/features/billing/webhookHelpers.test.ts
+++ b/core/features/billing/webhookHelpers.test.ts
@@ -143,6 +143,133 @@ describe("fulfillCheckoutSession", () => {
     expect(retrieveSubscription).toHaveBeenCalledWith("sub_test_canceled");
     expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
   });
+
+  it("skips unpaid checkout sessions without retrieving the subscription", async () => {
+    const session = makeStripeCheckoutSession({
+      paymentStatus: "unpaid",
+    });
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+    expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips paid checkout sessions that are missing metadata.userId", async () => {
+    const session = makeStripeCheckoutSession({
+      id: "cs_test_missing_user",
+      userId: null,
+    });
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "fulfillCheckoutSession: missing metadata.userId",
+      "cs_test_missing_user",
+    );
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+    expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["customer", { customerId: null, subscriptionId: "sub_test_incomplete" }],
+    ["subscription", { customerId: "cus_test_incomplete", subscriptionId: null }],
+  ] as const)(
+    "skips paid checkout sessions that are missing the %s id",
+    async (_missingField, overrides) => {
+      const session = makeStripeCheckoutSession({
+        id: "cs_test_incomplete",
+        userId: "user-test",
+        ...overrides,
+      });
+
+      await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "fulfillCheckoutSession: incomplete session payload",
+        ),
+        "cs_test_incomplete",
+      );
+      expect(retrieveSubscription).not.toHaveBeenCalled();
+      expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+    },
+  );
+
+  it("skips paid checkout sessions when the Stripe client is unavailable", async () => {
+    mockGetStripe.mockReturnValueOnce(null);
+    const session = makeStripeCheckoutSession({
+      userId: "user-test",
+      customerId: "cus_test_no_client",
+      subscriptionId: "sub_test_no_client",
+    });
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+    expect(mockGetStripe).toHaveBeenCalledTimes(1);
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+    expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses expanded checkout customer and subscription object ids", async () => {
+    const session = makeStripeCheckoutSession({
+      userId: "user-test",
+      customerId: "cus_test_expanded",
+      subscriptionId: "sub_test_expanded",
+    });
+    session.customer = {
+      id: "cus_test_expanded",
+    } as Stripe.Customer;
+    session.subscription = {
+      id: "sub_test_expanded",
+    } as Stripe.Subscription;
+    retrieveSubscription.mockResolvedValueOnce(
+      makeStripeSubscription({
+        id: "sub_test_expanded",
+        customer: {
+          id: "cus_test_expanded",
+        } as Stripe.Customer,
+        status: "trialing",
+      }),
+    );
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(true);
+
+    expect(retrieveSubscription).toHaveBeenCalledWith("sub_test_expanded");
+    expect(mockUpdateUserPlanAndStripeIdsDb).toHaveBeenCalledWith("user-test", {
+      plan: "pro",
+      stripeCustomerId: "cus_test_expanded",
+      stripeSubscriptionId: "sub_test_expanded",
+    });
+  });
+
+  it("skips sessions whose retrieved subscription belongs to a different customer", async () => {
+    const session = makeStripeCheckoutSession({
+      id: "cs_test_customer_mismatch",
+      userId: "user-test",
+      customerId: "cus_test_checkout",
+      subscriptionId: "sub_test_mismatch",
+    });
+    retrieveSubscription.mockResolvedValueOnce(
+      makeStripeSubscription({
+        id: "sub_test_mismatch",
+        customer: "cus_test_other",
+        status: "active",
+      }),
+    );
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "fulfillCheckoutSession: subscription is not fulfillable",
+      ),
+      "cs_test_customer_mismatch",
+    );
+    expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+  });
 });
 
 describe("markStripeEventProcessed", () => {
@@ -202,6 +329,19 @@ describe("markStripeEventRemediationRequired", () => {
     await expect(
       markStripeEventRemediationRequired("evt_test_db_error", "unclaim boom"),
     ).rejects.toBe(error);
+  });
+
+  it("rethrows coded non-Error values instead of treating them as rollout compatibility", async () => {
+    const updateChain = createDrizzleMutationChainMock();
+    const thrownValue = { code: "42703" };
+    updateChain.where.mockImplementationOnce(() => {
+      throw thrownValue;
+    });
+    mockDb.update.mockReturnValueOnce(updateChain);
+
+    await expect(
+      markStripeEventRemediationRequired("evt_test_non_error", "unclaim boom"),
+    ).rejects.toBe(thrownValue);
   });
 });
 


### PR DESCRIPTION
## Summary

- Added billing webhook helper tests for checkout fulfillment edge cases.
- Covered missing user metadata, incomplete customer/subscription payloads, unavailable Stripe client, expanded Stripe object IDs, trialing subscriptions, mismatched customers, and non-Error remediation failures.
- Updated `TEST_COVERAGE_PLAN.md` with latest verification and coverage results.

## Verification

- `npm.cmd test -- core/features/billing/webhookHelpers.test.ts --runInBand`
- `npm test` blocked by unsigned `npm.ps1` PowerShell execution policy before Jest starts
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/features/billing/webhookHelpers.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes / Risks

- No production code changes.
- No customer email fixtures were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with additional negative-path and edge-case scenarios, including handling missing data, unavailable services, and customer/subscription validation.

* **Documentation**
  * Updated test coverage metrics and tracking plan with new benchmark results and next testing focus areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->