### PR TITLE
test(lib): cover error toast behavior

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1330,6 +1330,61 @@ Move to `core/lib/errorToast.tsx` for the next small, high-gap utility slice.
 Focus on error message selection and toast invocation behavior while mocking
 only the toast boundary.
 
+### Error Toast Utility Slice - 2026-05-26
+
+Files/tests added or updated:
+
+- `core/lib/errorToast.test.tsx`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/lib/errorToast.test.tsx --runInBand`
+- `npm test`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/lib/errorToast.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused error toast slice passed: 1 test suite, 6 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 60 test suites, 430 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 60 test suites, 430
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed after narrowing the toast action to a React
+  element before rendering it in the test.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 94.73% statements, 90.31% branches, 90%
+  functions, and 96.73% lines.
+- Updated error toast coverage:
+  - `core/lib/errorToast.tsx`: 100% statements, 100% branches, 100% functions,
+    and 100% lines.
+- Updated `core/lib` aggregate coverage: 100% statements, 100% branches, 100%
+  functions, and 100% lines.
+
+Notes:
+
+- Added focused coverage for plan-limit upgrade action rendering and toast
+  dismissal, rate-limit messaging, Hume-unavailable messaging, file-size and
+  file-type upload errors, and fallback raw-message toasts.
+- Mocked only the `sonner` toast boundary; the plan-limit action renders the
+  real `Button`/`Link` composition and verifies the upgrade route.
+- The known unsigned `npm.ps1` PowerShell blocker remains the only verification
+  issue; the working `.cmd` test, coverage, type-check, and lint paths passed.
+- No customer email fixtures were used in this slice.
+
+Recommendation:
+
+Move next to `app/app/upgrade/syncSubscriptionOnLoad.ts` or another compact
+upgrade/billing utility with uncovered branches. Keep the slice focused on
+observable return behavior and mocked module boundaries.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/lib/errorToast.test.tsx
+++ b/core/lib/errorToast.test.tsx
@@ -1,0 +1,95 @@
+jest.mock("sonner", () => ({
+  toast: {
+    dismiss: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { isValidElement } from "react";
+import { toast } from "sonner";
+
+import { routes } from "@core/data/routes";
+import {
+  errorToast,
+  FILE_SIZE_TOO_LARGE_MESSAGE,
+  FILE_TYPE_NOT_SUPPORTED_MESSAGE,
+  HUME_UNAVAILABLE_MESSAGE,
+  PLAN_LIMIT_MESSAGE,
+  RATE_LIMIT_MESSAGE,
+} from "./errorToast";
+
+const mockToast = jest.mocked(toast);
+
+describe("errorToast", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockToast.error.mockReturnValue("toast-id");
+  });
+
+  it("shows an upgrade action for plan limit errors and dismisses the toast when clicked", async () => {
+    await errorToast(PLAN_LIMIT_MESSAGE);
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      "You have reached your plan limit.",
+      {
+        action: expect.any(Object),
+      },
+    );
+
+    const options = mockToast.error.mock.calls[0][1];
+    const action = options?.action;
+
+    expect(isValidElement(action)).toBe(true);
+
+    if (!isValidElement(action)) {
+      throw new Error("Expected plan limit toast action to be a React element");
+    }
+
+    render(action);
+
+    const upgradeLink = screen.getByRole("link", { name: "Upgrade" });
+    expect(upgradeLink).toHaveAttribute("href", routes.upgrade);
+
+    fireEvent.click(upgradeLink);
+
+    expect(mockToast.dismiss).toHaveBeenCalledWith("toast-id");
+  });
+
+  it.each([
+    [
+      RATE_LIMIT_MESSAGE,
+      "Whoa! Slow down.",
+      "You are making too many requests. Please try again later.",
+    ],
+    [
+      HUME_UNAVAILABLE_MESSAGE,
+      "Ooopsie!",
+      "Interviews are currently unavailable due to overwhelming demand.",
+    ],
+    [
+      FILE_SIZE_TOO_LARGE_MESSAGE,
+      "File size is too large",
+      "Please upload a file smaller than 10MB.",
+    ],
+    [
+      FILE_TYPE_NOT_SUPPORTED_MESSAGE,
+      "File type not supported",
+      "Please upload a file with a supported type.",
+    ],
+  ])("shows the mapped toast for %s", async (message, title, description) => {
+    await errorToast(message);
+
+    expect(mockToast.error).toHaveBeenCalledWith(title, { description });
+    expect(mockToast.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the raw message for unknown errors", async () => {
+    const message = "Something went wrong";
+
+    await errorToast(message);
+
+    expect(mockToast.error).toHaveBeenCalledWith(message);
+    expect(mockToast.dismiss).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused tests for `errorToast` message mapping and fallback behavior.
- Cover the plan-limit upgrade action, including route rendering and toast dismissal.
- Update the test coverage plan with the latest verification and coverage numbers.

## Verification

- `npm.cmd test -- core/lib/errorToast.test.tsx --runInBand`
- `npm test` blocked by unsigned `C:\nvm4w\nodejs\npm.ps1`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/lib/errorToast.test.tsx AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- No production code changes.
- `core/lib/errorToast.tsx` now has 100% statement, branch, function, and line coverage.