### PR TITLE
test(upgrade): cover subscription sync early returns

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1385,6 +1385,63 @@ Move next to `app/app/upgrade/syncSubscriptionOnLoad.ts` or another compact
 upgrade/billing utility with uncovered branches. Keep the slice focused on
 observable return behavior and mocked module boundaries.
 
+### Upgrade Subscription Sync Slice - 2026-05-26
+
+Files/tests added or updated:
+
+- `app/app/upgrade/syncSubscriptionOnLoad.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npx.cmd jest app/app/upgrade/syncSubscriptionOnLoad.test.ts --coverage --collectCoverageFrom=app/app/upgrade/syncSubscriptionOnLoad.ts --runInBand`
+- `npm test`
+- `npm.cmd test -- app/app/upgrade/syncSubscriptionOnLoad.test.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- app/app/upgrade/syncSubscriptionOnLoad.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+
+Result:
+
+- Focused coverage probe passed: 1 test suite, 7 tests, 0 snapshots.
+- Focused upgrade sync Jest passed: 1 test suite, 7 tests, 0 snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd test -- --runInBand` passed: 60 test suites, 434 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 60 test suites, 434
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- Updated coverage summary: 94.96% statements, 90.93% branches, 90%
+  functions, and 96.98% lines.
+- Updated upgrade sync coverage:
+  - `app/app/upgrade/syncSubscriptionOnLoad.ts`: 100% statements, 100%
+    branches, 100% functions, and 100% lines.
+- Updated `app/app/upgrade` aggregate coverage: 97.29% statements, 90.47%
+  branches, 100% functions, and 97.22% lines.
+
+Notes:
+
+- Added focused early-return coverage for Stripe not configured, configured
+  Stripe client unavailable, no signed-in user, and users without a Stripe
+  subscription id.
+- Kept mocking at module boundaries for auth, Stripe configuration, user DB
+  lookup, and subscription reconciliation.
+- The known unsigned `npm.ps1` PowerShell blocker remains the only verification
+  issue; the working `.cmd` test, coverage, type-check, and lint paths passed.
+- No customer email fixtures were used in this slice.
+
+Recommendation:
+
+Move next to `app/app/upgrade/checkSubscriptionSuccess.ts` to cover the final
+fallback branch when `success=true` but `session_id` is missing or Stripe is
+unavailable. Keep the slice narrow around observable `false` returns and
+downstream calls not firing.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/app/upgrade/syncSubscriptionOnLoad.test.ts
+++ b/app/app/upgrade/syncSubscriptionOnLoad.test.ts
@@ -67,6 +67,54 @@ describe("syncSubscriptionOnUpgradePageLoad", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it("skips reconciliation when Stripe is not configured", async () => {
+    mockIsStripeConfigured.mockReturnValue(false);
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockGetStripe).not.toHaveBeenCalled();
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetUserByIdDb).not.toHaveBeenCalled();
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips reconciliation when Stripe is configured but unavailable", async () => {
+    mockGetStripe.mockReturnValue(null);
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockGetCurrentUser).not.toHaveBeenCalled();
+    expect(mockGetUserByIdDb).not.toHaveBeenCalled();
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips reconciliation when no user is signed in", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeCurrentUser({ userId: null }));
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockGetUserByIdDb).not.toHaveBeenCalled();
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips reconciliation when the user has no Stripe subscription id", async () => {
+    mockGetUserByIdDb.mockResolvedValue(
+      makeUser({
+        id: TEST_USER_ID,
+        stripeSubscriptionId: null,
+      }),
+    );
+
+    await expect(syncSubscriptionOnUpgradePageLoad()).resolves.toBeUndefined();
+
+    expect(mockGetUserByIdDb).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(mockReconcileUserStripeSubscription).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it("swallows current user lookup failures so the page can render", async () => {
     const error = new Error("session failed");
     mockGetCurrentUser.mockRejectedValue(error);


### PR DESCRIPTION
## Summary

- Added coverage for upgrade page subscription sync early-return paths.
- Covered Stripe disabled, missing Stripe client, unauthenticated user, and users without a Stripe subscription id.
- Updated `TEST_COVERAGE_PLAN.md` with verification results, coverage summary, blockers, and next recommendation.

## Verification

- `npx.cmd jest app/app/upgrade/syncSubscriptionOnLoad.test.ts --coverage --collectCoverageFrom=app/app/upgrade/syncSubscriptionOnLoad.ts --runInBand`
- `npm.cmd test -- app/app/upgrade/syncSubscriptionOnLoad.test.ts --runInBand`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- app/app/upgrade/syncSubscriptionOnLoad.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`

## Notes

- `app/app/upgrade/syncSubscriptionOnLoad.ts` is now at 100% statements, branches, functions, and lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for subscription synchronization, adding edge case scenarios for Stripe configuration availability, user authentication status, and subscription identifier validation.

* **Documentation**
  * Updated test coverage documentation with new test specifications and updated coverage metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GuRuGuMaWaRu/nextjs_job-prep_ai/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->