### PR TITLE
chore(stripe): tighten TypeScript test fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@
 - All code should be formatted for readability with logical parts separated by empty lines.
 - In tests, place module-level `jest.mock(...)` calls before imports when mocking imported modules.
 
+## TypeScript Quality
+
+- Prefer precise types over type assertions.
+- Avoid `as unknown as ...` except at unavoidable external or test boundaries.
+- If a double assertion is needed, isolate it in a named helper or factory and explain why.
+- Prefer `satisfies`, `Pick`, narrow local types, typed factories, or proper runtime validation over broad casts.
+- Do not use `any`; prefer `unknown`, generics, precise interfaces, or narrow local types.
+- Keep mocks type-safe where practical, especially for external SDK payloads.
+- Run `npx.cmd tsc --noEmit` after TypeScript changes.
+
 ## General Rules
 
 - Never ever log customer emails.

--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1634,6 +1634,68 @@ Move next to `core/features/auth/oauth/base.ts` if branch coverage remains the
 priority. If the goal is a smaller and lower-risk slice, cover
 `core/dal/helpers.ts` or the remaining permission helper branches first.
 
+### Stripe Fixture Type-Safety Cleanup - 2026-05-28
+
+Files updated:
+
+- `AGENTS.md`
+- `package.json`
+- `app/api/stripe/webhooks/route.test.ts`
+- `app/api/stripe/create-checkout-session/route.test.ts`
+- `app/api/stripe/create-portal-session/route.test.ts`
+- `app/api/stripe/cancel-subscription/route.test.ts`
+- `core/test-utils/factories/index.ts`
+- `core/test-utils/factories/stripeEvent.ts`
+- `core/test-utils/factories/stripeEvent.test.ts`
+- `core/test-utils/mocks/stripe.ts`
+
+Commands run:
+
+- `npx.cmd biome format --write AGENTS.md package.json app/api/stripe/webhooks/route.test.ts app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts core/test-utils/factories/stripeEvent.ts core/test-utils/factories/stripeEvent.test.ts core/test-utils/factories/index.ts core/test-utils/mocks/stripe.ts`
+- `npm.cmd test -- app/api/stripe/webhooks/route.test.ts app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts core/test-utils/factories/stripeEvent.test.ts --runInBand`
+- `npm test`
+- `npm.cmd run check:ci`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run typecheck`
+
+Result:
+
+- Focused Stripe route/factory tests passed: 5 test suites, 69 tests, 0
+  snapshots.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `C:\nvm4w\nodejs\npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd run check:ci` passed: 270 files checked.
+- `npm.cmd test -- --runInBand` passed: 60 test suites, 461 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 60 test suites, 461
+  tests, 0 snapshots.
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd run typecheck` passed.
+- Updated coverage summary: 95.96% statements, 95.19% branches, 90.1%
+  functions, and 97.96% lines.
+
+Notes:
+
+- Replaced inline Stripe client double-casts in Stripe route tests with the
+  named `asStripeClient` mock-boundary helper.
+- Replaced inline `Stripe.Subscription` double-casts in webhook tests with
+  `makeStripeSubscription` and `makeStripeCustomer` fixtures.
+- Kept unavoidable broad casts centralized in named Stripe test factories and
+  mocks, with comments explaining the minimal external SDK shapes.
+- Added TypeScript quality guidance to `AGENTS.md`, including a no-`any`
+  preference, and a conservative `typecheck` package script without changing
+  `check:ci`.
+- Test data continues to use synthetic ids and `@test.local` emails only.
+
+Recommendation:
+
+For the next focused cleanup, consider replacing remaining non-Stripe
+`as unknown as` null-result mocks with typed helper constants near their test
+modules. Keep that separate from coverage work unless it directly improves a
+touched slice.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/app/api/stripe/cancel-subscription/route.test.ts
+++ b/app/api/stripe/cancel-subscription/route.test.ts
@@ -13,8 +13,6 @@ jest.mock("@/core/features/billing/stripe", () => ({
   isStripeConfigured: jest.fn(),
 }));
 
-import type Stripe from "stripe";
-
 import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
@@ -24,6 +22,7 @@ import {
 } from "@/core/features/billing/stripe";
 import { TEST_USER_ID } from "@core/test-utils/constants";
 import { makeProUser, makeUser } from "@core/test-utils/factories";
+import { asStripeClient } from "@core/test-utils/mocks/stripe";
 
 import { POST } from "./route";
 
@@ -91,7 +90,7 @@ describe("POST /api/stripe/cancel-subscription", () => {
     });
 
     mockGetStripe.mockReset();
-    mockGetStripe.mockReturnValue(mockStripe as unknown as Stripe);
+    mockGetStripe.mockReturnValue(asStripeClient(mockStripe));
 
     mockGetStripeBaseUrl.mockReset();
     mockGetStripeBaseUrl.mockReturnValue("https://app.test");

--- a/app/api/stripe/create-checkout-session/route.test.ts
+++ b/app/api/stripe/create-checkout-session/route.test.ts
@@ -21,8 +21,6 @@ jest.mock("@/core/features/billing/stripe", () => ({
   isStripeConfigured: jest.fn(),
 }));
 
-import type Stripe from "stripe";
-
 import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
@@ -33,6 +31,7 @@ import {
 import { TEST_USER_ID } from "@core/test-utils/constants";
 import { createTestServerEnv } from "@core/test-utils/env";
 import { makeUser } from "@core/test-utils/factories";
+import { asStripeClient } from "@core/test-utils/mocks/stripe";
 
 import { POST } from "./route";
 
@@ -112,7 +111,7 @@ describe("POST /api/stripe/create-checkout-session", () => {
     });
 
     mockGetStripe.mockReset();
-    mockGetStripe.mockReturnValue(mockStripe as unknown as Stripe);
+    mockGetStripe.mockReturnValue(asStripeClient(mockStripe));
 
     mockGetStripeBaseUrl.mockReset();
     mockGetStripeBaseUrl.mockReturnValue("https://app.test");

--- a/app/api/stripe/create-portal-session/route.test.ts
+++ b/app/api/stripe/create-portal-session/route.test.ts
@@ -13,8 +13,6 @@ jest.mock("@/core/features/billing/stripe", () => ({
   isStripeConfigured: jest.fn(),
 }));
 
-import type Stripe from "stripe";
-
 import { getCurrentUserWithProfileAction } from "@/core/features/auth/actions";
 import {
   getStripe,
@@ -24,6 +22,7 @@ import {
 } from "@/core/features/billing/stripe";
 import { TEST_USER_ID } from "@core/test-utils/constants";
 import { makeUser } from "@core/test-utils/factories";
+import { asStripeClient } from "@core/test-utils/mocks/stripe";
 
 import { POST } from "./route";
 
@@ -93,7 +92,7 @@ describe("POST /api/stripe/create-portal-session", () => {
     });
 
     mockGetStripe.mockReset();
-    mockGetStripe.mockReturnValue(mockStripe as unknown as Stripe);
+    mockGetStripe.mockReturnValue(asStripeClient(mockStripe));
 
     mockGetStripeBaseUrl.mockReset();
     mockGetStripeBaseUrl.mockReturnValue("https://app.test");

--- a/app/api/stripe/webhooks/route.test.ts
+++ b/app/api/stripe/webhooks/route.test.ts
@@ -3,6 +3,7 @@ import type Stripe from "stripe";
 import { createTestServerEnv, type TestServerEnv } from "@core/test-utils/env";
 import {
   createMockStripe,
+  asStripeClient,
   type MockStripeClient,
 } from "@core/test-utils/mocks/stripe";
 import {
@@ -13,6 +14,7 @@ import {
   makeSubscriptionUpdatedEvent,
   makeUnhandledStripeWebhookEvent,
   makeStripeCheckoutSession,
+  makeStripeCustomer,
   makeStripeSubscription,
   makeStripeEvent,
 } from "@core/test-utils/factories";
@@ -88,6 +90,16 @@ function buildWebhookRequest(
   });
 }
 
+function buildUnreadableBodyRequest(): Request {
+  const request = {
+    headers: new Headers({ "stripe-signature": VALID_SIGNATURE_HEADER }),
+    text: () => Promise.reject(new Error("read failed")),
+  };
+
+  // Minimal Request shape for the body-read failure branch.
+  return request as unknown as Request;
+}
+
 function primeHappyPath(event: Stripe.Event): void {
   mockStripe.webhooks.constructEvent.mockReturnValueOnce(event);
   mockClaimEvent.mockResolvedValueOnce("claimed");
@@ -103,7 +115,7 @@ beforeEach(() => {
   mockStripe.subscriptions.retrieve.mockReset();
 
   mockGetStripe.mockReset();
-  mockGetStripe.mockReturnValue(mockStripe as unknown as Stripe);
+  mockGetStripe.mockReturnValue(asStripeClient(mockStripe));
 
   mockClaimEvent.mockReset();
   mockUnclaimEvent.mockReset().mockResolvedValue(undefined);
@@ -161,12 +173,7 @@ describe("POST /api/stripe/webhooks — preconditions", () => {
   });
 
   it("returns 400 when reading the request body fails", async () => {
-    const failingRequest = {
-      headers: new Headers({ "stripe-signature": VALID_SIGNATURE_HEADER }),
-      text: () => Promise.reject(new Error("read failed")),
-    } as unknown as Request;
-
-    const response = await POST(failingRequest);
+    const response = await POST(buildUnreadableBodyRequest());
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
@@ -323,12 +330,11 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
   });
 
   it("resolves the customer id when subscription.customer is an expanded object", async () => {
-    const subscription = {
+    const subscription = makeStripeSubscription({
       id: "sub_test_expanded",
-      object: "subscription",
-      customer: { id: "cus_test_expanded", object: "customer" },
+      customer: makeStripeCustomer("cus_test_expanded"),
       status: "active",
-    } as unknown as Stripe.Subscription;
+    });
     const event = makeStripeEvent({
       type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
       object: subscription,
@@ -348,12 +354,11 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
   });
 
   it("skips syncing when a subscription event has no resolvable customer id", async () => {
-    const subscription = {
+    const subscription = makeStripeSubscription({
       id: "sub_test_no_customer",
-      object: "subscription",
       customer: null,
       status: "active",
-    } as unknown as Stripe.Subscription;
+    });
     const event = makeStripeEvent({
       type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionUpdated,
       object: subscription,
@@ -389,12 +394,11 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
   });
 
   it("resolves an expanded customer object on customer.subscription.deleted", async () => {
-    const subscription = {
+    const subscription = makeStripeSubscription({
       id: "sub_test_deleted_expanded",
-      object: "subscription",
-      customer: { id: "cus_test_deleted_expanded", object: "customer" },
+      customer: makeStripeCustomer("cus_test_deleted_expanded"),
       status: "canceled",
-    } as unknown as Stripe.Subscription;
+    });
     const event = makeStripeEvent({
       type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionDeleted,
       object: subscription,
@@ -415,12 +419,11 @@ describe("POST /api/stripe/webhooks — event handlers", () => {
   });
 
   it("skips syncing when a deleted subscription has no resolvable customer id", async () => {
-    const subscription = {
+    const subscription = makeStripeSubscription({
       id: "sub_test_deleted_no_customer",
-      object: "subscription",
       customer: null,
       status: "canceled",
-    } as unknown as Stripe.Subscription;
+    });
     const event = makeStripeEvent({
       type: STRIPE_WEBHOOK_EVENT_TYPES.subscriptionDeleted,
       object: subscription,

--- a/core/test-utils/factories/index.ts
+++ b/core/test-utils/factories/index.ts
@@ -5,6 +5,7 @@ export { makeInterview, type InterviewWithJobInfo } from "./interview";
 export { makeQuestion } from "./question";
 export {
   makeStripeSubscription,
+  makeStripeCustomer,
   makeStripeCheckoutSession,
   makeStripeEvent,
   makeCheckoutSessionCompletedEvent,

--- a/core/test-utils/factories/stripeEvent.test.ts
+++ b/core/test-utils/factories/stripeEvent.test.ts
@@ -7,6 +7,7 @@ import {
   makeCheckoutSessionAsyncPaymentSucceededEvent,
   makeCheckoutSessionCompletedEvent,
   makeStripeCheckoutSession,
+  makeStripeCustomer,
   makeStripeEvent,
   makeStripeSubscription,
   makeSubscriptionDeletedEvent,
@@ -39,6 +40,23 @@ describe("makeStripeSubscription", () => {
 
     expect(subscription.id).toBe("sub_test_custom");
     expect(subscription.status).toBe("past_due");
+  });
+
+  it("allows an explicitly missing customer for remediation branches", () => {
+    const subscription = makeStripeSubscription({ customer: null });
+
+    expect(subscription.customer).toBeNull();
+  });
+});
+
+describe("makeStripeCustomer", () => {
+  it("returns the minimal expanded customer shape", () => {
+    const customer = makeStripeCustomer("cus_test_custom");
+
+    expect(customer).toEqual({
+      id: "cus_test_custom",
+      object: "customer",
+    });
   });
 });
 

--- a/core/test-utils/factories/stripeEvent.ts
+++ b/core/test-utils/factories/stripeEvent.ts
@@ -33,10 +33,18 @@ function nextSubscriptionIndex(): number {
   return subscriptionCounter;
 }
 
+type MinimalStripeSubscription = Pick<
+  Stripe.Subscription,
+  "id" | "object" | "customer" | "status" | "created" | "cancel_at_period_end"
+>;
+
+type MinimalStripeCustomer = Pick<Stripe.Customer, "id" | "object">;
+
 export type MakeStripeSubscriptionOverrides = Partial<
-  Pick<Stripe.Subscription, "id" | "customer" | "status" | "created">
+  Pick<Stripe.Subscription, "id" | "status" | "created">
 > & {
   cancelAtPeriodEnd?: boolean;
+  customer?: Stripe.Subscription["customer"] | null;
 };
 
 /**
@@ -51,13 +59,31 @@ export function makeStripeSubscription(
   const subscription = {
     id: overrides.id ?? `sub_test_${index}`,
     object: "subscription" as const,
-    customer: overrides.customer ?? `cus_test_${index}`,
+    customer:
+      overrides.customer === undefined
+        ? `cus_test_${index}`
+        : overrides.customer,
     status: overrides.status ?? "active",
     created: overrides.created ?? index,
     cancel_at_period_end: overrides.cancelAtPeriodEnd ?? false,
+  } satisfies Omit<MinimalStripeSubscription, "customer"> & {
+    customer: Stripe.Subscription["customer"] | null;
   };
 
   return subscription as unknown as Stripe.Subscription;
+}
+
+/**
+ * Builds the minimal expanded customer object needed by subscription tests.
+ * Stripe's full `Customer` type is much larger than the route logic reads.
+ */
+export function makeStripeCustomer(id = "cus_test_expanded"): Stripe.Customer {
+  const customer = {
+    id,
+    object: "customer" as const,
+  } satisfies MinimalStripeCustomer;
+
+  return customer as unknown as Stripe.Customer;
 }
 
 export type MakeStripeCheckoutSessionOverrides = {

--- a/core/test-utils/mocks/stripe.ts
+++ b/core/test-utils/mocks/stripe.ts
@@ -55,3 +55,12 @@ export function createMockStripe(): MockStripeClient {
     },
   };
 }
+
+/**
+ * Adapts a narrow Stripe SDK mock to the full client type expected by code under
+ * test. Keep this cast at the mock boundary so individual tests can stay typed
+ * to the small Stripe surface they actually exercise.
+ */
+export function asStripeClient(mockStripe: object): Stripe {
+  return mockStripe as unknown as Stripe;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "biome format --write .",
     "check": "biome check --write .",
     "check:ci": "biome ci .",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary

- Centralize unavoidable Stripe SDK test casts in named factories/mocks
- Replace inline Stripe route test double-casts with typed helpers
- Add TypeScript quality guidance to AGENTS.md
- Add a conservative `typecheck` script for `tsc --noEmit`

## Verification

- `npm.cmd test -- app/api/stripe/webhooks/route.test.ts app/api/stripe/create-checkout-session/route.test.ts app/api/stripe/create-portal-session/route.test.ts app/api/stripe/cancel-subscription/route.test.ts core/test-utils/factories/stripeEvent.test.ts --runInBand`
- `npm.cmd run check:ci`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run typecheck`

## Notes

- No production dependencies were added.