### PR TITLE
test(dal): cover auth helper branches

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -1696,6 +1696,70 @@ For the next focused cleanup, consider replacing remaining non-Stripe
 modules. Keep that separate from coverage work unless it directly improves a
 touched slice.
 
+### DAL Helpers Coverage Slice - 2026-05-28
+
+Files added or updated:
+
+- `core/dal/helpers.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+
+Commands run:
+
+- `npm.cmd test -- core/dal/helpers.test.ts --runInBand`
+- `npx.cmd jest core/dal/helpers.test.ts --coverage --collectCoverageFrom=core/dal/helpers.ts --runInBand`
+- `npx.cmd biome format --write core/dal/helpers.test.ts`
+- `npm test`
+- `npm.cmd run check:ci`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run lint -- core/dal/helpers.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+
+Result:
+
+- Focused DAL helper Jest passed: 1 test suite, 5 tests, 0 snapshots.
+- Focused DAL helper coverage probe passed: 1 test suite, 5 tests, 0 snapshots.
+- `core/dal/helpers.ts` now reports 100% statements, 100% branches, 100%
+  functions, and 100% lines.
+- `npx.cmd biome format --write core/dal/helpers.test.ts` completed with no
+  fixes needed.
+- `npm test` still fails in PowerShell before Jest starts because the unsigned
+  `C:\nvm4w\nodejs\npm.ps1` shim is blocked by the local execution policy.
+- `npm.cmd run check:ci` passed: 271 files checked.
+- `npx.cmd tsc --noEmit` passed.
+- Focused `biome lint` passed for the touched TypeScript test file.
+  `AGENTS.md` and `TEST_COVERAGE_PLAN.md` were passed to the command but not
+  checked by Biome.
+- `npm.cmd test -- --runInBand` passed: 61 test suites, 466 tests, 0
+  snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 61 test suites, 466
+  tests, 0 snapshots.
+- Updated coverage summary: 96.07% statements, 95.5% branches, 90.1%
+  functions, and 98.08% lines.
+- Updated DAL coverage:
+  - `core/dal/helpers.ts`: 100% statements, 100% branches, 100% functions, and
+    100% lines.
+  - `core/dal` aggregate: 88.88% statements, 100% branches, 85.71% functions,
+    and 88.88% lines.
+
+Notes:
+
+- Added focused tests for `requireUser` and `requireUserWithData`, covering
+  successful auth delegation, missing `userId`, and missing profile data.
+- Mocked only the auth action module boundary.
+- Test data uses existing synthetic user fixtures with `@test.local` emails.
+- The known unsigned `npm.ps1` PowerShell blocker remains the only verification
+  issue; the working `.cmd` test, coverage, type-check, lint, and CI check
+  paths passed.
+
+Recommendation:
+
+Move next to `core/features/auth/oauth/base.ts` if branch coverage remains the
+priority. For another compact slice, cover remaining permission helper branches
+in `core/features/auth/permissions.ts`,
+`core/features/interviews/permissions.ts`, or
+`core/features/questions/permissions.ts`.
+
 ## Coverage Priorities
 
 1. Cover pure logic first.

--- a/core/dal/helpers.test.ts
+++ b/core/dal/helpers.test.ts
@@ -1,0 +1,76 @@
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUserAction: jest.fn(),
+  getCurrentUserWithProfileAction: jest.fn(),
+}));
+
+import {
+  getCurrentUserAction,
+  getCurrentUserWithProfileAction,
+} from "@/core/features/auth/actions";
+import { UnauthorizedError } from "@/core/dal/errors";
+import { requireUser, requireUserWithData } from "@/core/dal/helpers";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeCurrentUser, makeUser } from "@/core/test-utils/factories";
+
+const mockGetCurrentUserAction = jest.mocked(getCurrentUserAction);
+const mockGetCurrentUserWithProfileAction = jest.mocked(
+  getCurrentUserWithProfileAction,
+);
+
+describe("DAL helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("requireUser", () => {
+    it("returns the current user id", async () => {
+      mockGetCurrentUserAction.mockResolvedValue(
+        makeCurrentUser({ userId: TEST_USER_ID }),
+      );
+
+      await expect(requireUser()).resolves.toBe(TEST_USER_ID);
+
+      expect(mockGetCurrentUserAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when no user is authenticated", async () => {
+      mockGetCurrentUserAction.mockResolvedValue(
+        makeCurrentUser({ userId: null }),
+      );
+
+      await expect(requireUser()).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("requireUserWithData", () => {
+    it("returns the current user id and profile", async () => {
+      const user = makeUser({ id: TEST_USER_ID });
+      mockGetCurrentUserWithProfileAction.mockResolvedValue(
+        makeCurrentUser({ userId: TEST_USER_ID, user }),
+      );
+
+      await expect(requireUserWithData()).resolves.toEqual({
+        userId: TEST_USER_ID,
+        user,
+      });
+
+      expect(mockGetCurrentUserWithProfileAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when no user is authenticated", async () => {
+      mockGetCurrentUserWithProfileAction.mockResolvedValue(
+        makeCurrentUser({ userId: null }),
+      );
+
+      await expect(requireUserWithData()).rejects.toThrow(UnauthorizedError);
+    });
+
+    it("throws when the user profile is missing", async () => {
+      mockGetCurrentUserWithProfileAction.mockResolvedValue(
+        makeCurrentUser({ userId: TEST_USER_ID, user: undefined }),
+      );
+
+      await expect(requireUserWithData()).rejects.toThrow(UnauthorizedError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added focused tests for `requireUser` and `requireUserWithData`
- Covered authenticated success, missing `userId`, and missing profile-data branches
- Updated `TEST_COVERAGE_PLAN.md` with verification results and next coverage recommendation

## Verification

- `npm.cmd test -- core/dal/helpers.test.ts --runInBand`
- `npx.cmd jest core/dal/helpers.test.ts --coverage --collectCoverageFrom=core/dal/helpers.ts --runInBand`
- `npx.cmd biome format --write core/dal/helpers.test.ts`
- `npm.cmd run check:ci`
- `npx.cmd tsc --noEmit`
- `npm.cmd run lint -- core/dal/helpers.test.ts AGENTS.md TEST_COVERAGE_PLAN.md`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`

## Notes

- `core/dal/helpers.ts` now reports 100% statements, branches, functions, and lines.