### PR TITLE
test(ui): cover password input and card components

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,10 +10,10 @@ Date: 2026-05-28
 
 Latest full verification:
 
-- `npm.cmd run check:ci` passed: 272 files checked.
-- `npm.cmd test -- --runInBand` passed: 62 test suites, 485 tests, 0
+- `npm.cmd run check:ci` passed: 274 files checked.
+- `npm.cmd test -- --runInBand` passed: 64 test suites, 489 tests, 0
   snapshots.
-- `npm.cmd run test:coverage -- --runInBand` passed: 62 test suites, 485
+- `npm.cmd run test:coverage -- --runInBand` passed: 64 test suites, 489
   tests, 0 snapshots.
 - `npx.cmd tsc --noEmit` passed.
 
@@ -21,10 +21,10 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 96.41% |
-| Branches | 97.81% |
-| Functions | 90.1% |
-| Lines | 98.44% |
+| Statements | 96.64% |
+| Branches | 98.28% |
+| Functions | 91.57% |
+| Lines | 98.62% |
 
 Recent file-specific result:
 
@@ -37,21 +37,27 @@ Recent file-specific result:
 | `core/features/auth/permissions.ts` | 100% | 100% | 100% | 100% |
 | `core/features/interviews/permissions.ts` | 100% | 100% | 100% | 100% |
 | `core/features/questions/permissions.ts` | 100% | 100% | 100% | 100% |
+| `core/components/ui/password-input.tsx` | 100% | 100% | 100% | 100% |
+| `core/components/ui/card.tsx` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
-- Updated `core/features/auth/permissions.test.ts`.
-- Updated `core/features/interviews/permissions.test.ts`.
-- Updated `core/features/questions/permissions.ts`.
+- Added `core/components/ui/password-input.test.tsx`.
+- Added `core/components/ui/card.test.tsx`.
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Added branch tests for empty-plan fallback behavior, anonymous plan lookup,
-  subscription info fallback, and the interview count helper's missing-user
-  fallback.
-- Simplified the questions count helper to accept only the signed-in `userId`
-  string it receives after the anonymous-user guard.
+- Covered password input prop forwarding, visibility toggle state, and disabled
+  control forwarding.
+- Covered card subcomponent exports, slot attributes, custom class merging, and
+  rendered content.
+- Focused Jest passed:
+  `npm.cmd test -- core/components/ui/password-input.test.tsx --runInBand` (3
+  tests) and `npm.cmd test -- core/components/ui/card.test.tsx --runInBand` (1
+  test).
+- Focused coverage probes passed with 100% coverage for
+  `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx`.
 - Required raw `npm test` attempt still fails before Jest starts because
   unsigned `C:\nvm4w\nodejs\npm.ps1` is blocked by PowerShell execution policy.
-- Jest still emits the existing stale `baseline-browser-mapping` warning.
+- No production code was changed in this slice.
 
 ## Working Rules
 
@@ -106,9 +112,10 @@ Known local quirks:
 Recommended next slice:
 
 1. Component utility gaps:
-   - `core/components/ui/password-input.tsx`
-   - `core/components/ui/card.tsx`
-   - Next lowest-risk path after permission helpers reached 100%.
+   - `core/components/ui/badge.tsx`
+   - `core/components/ui/sonner.tsx`
+   - Next lowest-risk UI utilities after `password-input.tsx` and `card.tsx`
+     reached 100%.
 2. Route branch gaps:
    - `app/api/ai/questions/generate-question/route.ts`
    - `app/api/ai/resumes/analyze/route.ts`
@@ -153,6 +160,7 @@ Recommended next slice:
 | 2026-05-28 | OAuth errors branches | `core/features/auth/oauth/errors.ts` reached 100% coverage. |
 | 2026-05-28 | OAuth connect user branches | `core/features/auth/oauth/connectUser.ts` reached 100% coverage. |
 | 2026-05-28 | Permission helper branches | Auth, interview, and question permission helpers reached 100% coverage. |
+| 2026-05-28 | Component utility coverage | `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx` reached 100% coverage. |
 
 ## Archive
 

--- a/core/components/ui/card.test.tsx
+++ b/core/components/ui/card.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./card";
+
+describe("Card", () => {
+  it("renders card sections with their slot attributes and content", () => {
+    render(
+      <Card aria-label="Interview prep card" className="custom-card">
+        <CardHeader className="custom-header">
+          <CardTitle className="custom-title">Behavioral practice</CardTitle>
+          <CardDescription className="custom-description">
+            Review common prompts
+          </CardDescription>
+          <CardAction className="custom-action">
+            <button type="button">Start</button>
+          </CardAction>
+        </CardHeader>
+        <CardContent className="custom-content">
+          Two questions are ready.
+        </CardContent>
+        <CardFooter className="custom-footer">Updated today</CardFooter>
+      </Card>,
+    );
+
+    const card = screen.getByLabelText("Interview prep card");
+    const header = screen.getByText("Behavioral practice").parentElement;
+    const title = screen.getByText("Behavioral practice");
+    const description = screen.getByText("Review common prompts");
+    const action = screen.getByRole("button", { name: "Start" }).parentElement;
+    const content = screen.getByText("Two questions are ready.");
+    const footer = screen.getByText("Updated today");
+
+    expect(card).toHaveAttribute("data-slot", "card");
+    expect(card).toHaveClass("custom-card");
+    expect(header).toHaveAttribute("data-slot", "card-header");
+    expect(header).toHaveClass("custom-header");
+    expect(title).toHaveAttribute("data-slot", "card-title");
+    expect(title).toHaveClass("custom-title");
+    expect(description).toHaveAttribute("data-slot", "card-description");
+    expect(description).toHaveClass("custom-description");
+    expect(action).toHaveAttribute("data-slot", "card-action");
+    expect(action).toHaveClass("custom-action");
+    expect(content).toHaveAttribute("data-slot", "card-content");
+    expect(content).toHaveClass("custom-content");
+    expect(footer).toHaveAttribute("data-slot", "card-footer");
+    expect(footer).toHaveClass("custom-footer");
+  });
+});

--- a/core/components/ui/password-input.test.tsx
+++ b/core/components/ui/password-input.test.tsx
@@ -1,0 +1,63 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "@/core/test-utils/render";
+
+import { PasswordInput } from "./password-input";
+
+describe("PasswordInput", () => {
+  it("renders as a password field and forwards input props", () => {
+    render(
+      <PasswordInput
+        aria-label="Account password"
+        autoComplete="current-password"
+        className="custom-password"
+        defaultValue="secret"
+        name="password"
+      />,
+    );
+
+    const input = screen.getByLabelText("Account password");
+
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveAttribute("autocomplete", "current-password");
+    expect(input).toHaveAttribute("name", "password");
+    expect(input).toHaveClass("pr-10");
+    expect(input).toHaveClass("custom-password");
+    expect(input).toHaveValue("secret");
+    expect(
+      screen.getByRole("button", { name: "Show password" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("toggles the password visibility control", async () => {
+    const user = userEvent.setup();
+
+    render(<PasswordInput aria-label="Account password" />);
+
+    const input = screen.getByLabelText("Account password");
+    const showButton = screen.getByRole("button", { name: "Show password" });
+
+    await user.click(showButton);
+
+    expect(input).toHaveAttribute("type", "text");
+    expect(
+      screen.getByRole("button", { name: "Hide password" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Hide password" }));
+
+    expect(input).toHaveAttribute("type", "password");
+    expect(
+      screen.getByRole("button", { name: "Show password" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("disables both the input and visibility button", () => {
+    render(<PasswordInput aria-label="Account password" disabled />);
+
+    expect(screen.getByLabelText("Account password")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Show password" }),
+    ).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused tests for `PasswordInput` prop forwarding, visibility toggling, and disabled state.
- Add focused tests for `Card` subcomponents, slot attributes, class merging, and rendered content.
- Update `TEST_COVERAGE_PLAN.md` with the latest coverage slice, verification commands, and next recommendation.

## Verification

- `npm.cmd test -- core/components/ui/password-input.test.tsx --runInBand`
- `npm.cmd test -- core/components/ui/card.test.tsx --runInBand`
- `npx.cmd jest core/components/ui/password-input.test.tsx --coverage --collectCoverageFrom=core/components/ui/password-input.tsx --runInBand`
- `npx.cmd jest core/components/ui/card.test.tsx --coverage --collectCoverageFrom=core/components/ui/card.tsx --runInBand`
- `npx.cmd biome format --write core/components/ui/password-input.test.tsx core/components/ui/card.test.tsx TEST_COVERAGE_PLAN.md`
- `npm.cmd run check:ci`
- `npm.cmd test -- --runInBand`
- `npm.cmd run test:coverage -- --runInBand`
- `npx.cmd tsc --noEmit`

## Notes / Risks

- No production code changed.
- Overall coverage increased to 96.64% statements, 98.28% branches, 91.57% functions, and 98.62% lines.