### PR TITLE
test(ui): cover badge and sonner utilities

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -6,9 +6,26 @@ for practical handoff use.
 
 ## Current Status
 
-Date: 2026-05-28
+Date: 2026-06-01
 
 Latest full verification:
+
+- `npm run check:ci` passed: 276 files checked.
+- `npm test -- --runInBand --watchman=false` passed: 66 test suites, 495
+  tests, 0 snapshots.
+- `npm run test:coverage -- --runInBand --watchman=false` passed: 66 test
+  suites, 495 tests, 0 snapshots.
+- `npx tsc --noEmit` passed.
+- Initial `npm test -- core/components/ui/badge.test.tsx
+  core/components/ui/sonner.test.tsx --runInBand` failed before Jest started
+  because Watchman could not write
+  `/Users/gurugumawaru/Library/LaunchAgents/com.github.facebook.watchman.plist`;
+  rerunning with `--watchman=false` passed.
+- Initial sandboxed `npm ci` failed with npm's `Exit handler never called`
+  error while writing npm logs outside the workspace; rerunning with elevated
+  filesystem access passed.
+
+Previous full verification:
 
 - `npm.cmd run check:ci` passed: 274 files checked.
 - `npm.cmd test -- --runInBand` passed: 64 test suites, 489 tests, 0
@@ -21,8 +38,8 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 96.64% |
-| Branches | 98.28% |
+| Statements | 96.69% |
+| Branches | 98.59% |
 | Functions | 91.57% |
 | Lines | 98.62% |
 
@@ -39,24 +56,28 @@ Recent file-specific result:
 | `core/features/questions/permissions.ts` | 100% | 100% | 100% | 100% |
 | `core/components/ui/password-input.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/card.tsx` | 100% | 100% | 100% | 100% |
+| `core/components/ui/badge.tsx` | 100% | 100% | 100% | 100% |
+| `core/components/ui/sonner.tsx` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
-- Added `core/components/ui/password-input.test.tsx`.
-- Added `core/components/ui/card.test.tsx`.
+- Added `core/components/ui/badge.test.tsx`.
+- Added `core/components/ui/sonner.test.tsx`.
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Covered password input prop forwarding, visibility toggle state, and disabled
-  control forwarding.
-- Covered card subcomponent exports, slot attributes, custom class merging, and
-  rendered content.
+- Covered badge prop forwarding, variant classes, `asChild` rendering, and
+  exported variant helper output.
+- Covered toaster theme fallback, caller prop forwarding, icon map creation, and
+  CSS variable style forwarding.
 - Focused Jest passed:
-  `npm.cmd test -- core/components/ui/password-input.test.tsx --runInBand` (3
-  tests) and `npm.cmd test -- core/components/ui/card.test.tsx --runInBand` (1
-  test).
+  `npm test -- core/components/ui/badge.test.tsx
+  core/components/ui/sonner.test.tsx --runInBand --watchman=false` (6 tests).
 - Focused coverage probes passed with 100% coverage for
-  `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx`.
-- Required raw `npm test` attempt still fails before Jest starts because
-  unsigned `C:\nvm4w\nodejs\npm.ps1` is blocked by PowerShell execution policy.
+  `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx`.
+- Full coverage passed with `core/components/ui` aggregate at 97.87%
+  statements, 100% branches, 100% functions, and 100% lines.
+- Required raw focused Jest attempt failed before Jest started because Watchman
+  could not write the local LaunchAgent plist; `--watchman=false` is the working
+  local path on this macOS worktree.
 - No production code was changed in this slice.
 
 ## Working Rules
@@ -97,6 +118,9 @@ Known local quirks:
 - Raw `npm test` fails in PowerShell before Jest starts because unsigned
   `C:\nvm4w\nodejs\npm.ps1` is blocked by the local execution policy. Use
   `npm.cmd` for real verification after recording the raw blocker.
+- On this macOS worktree, Jest can fail before tests start when Watchman tries
+  to write `~/Library/LaunchAgents/com.github.facebook.watchman.plist`. Add
+  `--watchman=false` to Jest commands when that happens.
 - Sandboxed coverage report writes can fail with `EPERM` under `coverage`.
   Rerun the same coverage command outside the sandbox when needed.
 - Sandboxed Biome writes can fail with `Access is denied. (os error 5)` for
@@ -112,10 +136,9 @@ Known local quirks:
 Recommended next slice:
 
 1. Component utility gaps:
-   - `core/components/ui/badge.tsx`
-   - `core/components/ui/sonner.tsx`
-   - Next lowest-risk UI utilities after `password-input.tsx` and `card.tsx`
-     reached 100%.
+   - `core/components/ui/button.tsx`
+   - Next lowest-risk UI utilities after `badge.tsx` and `sonner.tsx` reached
+     100%.
 2. Route branch gaps:
    - `app/api/ai/questions/generate-question/route.ts`
    - `app/api/ai/resumes/analyze/route.ts`
@@ -161,6 +184,7 @@ Recommended next slice:
 | 2026-05-28 | OAuth connect user branches | `core/features/auth/oauth/connectUser.ts` reached 100% coverage. |
 | 2026-05-28 | Permission helper branches | Auth, interview, and question permission helpers reached 100% coverage. |
 | 2026-05-28 | Component utility coverage | `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx` reached 100% coverage. |
+| 2026-06-01 | Component utility coverage | `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx` reached 100% coverage. |
 
 ## Archive
 

--- a/core/components/ui/badge.test.tsx
+++ b/core/components/ui/badge.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+
+import { Badge, badgeVariants } from "./badge";
+
+describe("Badge", () => {
+  it("renders a default badge and forwards span props", () => {
+    render(
+      <Badge aria-label="Current plan" className="custom-badge">
+        Pro
+      </Badge>,
+    );
+
+    const badge = screen.getByLabelText("Current plan");
+
+    expect(badge).toHaveAttribute("data-slot", "badge");
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge).toHaveClass("custom-badge");
+    expect(badge).toHaveClass("bg-primary");
+    expect(badge).toHaveTextContent("Pro");
+  });
+
+  it("applies the selected variant classes", () => {
+    render(<Badge variant="warning">Expiring soon</Badge>);
+
+    const badge = screen.getByText("Expiring soon");
+
+    expect(badge).toHaveClass("bg-warning");
+    expect(badge).toHaveClass("text-white");
+  });
+
+  it("renders as a child element while preserving badge attributes", () => {
+    render(
+      <Badge asChild variant="outline">
+        <a href="/app/upgrade">Upgrade</a>
+      </Badge>,
+    );
+
+    const link = screen.getByRole("link", { name: "Upgrade" });
+
+    expect(link).toHaveAttribute("href", "/app/upgrade");
+    expect(link).toHaveAttribute("data-slot", "badge");
+    expect(link).toHaveClass("text-foreground");
+  });
+});
+
+describe("badgeVariants", () => {
+  it("returns default and custom variant class names", () => {
+    expect(badgeVariants()).toContain("bg-primary");
+    expect(badgeVariants({ variant: "primary" })).toContain(
+      "bg-positive-badge-background",
+    );
+  });
+});

--- a/core/components/ui/sonner.test.tsx
+++ b/core/components/ui/sonner.test.tsx
@@ -1,0 +1,70 @@
+jest.mock("next-themes", () => ({
+  useTheme: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  Toaster: jest.fn(() => null),
+}));
+
+import { render } from "@testing-library/react";
+import { isValidElement } from "react";
+import { useTheme } from "next-themes";
+import { Toaster as Sonner } from "sonner";
+
+import { Toaster } from "./sonner";
+
+const mockUseTheme = jest.mocked(useTheme);
+const mockSonner = jest.mocked(Sonner);
+
+function createThemeResult(theme?: string): ReturnType<typeof useTheme> {
+  return {
+    forcedTheme: undefined,
+    resolvedTheme: theme,
+    setTheme: jest.fn(),
+    systemTheme: undefined,
+    theme,
+    themes: ["light", "dark", "system"],
+  };
+}
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes the active theme, icons, style variables, and caller props to Sonner", () => {
+    mockUseTheme.mockReturnValue(createThemeResult("dark"));
+
+    render(<Toaster closeButton position="bottom-right" />);
+
+    expect(mockSonner).toHaveBeenCalledTimes(1);
+
+    const props = mockSonner.mock.calls[0][0];
+
+    expect(props).toMatchObject({
+      className: "toaster group",
+      closeButton: true,
+      position: "bottom-right",
+      theme: "dark",
+    });
+    expect(props.style).toMatchObject({
+      "--border-radius": "var(--radius)",
+      "--normal-bg": "var(--popover)",
+      "--normal-border": "var(--border)",
+      "--normal-text": "var(--popover-foreground)",
+    });
+    expect(isValidElement(props.icons?.success)).toBe(true);
+    expect(isValidElement(props.icons?.info)).toBe(true);
+    expect(isValidElement(props.icons?.warning)).toBe(true);
+    expect(isValidElement(props.icons?.error)).toBe(true);
+    expect(isValidElement(props.icons?.loading)).toBe(true);
+  });
+
+  it("falls back to the system theme when the provider has no theme", () => {
+    mockUseTheme.mockReturnValue(createThemeResult());
+
+    render(<Toaster />);
+
+    expect(mockSonner.mock.calls[0][0].theme).toBe("system");
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused test coverage for `Badge`, including prop forwarding, variants, `asChild`, and `badgeVariants`.
- Add focused test coverage for `Toaster`, including theme fallback, Sonner prop forwarding, icons, and CSS variables.
- Update the test coverage plan with the latest metrics, verification notes, and next recommended slice.

## Verification

- `npm test -- core/components/ui/badge.test.tsx core/components/ui/sonner.test.tsx --runInBand --watchman=false`
- `npx jest core/components/ui/badge.test.tsx --coverage --collectCoverageFrom=core/components/ui/badge.tsx --runInBand --watchman=false`
- `npx jest core/components/ui/sonner.test.tsx --coverage --collectCoverageFrom=core/components/ui/sonner.tsx --runInBand --watchman=false`
- `npm run check:ci`
- `npm test -- --runInBand --watchman=false`
- `npm run test:coverage -- --runInBand --watchman=false`
- `npx tsc --noEmit`

## Notes / Risks

- No production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Badge UI component, including variant styling and `asChild` rendering behavior.
  * Added test coverage for the Toaster component, verifying theme resolution and fallback behavior.

* **Documentation**
  * Updated test coverage plan with latest metrics and newly achieved 100% coverage for Badge and Toaster components.
  * Added macOS-specific Jest configuration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->