### PR TITLE
test(ui): cover button component variants

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,12 +10,20 @@ Date: 2026-06-01
 
 Latest full verification:
 
-- `npm run check:ci` passed: 276 files checked.
-- `npm test -- --runInBand --watchman=false` passed: 66 test suites, 495
+- `npm run check:ci` passed: 277 files checked.
+- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 499
   tests, 0 snapshots.
-- `npm run test:coverage -- --runInBand --watchman=false` passed: 66 test
-  suites, 495 tests, 0 snapshots.
+- `npm run test:coverage -- --runInBand --watchman=false` passed: 67 test
+  suites, 499 tests, 0 snapshots.
 - `npx tsc --noEmit` passed.
+- `npx biome format --write core/components/ui/button.test.tsx` passed.
+- Sandboxed coverage writes failed with `EPERM` for `coverage/coverage-final.json`;
+  rerunning the focused and full coverage commands with elevated filesystem
+  access passed.
+- Sandboxed Biome format failed with `Operation not permitted`; rerunning with
+  elevated filesystem access passed with no changes needed.
+- Sandboxed `npx tsc --noEmit` failed with `EPERM` for
+  `tsconfig.tsbuildinfo`; rerunning with elevated filesystem access passed.
 - Initial `npm test -- core/components/ui/badge.test.tsx
   core/components/ui/sonner.test.tsx --runInBand` failed before Jest started
   because Watchman could not write
@@ -38,7 +46,7 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 96.69% |
+| Statements | 96.75% |
 | Branches | 98.59% |
 | Functions | 91.57% |
 | Lines | 98.62% |
@@ -58,26 +66,24 @@ Recent file-specific result:
 | `core/components/ui/card.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/badge.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/sonner.tsx` | 100% | 100% | 100% | 100% |
+| `core/components/ui/button.tsx` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
-- Added `core/components/ui/badge.test.tsx`.
-- Added `core/components/ui/sonner.test.tsx`.
+- Added `core/components/ui/button.test.tsx`.
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Covered badge prop forwarding, variant classes, `asChild` rendering, and
-  exported variant helper output.
-- Covered toaster theme fallback, caller prop forwarding, icon map creation, and
-  CSS variable style forwarding.
+- Covered button prop forwarding, selected variant and size classes, `asChild`
+  rendering, and exported variant helper output.
 - Focused Jest passed:
-  `npm test -- core/components/ui/badge.test.tsx
-  core/components/ui/sonner.test.tsx --runInBand --watchman=false` (6 tests).
-- Focused coverage probes passed with 100% coverage for
-  `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx`.
-- Full coverage passed with `core/components/ui` aggregate at 97.87%
+- `npm test -- core/components/ui/button.test.tsx --runInBand
+  --watchman=false` (4 tests).
+- Focused coverage probe passed with 100% coverage for
+  `core/components/ui/button.tsx`.
+- Full coverage passed with `core/components/ui` aggregate at 100%
   statements, 100% branches, 100% functions, and 100% lines.
-- Required raw focused Jest attempt failed before Jest started because Watchman
-  could not write the local LaunchAgent plist; `--watchman=false` is the working
-  local path on this macOS worktree.
+- Full coverage increased statements from 96.69% to 96.75%; branches,
+  functions, and lines stayed at 98.59%, 91.57%, and 98.62%.
+- `--watchman=false` remains required for Jest commands on this macOS worktree.
 - No production code was changed in this slice.
 
 ## Working Rules
@@ -135,15 +141,12 @@ Known local quirks:
 
 Recommended next slice:
 
-1. Component utility gaps:
-   - `core/components/ui/button.tsx`
-   - Next lowest-risk UI utilities after `badge.tsx` and `sonner.tsx` reached
-     100%.
-2. Route branch gaps:
+1. Route branch gaps:
    - `app/api/ai/questions/generate-question/route.ts`
    - `app/api/ai/resumes/analyze/route.ts`
    - `app/api/cron/sync-stripe-subscriptions/route.ts`
-   - Good follow-up once the low-risk helper branches are exhausted.
+   - Good follow-up now that the low-risk component utility branches are
+     exhausted.
 
 ## Completed Slices
 
@@ -185,6 +188,7 @@ Recommended next slice:
 | 2026-05-28 | Permission helper branches | Auth, interview, and question permission helpers reached 100% coverage. |
 | 2026-05-28 | Component utility coverage | `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx` reached 100% coverage. |
 | 2026-06-01 | Component utility coverage | `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx` reached 100% coverage. |
+| 2026-06-01 | Component utility coverage | `core/components/ui/button.tsx` reached 100% coverage. |
 
 ## Archive
 

--- a/core/components/ui/button.test.tsx
+++ b/core/components/ui/button.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+
+import { Button, buttonVariants } from "./button";
+
+describe("Button", () => {
+  it("renders a default button and forwards button props", () => {
+    render(
+      <Button
+        aria-label="Save changes"
+        className="custom-button"
+        disabled
+        type="submit"
+      >
+        Save
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Save changes" });
+
+    expect(button).toHaveAttribute("data-slot", "button");
+    expect(button).toHaveAttribute("type", "submit");
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass("custom-button");
+    expect(button).toHaveClass("bg-primary");
+    expect(button).toHaveClass("h-9");
+    expect(button).toHaveTextContent("Save");
+  });
+
+  it("applies the selected variant and size classes", () => {
+    render(
+      <Button size="icon-lg" variant="destructive">
+        Delete
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Delete" });
+
+    expect(button).toHaveClass("bg-destructive");
+    expect(button).toHaveClass("size-10");
+  });
+
+  it("renders as a child element while preserving button attributes", () => {
+    render(
+      <Button asChild size="sm" variant="link">
+        <a href="/dashboard">Dashboard</a>
+      </Button>,
+    );
+
+    const link = screen.getByRole("link", { name: "Dashboard" });
+
+    expect(link).toHaveAttribute("href", "/dashboard");
+    expect(link).toHaveAttribute("data-slot", "button");
+    expect(link).toHaveClass("text-primary");
+    expect(link).toHaveClass("h-8");
+  });
+});
+
+describe("buttonVariants", () => {
+  it("returns default and custom variant class names", () => {
+    expect(buttonVariants()).toContain("bg-primary");
+    expect(buttonVariants({ size: "lg", variant: "outline" })).toContain(
+      "border",
+    );
+    expect(buttonVariants({ size: "lg", variant: "outline" })).toContain(
+      "h-10",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused tests for `core/components/ui/button.tsx`
- Cover default prop forwarding, variant and size classes, `asChild` rendering, and `buttonVariants`
- Update `TEST_COVERAGE_PLAN.md` with the latest coverage results and next recommended targets

## Verification

- `npm test -- core/components/ui/button.test.tsx --runInBand --watchman=false`
- `npx jest core/components/ui/button.test.tsx --coverage --collectCoverageFrom=core/components/ui/button.tsx --runInBand --watchman=false`
- `npx biome format --write core/components/ui/button.test.tsx`
- `npm run check:ci`
- `npm test -- --runInBand --watchman=false`
- `npm run test:coverage -- --runInBand --watchman=false`
- `npx tsc --noEmit`
- `git diff --check`

## Notes

- `core/components/ui/button.tsx` is now at 100% coverage.
- Overall statement coverage increased from 96.69% to 96.75%.