### PR TITLE
test(routes): close AI and Stripe cron branch gaps

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,25 +10,25 @@ Date: 2026-06-01
 
 Latest full verification:
 
+- `npm test -- app/api/ai/questions/generate-question/route.test.ts
+  app/api/ai/resumes/analyze/route.test.ts
+  app/api/cron/sync-stripe-subscriptions/route.test.ts --runInBand
+  --watchman=false` passed: 3 test suites, 29 tests, 0 snapshots.
+- Focused coverage probes passed with 100% statements, branches, functions, and
+  lines for:
+  - `app/api/ai/questions/generate-question/route.ts`
+  - `app/api/ai/resumes/analyze/route.ts`
+  - `app/api/cron/sync-stripe-subscriptions/route.ts`
+- `npx biome format --write
+  app/api/ai/questions/generate-question/route.test.ts
+  app/api/ai/resumes/analyze/route.test.ts
+  app/api/cron/sync-stripe-subscriptions/route.test.ts` passed.
 - `npm run check:ci` passed: 277 files checked.
-- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 499
+- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 504
   tests, 0 snapshots.
 - `npm run test:coverage -- --runInBand --watchman=false` passed: 67 test
-  suites, 499 tests, 0 snapshots.
+  suites, 504 tests, 0 snapshots.
 - `npx tsc --noEmit` passed.
-- `npx biome format --write core/components/ui/button.test.tsx` passed.
-- Sandboxed coverage writes failed with `EPERM` for `coverage/coverage-final.json`;
-  rerunning the focused and full coverage commands with elevated filesystem
-  access passed.
-- Sandboxed Biome format failed with `Operation not permitted`; rerunning with
-  elevated filesystem access passed with no changes needed.
-- Sandboxed `npx tsc --noEmit` failed with `EPERM` for
-  `tsconfig.tsbuildinfo`; rerunning with elevated filesystem access passed.
-- Initial `npm test -- core/components/ui/badge.test.tsx
-  core/components/ui/sonner.test.tsx --runInBand` failed before Jest started
-  because Watchman could not write
-  `/Users/gurugumawaru/Library/LaunchAgents/com.github.facebook.watchman.plist`;
-  rerunning with `--watchman=false` passed.
 - Initial sandboxed `npm ci` failed with npm's `Exit handler never called`
   error while writing npm logs outside the workspace; rerunning with elevated
   filesystem access passed.
@@ -46,10 +46,10 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 96.75% |
-| Branches | 98.59% |
+| Statements | 96.98% |
+| Branches | 99.21% |
 | Functions | 91.57% |
-| Lines | 98.62% |
+| Lines | 98.74% |
 
 Recent file-specific result:
 
@@ -67,22 +67,33 @@ Recent file-specific result:
 | `core/components/ui/badge.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/sonner.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/button.tsx` | 100% | 100% | 100% | 100% |
+| `app/api/ai/questions/generate-question/route.ts` | 100% | 100% | 100% | 100% |
+| `app/api/ai/resumes/analyze/route.ts` | 100% | 100% | 100% | 100% |
+| `app/api/cron/sync-stripe-subscriptions/route.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
-- Added `core/components/ui/button.test.tsx`.
+- Expanded route tests:
+  - `app/api/ai/questions/generate-question/route.test.ts`
+  - `app/api/ai/resumes/analyze/route.test.ts`
+  - `app/api/cron/sync-stripe-subscriptions/route.test.ts`
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Covered button prop forwarding, selected variant and size classes, `asChild`
-  rendering, and exported variant helper output.
+- Covered generate-question inaccessible job info, permission error, and
+  unexpected error handling.
+- Covered resume analysis validation fallback when no issue message is
+  available.
+- Covered cron rejected reconciliation failures after the five returned error
+  samples are full.
 - Focused Jest passed:
-- `npm test -- core/components/ui/button.test.tsx --runInBand
-  --watchman=false` (4 tests).
-- Focused coverage probe passed with 100% coverage for
-  `core/components/ui/button.tsx`.
-- Full coverage passed with `core/components/ui` aggregate at 100%
-  statements, 100% branches, 100% functions, and 100% lines.
-- Full coverage increased statements from 96.69% to 96.75%; branches,
-  functions, and lines stayed at 98.59%, 91.57%, and 98.62%.
+  `npm test -- app/api/ai/questions/generate-question/route.test.ts
+  app/api/ai/resumes/analyze/route.test.ts
+  app/api/cron/sync-stripe-subscriptions/route.test.ts --runInBand
+  --watchman=false` (29 tests).
+- Focused coverage probes passed with 100% coverage for all three target route
+  files.
+- Full coverage increased statements from 96.75% to 96.98%, branches from
+  98.59% to 99.21%, and lines from 98.62% to 98.74%; functions stayed at
+  91.57%.
 - `--watchman=false` remains required for Jest commands on this macOS worktree.
 - No production code was changed in this slice.
 
@@ -141,12 +152,11 @@ Known local quirks:
 
 Recommended next slice:
 
-1. Route branch gaps:
-   - `app/api/ai/questions/generate-question/route.ts`
-   - `app/api/ai/resumes/analyze/route.ts`
-   - `app/api/cron/sync-stripe-subscriptions/route.ts`
-   - Good follow-up now that the low-risk component utility branches are
-     exhausted.
+1. Remaining component and helper gaps:
+   - `core/features/auth/components/OAuthSignInSection.tsx`
+   - `core/features/billing/webhookHelpers.ts`
+   - `core/features/interviews/service.ts`
+   - Good follow-up now that API route branch coverage is closed.
 
 ## Completed Slices
 
@@ -189,6 +199,7 @@ Recommended next slice:
 | 2026-05-28 | Component utility coverage | `core/components/ui/password-input.tsx` and `core/components/ui/card.tsx` reached 100% coverage. |
 | 2026-06-01 | Component utility coverage | `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx` reached 100% coverage. |
 | 2026-06-01 | Component utility coverage | `core/components/ui/button.tsx` reached 100% coverage. |
+| 2026-06-01 | Route branch coverage | AI question generation, resume analysis, and Stripe subscription cron routes reached 100% coverage. |
 
 ## Archive
 

--- a/app/api/ai/questions/generate-question/route.test.ts
+++ b/app/api/ai/questions/generate-question/route.test.ts
@@ -61,6 +61,7 @@ import { generateAiQuestion } from "@/core/services/ai/questions";
 import {
   DatabaseError,
   NotFoundError,
+  PermissionError,
   UnauthorizedError,
 } from "@/core/dal/errors";
 import { PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
@@ -104,6 +105,13 @@ async function expectTextResponse(
 ): Promise<void> {
   expect(response.status).toBe(status);
   await expect(response.text()).resolves.toBe(body);
+}
+
+function makeInaccessibleJobInfoResult(): Awaited<
+  ReturnType<typeof getJobInfoAction>
+> {
+  // The route defensively handles null, but the action's exported type is narrower.
+  return null as unknown as Awaited<ReturnType<typeof getJobInfoAction>>;
 }
 
 describe("POST /api/ai/questions/generate-question", () => {
@@ -184,6 +192,22 @@ describe("POST /api/ai/questions/generate-question", () => {
     expect(mockGenerateAiQuestion).not.toHaveBeenCalled();
   });
 
+  it("returns 403 when the job info is inaccessible", async () => {
+    mockGetJobInfoAction.mockResolvedValueOnce(makeInaccessibleJobInfoResult());
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+    expect(mockGetQuestionsAction).not.toHaveBeenCalled();
+    expect(mockGenerateAiQuestion).not.toHaveBeenCalled();
+  });
+
   it("returns a streamed success response and stores the generated question", async () => {
     const response = await POST(
       buildJsonRequest({ prompt: "medium", jobInfoId }),
@@ -251,6 +275,22 @@ describe("POST /api/ai/questions/generate-question", () => {
     );
   });
 
+  it("maps permission action failures to a 403 response", async () => {
+    mockGetJobInfoAction.mockRejectedValueOnce(
+      new PermissionError("Job info is not available"),
+    );
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(
+      response,
+      403,
+      "You do not have permission to do this",
+    );
+  });
+
   it("maps database failures to a 500 response", async () => {
     mockGetQuestionsAction.mockRejectedValueOnce(
       new DatabaseError("Question lookup failed"),
@@ -264,6 +304,24 @@ describe("POST /api/ai/questions/generate-question", () => {
       response,
       500,
       "Database error while generating question",
+    );
+  });
+
+  it("maps unexpected generation failures to a 500 response", async () => {
+    mockGetQuestionsAction.mockRejectedValueOnce(new Error("Model offline"));
+
+    const response = await POST(
+      buildJsonRequest({ prompt: "medium", jobInfoId }),
+    );
+
+    await expectTextResponse(
+      response,
+      500,
+      "An error occurred while generating your question",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error generating question:",
+      expect.any(Error),
     );
   });
 });

--- a/app/api/ai/resumes/analyze/route.test.ts
+++ b/app/api/ai/resumes/analyze/route.test.ts
@@ -10,13 +10,32 @@ jest.mock("@/core/features/resumeAnalysis/permissions", () => ({
   checkResumeAnalysisPermission: jest.fn(),
 }));
 
+jest.mock("@/core/features/resumeAnalysis/schemas", () => {
+  const actual = jest.requireActual<
+    typeof import("@/core/features/resumeAnalysis/schemas")
+  >("@/core/features/resumeAnalysis/schemas");
+
+  return {
+    ...actual,
+    resumeAnalysisInputSchema: {
+      ...actual.resumeAnalysisInputSchema,
+      safeParse: jest.fn((input: unknown) =>
+        actual.resumeAnalysisInputSchema.safeParse(input),
+      ),
+    },
+  };
+});
+
 jest.mock("@/core/services/ai/resumes/ai", () => ({
   analyzeResumeForJob: jest.fn(),
 }));
 
+import { z } from "zod";
+
 import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { getJobInfoAction } from "@/core/features/jobInfos/actions";
 import { checkResumeAnalysisPermission } from "@/core/features/resumeAnalysis/permissions";
+import { resumeAnalysisInputSchema } from "@/core/features/resumeAnalysis/schemas";
 import { analyzeResumeForJob } from "@/core/services/ai/resumes/ai";
 import {
   DatabaseError,
@@ -35,6 +54,12 @@ const mockCheckResumeAnalysisPermission = jest.mocked(
   checkResumeAnalysisPermission,
 );
 const mockAnalyzeResumeForJob = jest.mocked(analyzeResumeForJob);
+const mockResumeAnalysisSafeParse = jest.mocked(
+  resumeAnalysisInputSchema.safeParse,
+);
+const actualResumeAnalysisInputSchema = jest.requireActual<
+  typeof import("@/core/features/resumeAnalysis/schemas")
+>("@/core/features/resumeAnalysis/schemas").resumeAnalysisInputSchema;
 
 const jobInfoId = "00000000-0000-4000-8000-000000000401";
 
@@ -105,6 +130,9 @@ describe("POST /api/ai/resumes/analyze", () => {
       makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID }),
     );
     mockCheckResumeAnalysisPermission.mockResolvedValue(true);
+    mockResumeAnalysisSafeParse.mockImplementation((input) =>
+      actualResumeAnalysisInputSchema.safeParse(input),
+    );
     mockAnalyzeStream();
 
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -120,6 +148,19 @@ describe("POST /api/ai/resumes/analyze", () => {
     await expectTextResponse(response, 400, "Missing resume or job info id");
     expect(mockGetJobInfoAction).not.toHaveBeenCalled();
     expect(mockCheckResumeAnalysisPermission).not.toHaveBeenCalled();
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+  });
+
+  it("returns the fallback validation message when no issue message is available", async () => {
+    mockResumeAnalysisSafeParse.mockReturnValueOnce({
+      success: false,
+      error: new z.ZodError([]),
+    });
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(response, 400, "Missing resume or job info id");
+    expect(mockGetJobInfoAction).not.toHaveBeenCalled();
     expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
   });
 

--- a/app/api/cron/sync-stripe-subscriptions/route.test.ts
+++ b/app/api/cron/sync-stripe-subscriptions/route.test.ts
@@ -220,6 +220,33 @@ describe("GET /api/cron/sync-stripe-subscriptions", () => {
     });
   });
 
+  it("limits returned error samples for rejected reconciliation failures", async () => {
+    const userIds = Array.from({ length: 6 }, (_, idx) => `user-${idx + 1}`);
+    mockGetUserIdsWithStripeSubscriptionDb.mockResolvedValueOnce(userIds);
+    mockReconcileUserStripeSubscription.mockRejectedValue(
+      new Error("stripe_unavailable"),
+    );
+
+    const response = await GET(buildCronRequest());
+
+    await expectJsonResponse(response, 200, {
+      ok: true,
+      batchLimit: 500,
+      candidates: 6,
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      errors: 6,
+      errorSamples: [
+        "user-1:stripe_unavailable",
+        "user-2:stripe_unavailable",
+        "user-3:stripe_unavailable",
+        "user-4:stripe_unavailable",
+        "user-5:stripe_unavailable",
+      ],
+    });
+  });
+
   it("propagates unexpected user lookup failures", async () => {
     mockGetUserIdsWithStripeSubscriptionDb.mockRejectedValueOnce(
       new Error("database offline"),


### PR DESCRIPTION
## Summary

- Expanded AI question generation route tests for inaccessible job info, permission failures, and unexpected generation errors.
- Added resume analysis validation fallback coverage when schema validation has no issue message.
- Added Stripe subscription cron coverage for rejected reconciliation failures after returned error samples are capped.
- Updated `TEST_COVERAGE_PLAN.md` with the latest coverage results and next recommended targets.

## Verification

- `npm test -- app/api/ai/questions/generate-question/route.test.ts app/api/ai/resumes/analyze/route.test.ts app/api/cron/sync-stripe-subscriptions/route.test.ts --runInBand --watchman=false`
- `npx jest app/api/ai/questions/generate-question/route.test.ts --coverage --collectCoverageFrom=app/api/ai/questions/generate-question/route.ts --runInBand --watchman=false`
- `npx jest app/api/ai/resumes/analyze/route.test.ts --coverage --collectCoverageFrom=app/api/ai/resumes/analyze/route.ts --runInBand --watchman=false`
- `npx jest app/api/cron/sync-stripe-subscriptions/route.test.ts --coverage --collectCoverageFrom=app/api/cron/sync-stripe-subscriptions/route.ts --runInBand --watchman=false`
- `npx biome format --write app/api/ai/questions/generate-question/route.test.ts app/api/ai/resumes/analyze/route.test.ts app/api/cron/sync-stripe-subscriptions/route.test.ts`
- `npm run check:ci`
- `npm test -- --runInBand --watchman=false`
- `npm run test:coverage -- --runInBand --watchman=false`
- `npx tsc --noEmit`

## Notes

Coverage moved from 96.75% to 96.98% statements, 98.59% to 99.21% branches, and 98.62% to 98.74% lines. Functions stayed at 91.57%.