### PR TITLE
test(coverage): close component and helper gaps

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,28 +10,25 @@ Date: 2026-06-01
 
 Latest full verification:
 
-- `npm test -- app/api/ai/questions/generate-question/route.test.ts
-  app/api/ai/resumes/analyze/route.test.ts
-  app/api/cron/sync-stripe-subscriptions/route.test.ts --runInBand
-  --watchman=false` passed: 3 test suites, 29 tests, 0 snapshots.
+- `npm test -- core/features/auth/components/OAuthSignInSection.test.tsx
+  core/features/billing/webhookHelpers.test.ts
+  core/features/interviews/service.test.ts --runInBand --watchman=false`
+  passed: 3 test suites, 37 tests, 0 snapshots.
 - Focused coverage probes passed with 100% statements, branches, functions, and
   lines for:
-  - `app/api/ai/questions/generate-question/route.ts`
-  - `app/api/ai/resumes/analyze/route.ts`
-  - `app/api/cron/sync-stripe-subscriptions/route.ts`
+  - `core/features/auth/components/OAuthSignInSection.tsx`
+  - `core/features/billing/webhookHelpers.ts`
+  - `core/features/interviews/service.ts`
 - `npx biome format --write
-  app/api/ai/questions/generate-question/route.test.ts
-  app/api/ai/resumes/analyze/route.test.ts
-  app/api/cron/sync-stripe-subscriptions/route.test.ts` passed.
+  core/features/auth/components/OAuthSignInSection.test.tsx
+  core/features/billing/webhookHelpers.test.ts
+  core/features/interviews/service.test.ts` passed.
 - `npm run check:ci` passed: 277 files checked.
-- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 504
+- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 507
   tests, 0 snapshots.
 - `npm run test:coverage -- --runInBand --watchman=false` passed: 67 test
-  suites, 504 tests, 0 snapshots.
+  suites, 507 tests, 0 snapshots.
 - `npx tsc --noEmit` passed.
-- Initial sandboxed `npm ci` failed with npm's `Exit handler never called`
-  error while writing npm logs outside the workspace; rerunning with elevated
-  filesystem access passed.
 
 Previous full verification:
 
@@ -46,10 +43,10 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 96.98% |
-| Branches | 99.21% |
-| Functions | 91.57% |
-| Lines | 98.74% |
+| Statements | 97.15% |
+| Branches | 99.68% |
+| Functions | 91.94% |
+| Lines | 98.92% |
 
 Recent file-specific result:
 
@@ -70,30 +67,33 @@ Recent file-specific result:
 | `app/api/ai/questions/generate-question/route.ts` | 100% | 100% | 100% | 100% |
 | `app/api/ai/resumes/analyze/route.ts` | 100% | 100% | 100% | 100% |
 | `app/api/cron/sync-stripe-subscriptions/route.ts` | 100% | 100% | 100% | 100% |
+| `core/features/auth/components/OAuthSignInSection.tsx` | 100% | 100% | 100% | 100% |
+| `core/features/billing/webhookHelpers.ts` | 100% | 100% | 100% | 100% |
+| `core/features/interviews/service.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
-- Expanded route tests:
-  - `app/api/ai/questions/generate-question/route.test.ts`
-  - `app/api/ai/resumes/analyze/route.test.ts`
-  - `app/api/cron/sync-stripe-subscriptions/route.test.ts`
+- Expanded focused tests:
+  - `core/features/auth/components/OAuthSignInSection.test.tsx`
+  - `core/features/billing/webhookHelpers.test.ts`
+  - `core/features/interviews/service.test.ts`
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Covered generate-question inaccessible job info, permission error, and
-  unexpected error handling.
-- Covered resume analysis validation fallback when no issue message is
-  available.
-- Covered cron rejected reconciliation failures after the five returned error
-  samples are full.
+- Covered the OAuth provider defensive default path for unsupported runtime
+  values.
+- Covered checkout fulfillment when Stripe returns an expanded subscription
+  payload without a customer id.
+- Covered feedback generation rejection when no accessible interview exists.
+- Isolated the interview DAL nullable mock boundary in a named helper to avoid
+  repeating broad casts.
 - Focused Jest passed:
-  `npm test -- app/api/ai/questions/generate-question/route.test.ts
-  app/api/ai/resumes/analyze/route.test.ts
-  app/api/cron/sync-stripe-subscriptions/route.test.ts --runInBand
-  --watchman=false` (29 tests).
-- Focused coverage probes passed with 100% coverage for all three target route
-  files.
-- Full coverage increased statements from 96.75% to 96.98%, branches from
-  98.59% to 99.21%, and lines from 98.62% to 98.74%; functions stayed at
-  91.57%.
+  `npm test -- core/features/auth/components/OAuthSignInSection.test.tsx
+  core/features/billing/webhookHelpers.test.ts
+  core/features/interviews/service.test.ts --runInBand --watchman=false` (37
+  tests).
+- Focused coverage probes passed with 100% coverage for all three target files.
+- Full coverage increased statements from 96.98% to 97.15%, branches from
+  99.21% to 99.68%, functions from 91.57% to 91.94%, and lines from 98.74% to
+  98.92%.
 - `--watchman=false` remains required for Jest commands on this macOS worktree.
 - No production code was changed in this slice.
 
@@ -152,11 +152,13 @@ Known local quirks:
 
 Recommended next slice:
 
-1. Remaining component and helper gaps:
-   - `core/features/auth/components/OAuthSignInSection.tsx`
-   - `core/features/billing/webhookHelpers.ts`
-   - `core/features/interviews/service.ts`
-   - Good follow-up now that API route branch coverage is closed.
+1. Remaining low-risk helper and fixture gaps:
+   - `core/dal/errors.ts`
+   - `core/drizzle/schemaHelpers.ts`
+   - `core/test-utils/factories/stripeEvent.ts`
+   - `core/test-utils/factories/user.ts`
+   - `core/test-utils/mocks/db.ts`
+   - `core/test-utils/mocks/next.ts`
 
 ## Completed Slices
 
@@ -200,6 +202,7 @@ Recommended next slice:
 | 2026-06-01 | Component utility coverage | `core/components/ui/badge.tsx` and `core/components/ui/sonner.tsx` reached 100% coverage. |
 | 2026-06-01 | Component utility coverage | `core/components/ui/button.tsx` reached 100% coverage. |
 | 2026-06-01 | Route branch coverage | AI question generation, resume analysis, and Stripe subscription cron routes reached 100% coverage. |
+| 2026-06-01 | Component and helper gaps | OAuth sign-in section, billing webhook helpers, and interview service reached 100% coverage. |
 
 ## Archive
 

--- a/core/features/auth/components/OAuthSignInSection.test.tsx
+++ b/core/features/auth/components/OAuthSignInSection.test.tsx
@@ -5,6 +5,7 @@ jest.mock("@/core/features/auth/actions", () => ({
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import type { OAuthProvider } from "@/core/drizzle/schema/oauthProviderIds";
 import { signInWithOAuthAction } from "@/core/features/auth/actions";
 
 import { OAuthSignInSection } from "./OAuthSignInSection";
@@ -55,5 +56,15 @@ describe("OAuthSignInSection", () => {
     expect(mockSignInWithOAuthAction).toHaveBeenCalledWith("discord", {
       errorReturn: "sign-up",
     });
+  });
+
+  it("throws for an unsupported provider value at runtime", () => {
+    const unsupportedProvider = "linkedin" as OAuthProvider;
+
+    expect(() =>
+      render(
+        <OAuthSignInSection configuredOAuthProviders={[unsupportedProvider]} />,
+      ),
+    ).toThrow("Unexpected: linkedin");
   });
 });

--- a/core/features/billing/webhookHelpers.test.ts
+++ b/core/features/billing/webhookHelpers.test.ts
@@ -267,6 +267,32 @@ describe("fulfillCheckoutSession", () => {
     );
     expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
   });
+
+  it("skips sessions whose retrieved expanded subscription has no customer id", async () => {
+    const session = makeStripeCheckoutSession({
+      id: "cs_test_subscription_customer_missing",
+      userId: "user-test",
+      customerId: "cus_test_checkout",
+      subscriptionId: "sub_test_customer_missing",
+    });
+    retrieveSubscription.mockResolvedValueOnce(
+      makeStripeSubscription({
+        id: "sub_test_customer_missing",
+        customer: null,
+        status: "active",
+      }),
+    );
+
+    await expect(fulfillCheckoutSession(session)).resolves.toBe(false);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "fulfillCheckoutSession: subscription is not fulfillable",
+      ),
+      "cs_test_subscription_customer_missing",
+    );
+    expect(mockUpdateUserPlanAndStripeIdsDb).not.toHaveBeenCalled();
+  });
 });
 
 describe("markStripeEventProcessed", () => {

--- a/core/features/interviews/service.test.ts
+++ b/core/features/interviews/service.test.ts
@@ -65,9 +65,19 @@ const mockGenerateAiInterviewFeedback = jest.mocked(
   generateAiInterviewFeedback,
 );
 
+type InterviewByIdDalResult = Awaited<ReturnType<typeof getInterviewByIdDal>>;
+
 const SIGNED_IN_USER_ID = TEST_USER_ID;
 const OTHER_USER_ID = TEST_OTHER_USER_ID;
 const SIGNED_IN_USER_NAME = TEST_USER_NAME;
+
+function mockNoInterviewFound() {
+  // The service handles a nullable DAL result, but the mocked DAL type is inferred
+  // from the selected relation shape. Keep the boundary cast in one helper.
+  mockGetInterviewByIdDal.mockResolvedValue(
+    null as unknown as InterviewByIdDalResult,
+  );
+}
 
 describe("interview service", () => {
   beforeEach(() => {
@@ -95,9 +105,7 @@ describe("interview service", () => {
   });
 
   it("returns null when the interview does not exist", async () => {
-    mockGetInterviewByIdDal.mockResolvedValue(
-      null as unknown as Awaited<ReturnType<typeof getInterviewByIdDal>>,
-    );
+    mockNoInterviewFound();
 
     await expect(
       getInterviewByIdService("interview-1", SIGNED_IN_USER_ID),
@@ -158,9 +166,7 @@ describe("interview service", () => {
   });
 
   it("rejects interview updates when no accessible interview exists", async () => {
-    mockGetInterviewByIdDal.mockResolvedValue(
-      null as unknown as Awaited<ReturnType<typeof getInterviewByIdDal>>,
-    );
+    mockNoInterviewFound();
 
     await expect(
       updateInterviewService("interview-1", { duration: "00:01:00" }),
@@ -217,6 +223,17 @@ describe("interview service", () => {
     ).rejects.toBeInstanceOf(PermissionError);
 
     expect(mockGenerateAiInterviewFeedback).not.toHaveBeenCalled();
+  });
+
+  it("rejects feedback generation when no accessible interview exists", async () => {
+    mockNoInterviewFound();
+
+    await expect(
+      generateInterviewFeedbackService("interview-1"),
+    ).rejects.toBeInstanceOf(PermissionError);
+
+    expect(mockGenerateAiInterviewFeedback).not.toHaveBeenCalled();
+    expect(mockUpdateInterviewDal).not.toHaveBeenCalled();
   });
 
   it("throws when AI feedback generation returns no feedback", async () => {


### PR DESCRIPTION
## Summary

- Added focused coverage for `OAuthSignInSection` unsupported runtime provider handling.
- Added Stripe webhook helper coverage for expanded subscriptions without a customer id.
- Added interview service coverage for feedback generation when no accessible interview exists.
- Updated `TEST_COVERAGE_PLAN.md` with the latest coverage results and next recommended targets.

## Verification

- `npm test -- core/features/auth/components/OAuthSignInSection.test.tsx core/features/billing/webhookHelpers.test.ts core/features/interviews/service.test.ts --runInBand --watchman=false`
- Focused coverage probes for:
  - `core/features/auth/components/OAuthSignInSection.tsx`
  - `core/features/billing/webhookHelpers.ts`
  - `core/features/interviews/service.ts`
- `npx biome format --write core/features/auth/components/OAuthSignInSection.test.tsx core/features/billing/webhookHelpers.test.ts core/features/interviews/service.test.ts`
- `npm run check:ci`
- `npm test -- --runInBand --watchman=false`
- `npm run test:coverage -- --runInBand --watchman=false`
- `npx tsc --noEmit`

## Notes

- Full coverage moved to 97.15% statements, 99.68% branches, 91.94% functions, and 98.92% lines.
- No production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test coverage metrics and planning documentation with latest verification results, including revised recommendations for remaining coverage targets.

* **Tests**
  * Expanded test coverage for authentication provider handling, billing subscription processing, and interview service operations with additional validation scenarios for edge cases including unsupported providers, missing subscription customer associations, and missing interview access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->