### PR TITLE
test(coverage): close helper and fixture gaps

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,24 +10,29 @@ Date: 2026-06-01
 
 Latest full verification:
 
-- `npm test -- core/features/auth/components/OAuthSignInSection.test.tsx
-  core/features/billing/webhookHelpers.test.ts
-  core/features/interviews/service.test.ts --runInBand --watchman=false`
-  passed: 3 test suites, 37 tests, 0 snapshots.
+- `npm test -- core/dal/errors.test.ts core/drizzle/schemaHelpers.test.ts
+  core/test-utils/factories/stripeEvent.test.ts
+  core/test-utils/factories/user.test.ts core/test-utils/mocks/db.test.ts
+  core/test-utils/mocks/next.test.ts --runInBand --watchman=false` passed:
+  6 test suites, 58 tests, 0 snapshots.
 - Focused coverage probes passed with 100% statements, branches, functions, and
   lines for:
-  - `core/features/auth/components/OAuthSignInSection.tsx`
-  - `core/features/billing/webhookHelpers.ts`
-  - `core/features/interviews/service.ts`
-- `npx biome format --write
-  core/features/auth/components/OAuthSignInSection.test.tsx
-  core/features/billing/webhookHelpers.test.ts
-  core/features/interviews/service.test.ts` passed.
-- `npm run check:ci` passed: 277 files checked.
-- `npm test -- --runInBand --watchman=false` passed: 67 test suites, 507
+  - `core/dal/errors.ts`
+  - `core/drizzle/schemaHelpers.ts`
+  - `core/test-utils/factories/stripeEvent.ts`
+  - `core/test-utils/factories/user.ts`
+  - `core/test-utils/mocks/db.ts`
+  - `core/test-utils/mocks/next.ts`
+- `npx biome format --write core/dal/errors.test.ts
+  core/drizzle/schemaHelpers.test.ts
+  core/test-utils/factories/stripeEvent.test.ts
+  core/test-utils/factories/user.test.ts core/test-utils/mocks/db.test.ts
+  core/test-utils/mocks/next.test.ts` passed.
+- `npm run check:ci` passed: 279 files checked.
+- `npm test -- --runInBand --watchman=false` passed: 69 test suites, 522
   tests, 0 snapshots.
-- `npm run test:coverage -- --runInBand --watchman=false` passed: 67 test
-  suites, 507 tests, 0 snapshots.
+- `npm run test:coverage -- --runInBand --watchman=false` passed: 69 test
+  suites, 522 tests, 0 snapshots.
 - `npx tsc --noEmit` passed.
 
 Previous full verification:
@@ -43,10 +48,10 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 97.15% |
-| Branches | 99.68% |
-| Functions | 91.94% |
-| Lines | 98.92% |
+| Statements | 97.60% |
+| Branches | 100% |
+| Functions | 94.13% |
+| Lines | 99.34% |
 
 Recent file-specific result:
 
@@ -70,30 +75,34 @@ Recent file-specific result:
 | `core/features/auth/components/OAuthSignInSection.tsx` | 100% | 100% | 100% | 100% |
 | `core/features/billing/webhookHelpers.ts` | 100% | 100% | 100% | 100% |
 | `core/features/interviews/service.ts` | 100% | 100% | 100% | 100% |
+| `core/dal/errors.ts` | 100% | 100% | 100% | 100% |
+| `core/drizzle/schemaHelpers.ts` | 100% | 100% | 100% | 100% |
+| `core/test-utils/factories/stripeEvent.ts` | 100% | 100% | 100% | 100% |
+| `core/test-utils/factories/user.ts` | 100% | 100% | 100% | 100% |
+| `core/test-utils/mocks/db.ts` | 100% | 100% | 100% | 100% |
+| `core/test-utils/mocks/next.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
+- Added focused tests:
+  - `core/dal/errors.test.ts`
+  - `core/drizzle/schemaHelpers.test.ts`
 - Expanded focused tests:
-  - `core/features/auth/components/OAuthSignInSection.test.tsx`
-  - `core/features/billing/webhookHelpers.test.ts`
-  - `core/features/interviews/service.test.ts`
+  - `core/test-utils/factories/stripeEvent.test.ts`
+  - `core/test-utils/factories/user.test.ts`
+  - `core/test-utils/mocks/db.test.ts`
+  - `core/test-utils/mocks/next.test.ts`
 - Updated `TEST_COVERAGE_PLAN.md`.
-- Covered the OAuth provider defensive default path for unsupported runtime
-  values.
-- Covered checkout fulfillment when Stripe returns an expanded subscription
-  payload without a customer id.
-- Covered feedback generation rejection when no accessible interview exists.
-- Isolated the interview DAL nullable mock boundary in a named helper to avoid
-  repeating broad casts.
-- Focused Jest passed:
-  `npm test -- core/features/auth/components/OAuthSignInSection.test.tsx
-  core/features/billing/webhookHelpers.test.ts
-  core/features/interviews/service.test.ts --runInBand --watchman=false` (37
-  tests).
-- Focused coverage probes passed with 100% coverage for all three target files.
-- Full coverage increased statements from 96.98% to 97.15%, branches from
-  99.21% to 99.68%, functions from 91.57% to 91.94%, and lines from 98.74% to
-  98.92%.
+- Covered DAL error names/messages/causes and Drizzle shared column helper
+  metadata using public column instances.
+- Covered Stripe fixture default customer/session paths, current-user redirect
+  sentinel behavior, Drizzle mock promise helpers/default query results, and
+  Next mock cookie dump/default redirect digest behavior.
+- Focused Jest passed for the six touched helper test files (58 tests).
+- Focused coverage probes passed with 100% coverage for all six target files.
+- Full coverage increased statements from 97.15% to 97.60%, branches from
+  99.68% to 100%, functions from 91.94% to 94.13%, and lines from 98.92% to
+  99.34%.
 - `--watchman=false` remains required for Jest commands on this macOS worktree.
 - No production code was changed in this slice.
 
@@ -152,13 +161,17 @@ Known local quirks:
 
 Recommended next slice:
 
-1. Remaining low-risk helper and fixture gaps:
-   - `core/dal/errors.ts`
-   - `core/drizzle/schemaHelpers.ts`
-   - `core/test-utils/factories/stripeEvent.ts`
-   - `core/test-utils/factories/user.ts`
-   - `core/test-utils/mocks/db.ts`
-   - `core/test-utils/mocks/next.ts`
+1. Remaining schema declaration coverage gaps:
+   - `core/drizzle/schema/interview.ts`
+   - `core/drizzle/schema/jobInfo.ts`
+   - `core/drizzle/schema/question.ts`
+   - `core/drizzle/schema/session.ts`
+   - `core/drizzle/schema/token.ts`
+   - `core/drizzle/schema/userOAuthAccount.ts`
+2. Small residual helper gaps:
+   - `core/features/auth/constants.ts`
+   - `core/features/auth/oauth/google.ts`
+   - `core/test-utils/factories/index.ts`
 
 ## Completed Slices
 
@@ -203,6 +216,7 @@ Recommended next slice:
 | 2026-06-01 | Component utility coverage | `core/components/ui/button.tsx` reached 100% coverage. |
 | 2026-06-01 | Route branch coverage | AI question generation, resume analysis, and Stripe subscription cron routes reached 100% coverage. |
 | 2026-06-01 | Component and helper gaps | OAuth sign-in section, billing webhook helpers, and interview service reached 100% coverage. |
+| 2026-06-01 | Helper and fixture gaps | DAL errors, schema helpers, Stripe/user factories, and DB/Next mocks reached 100% coverage. |
 
 ## Archive
 

--- a/core/dal/errors.test.ts
+++ b/core/dal/errors.test.ts
@@ -1,0 +1,64 @@
+import {
+  DatabaseError,
+  NotFoundError,
+  PermissionError,
+  UnauthorizedError,
+  ValidationError,
+} from "./errors";
+
+describe("DAL errors", () => {
+  it("uses the default unauthorized message when none is provided", () => {
+    const error = new UnauthorizedError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("UnauthorizedError");
+    expect(error.message).toBe("You must be logged in to perform this action");
+  });
+
+  it("keeps custom messages and names for domain errors", () => {
+    const errors = [
+      new UnauthorizedError("auth required"),
+      new NotFoundError("missing record"),
+      new PermissionError("not allowed"),
+      new ValidationError("invalid input"),
+    ];
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        name: "UnauthorizedError",
+        message: "auth required",
+      }),
+      expect.objectContaining({
+        name: "NotFoundError",
+        message: "missing record",
+      }),
+      expect.objectContaining({
+        name: "PermissionError",
+        message: "not allowed",
+      }),
+      expect.objectContaining({
+        name: "ValidationError",
+        message: "invalid input",
+      }),
+    ]);
+  });
+
+  it("preserves the original database error as both a property and cause", () => {
+    const originalError = new Error("connection refused");
+
+    const error = new DatabaseError("database failed", originalError);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("DatabaseError");
+    expect(error.message).toBe("database failed");
+    expect(error.originalError).toBe(originalError);
+    expect(error.cause).toBe(originalError);
+  });
+
+  it("allows database errors without an original error", () => {
+    const error = new DatabaseError("database failed");
+
+    expect(error.originalError).toBeUndefined();
+    expect(error.cause).toBeUndefined();
+  });
+});

--- a/core/drizzle/schemaHelpers.test.ts
+++ b/core/drizzle/schemaHelpers.test.ts
@@ -1,0 +1,50 @@
+import { pgTable } from "drizzle-orm/pg-core";
+
+import { createdAt, id, updatedAt } from "./schemaHelpers";
+
+describe("schema helpers", () => {
+  const table = pgTable("coverage_probe", {
+    id,
+    createdAt,
+    updatedAt,
+  });
+
+  it("configures id as a defaulted primary uuid column", () => {
+    expect(table.id).toEqual(
+      expect.objectContaining({
+        columnType: "PgUUID",
+        dataType: "string",
+        hasDefault: true,
+        notNull: true,
+        primary: true,
+      }),
+    );
+  });
+
+  it("configures createdAt as a timezone-aware default timestamp", () => {
+    expect(table.createdAt).toEqual(
+      expect.objectContaining({
+        columnType: "PgTimestamp",
+        dataType: "date",
+        hasDefault: true,
+        notNull: true,
+        primary: false,
+        withTimezone: true,
+      }),
+    );
+  });
+
+  it("configures updatedAt with an on-update timestamp callback", () => {
+    expect(table.updatedAt).toEqual(
+      expect.objectContaining({
+        columnType: "PgTimestamp",
+        dataType: "date",
+        hasDefault: true,
+        notNull: true,
+        withTimezone: true,
+      }),
+    );
+    expect(table.updatedAt.onUpdateFn).toEqual(expect.any(Function));
+    expect(table.updatedAt.onUpdateFn?.()).toBeInstanceOf(Date);
+  });
+});

--- a/core/test-utils/factories/stripeEvent.test.ts
+++ b/core/test-utils/factories/stripeEvent.test.ts
@@ -50,6 +50,12 @@ describe("makeStripeSubscription", () => {
 });
 
 describe("makeStripeCustomer", () => {
+  it("returns a placeholder customer id by default", () => {
+    const customer = makeStripeCustomer();
+
+    expect(customer.id).toBe("cus_test_expanded");
+  });
+
   it("returns the minimal expanded customer shape", () => {
     const customer = makeStripeCustomer("cus_test_custom");
 
@@ -117,6 +123,17 @@ describe("makeStripeEvent", () => {
 });
 
 describe("named Stripe event builders", () => {
+  it("makeCheckoutSessionCompletedEvent builds a default paid session", () => {
+    const event = makeCheckoutSessionCompletedEvent();
+
+    expect(event.type).toBe(
+      STRIPE_WEBHOOK_EVENT_TYPES.checkoutSessionCompleted,
+    );
+    const session = event.data.object as Stripe.Checkout.Session;
+    expect(session.payment_status).toBe("paid");
+    expect(session.metadata?.userId).toMatch(/^user-/);
+  });
+
   it("makeCheckoutSessionCompletedEvent has the correct type and nested session", () => {
     const event = makeCheckoutSessionCompletedEvent({ userId: "user-c1" });
 

--- a/core/test-utils/factories/user.test.ts
+++ b/core/test-utils/factories/user.test.ts
@@ -89,6 +89,12 @@ describe("makeCurrentUser", () => {
     expect(currentUser.redirectToSignIn).toEqual(expect.any(Function));
   });
 
+  it("throws a redirect sentinel from the default sign-in redirect", () => {
+    const currentUser = makeCurrentUser();
+
+    expect(() => currentUser.redirectToSignIn()).toThrow("redirect");
+  });
+
   it("accepts overrides for anonymous-user scenarios", () => {
     const currentUser = makeCurrentUser({ userId: null });
 

--- a/core/test-utils/mocks/db.test.ts
+++ b/core/test-utils/mocks/db.test.ts
@@ -21,9 +21,34 @@ describe("createDrizzleMutationChainMock", () => {
 
     await expect(chain.returning({ id: "column" })).resolves.toBe(rows);
   });
+
+  it("supports promise finally handlers on the chain", async () => {
+    const chain = createDrizzleMutationChainMock([{ id: "user-1" }]);
+    const onFinally = jest.fn();
+
+    await chain.finally(onFinally);
+
+    expect(onFinally).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports promise catch handlers on the chain", async () => {
+    const chain = createDrizzleMutationChainMock([{ id: "user-1" }]);
+    const onCatch = jest.fn();
+
+    await chain.catch(onCatch);
+
+    expect(onCatch).not.toHaveBeenCalled();
+  });
 });
 
 describe("createMockDrizzleTableQuery", () => {
+  it("defaults query methods to resolving undefined", async () => {
+    const query = createMockDrizzleTableQuery();
+
+    await expect(query.findFirst()).resolves.toBeUndefined();
+    await expect(query.findMany()).resolves.toBeUndefined();
+  });
+
   it("exposes findFirst and findMany as jest functions with configured results", async () => {
     const query = createMockDrizzleTableQuery({
       findFirst: { id: "user-1" },

--- a/core/test-utils/mocks/next.test.ts
+++ b/core/test-utils/mocks/next.test.ts
@@ -71,6 +71,17 @@ describe("createMockCookieStore", () => {
 
     expect(store.has("x")).toBe(false);
   });
+
+  it("_dump returns the current cookie records", () => {
+    const store = createMockCookieStore([{ name: "a", value: "1" }]);
+
+    store.set("b", "2");
+
+    expect(store._dump()).toEqual([
+      { name: "a", value: "1" },
+      { name: "b", value: "2", options: undefined },
+    ]);
+  });
 });
 
 describe("createNextHeadersMock", () => {
@@ -107,6 +118,13 @@ describe("createNextHeadersMock", () => {
 });
 
 describe("createNextNavigationMock", () => {
+  it("NextRedirectError defaults to a temporary redirect digest", () => {
+    const error = new NextRedirectError("/target");
+
+    expect(error.message).toBe("NEXT_REDIRECT /target");
+    expect(error.digest).toBe("NEXT_REDIRECT;/target");
+  });
+
   it("redirect throws NextRedirectError and records the URL", () => {
     const mock = createNextNavigationMock();
 


### PR DESCRIPTION
## Summary
- Add focused coverage for DAL error classes and shared Drizzle schema helpers.
- Expand Stripe/user fixture and DB/Next mock tests for default and edge paths.
- Update `TEST_COVERAGE_PLAN.md` with the latest coverage results and next targets.

## Verification
- `npm test -- core/dal/errors.test.ts core/drizzle/schemaHelpers.test.ts core/test-utils/factories/stripeEvent.test.ts core/test-utils/factories/user.test.ts core/test-utils/mocks/db.test.ts core/test-utils/mocks/next.test.ts --runInBand --watchman=false`
- Focused coverage probes for all six target source files
- `npx biome format --write core/dal/errors.test.ts core/drizzle/schemaHelpers.test.ts core/test-utils/factories/stripeEvent.test.ts core/test-utils/factories/user.test.ts core/test-utils/mocks/db.test.ts core/test-utils/mocks/next.test.ts`
- `npm run check:ci`
- `npm test -- --runInBand --watchman=false`
- `npm run test:coverage -- --runInBand --watchman=false`
- `npx tsc --noEmit`

## Notes
- Overall coverage moved to 97.60% statements, 100% branches, 94.13% functions, and 99.34% lines.
- No production code or dependency files changed.