### PR TITLE
test(job-infos): cover job info form behavior

### DIFF
--- a/core/features/jobInfos/components/JobInfoForm.test.tsx
+++ b/core/features/jobInfos/components/JobInfoForm.test.tsx
@@ -107,7 +107,7 @@ describe("JobInfoForm", () => {
   it("renders existing job info and submits edits to updateJobInfoAction with the job id", async () => {
     mockUpdateJobInfoAction.mockResolvedValue({
       success: true,
-      data: { id: "job-info-existing" },
+      data: { id: existingJobInfo.id },
     });
 
     render(<JobInfoForm jobInfo={existingJobInfo} />);
@@ -147,6 +147,8 @@ describe("JobInfoForm", () => {
       });
     });
     expect(mockCreateJobInfoAction).not.toHaveBeenCalled();
+    expect(mockToast.success).toHaveBeenCalledWith("Job information updated!");
+    expect(mockPush).toHaveBeenCalledWith(routes.jobInfo(existingJobInfo.id));
   });
 
   it("does not call server actions and shows validation feedback when required fields are invalid", async () => {

--- a/core/features/jobInfos/components/JobInfoForm.test.tsx
+++ b/core/features/jobInfos/components/JobInfoForm.test.tsx
@@ -1,0 +1,211 @@
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/core/features/jobInfos/actions", () => ({
+  createJobInfoAction: jest.fn(),
+  updateJobInfoAction: jest.fn(),
+}));
+
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { routes } from "@/core/data/routes";
+import {
+  createJobInfoAction,
+  updateJobInfoAction,
+} from "@/core/features/jobInfos/actions";
+import { render, screen, waitFor } from "@/core/test-utils/render";
+
+import { JobInfoForm } from "./JobInfoForm";
+
+const mockCreateJobInfoAction = jest.mocked(createJobInfoAction);
+const mockUpdateJobInfoAction = jest.mocked(updateJobInfoAction);
+const mockToast = jest.mocked(toast);
+const mockUseRouter = jest.mocked(useRouter);
+const mockPush = jest.fn();
+
+const validJobInfoInput = {
+  name: "Frontend prep",
+  title: "Senior Frontend Engineer",
+  experienceLevel: "junior",
+  description: "React and Next.js interview preparation.",
+} as const;
+
+function mockRouter() {
+  mockUseRouter.mockReturnValue({
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+    push: mockPush,
+    refresh: jest.fn(),
+    replace: jest.fn(),
+  });
+}
+
+async function fillRequiredFields() {
+  const user = userEvent.setup();
+
+  await user.type(screen.getByLabelText("Name"), validJobInfoInput.name);
+  await user.type(screen.getByLabelText("Job Title"), validJobInfoInput.title);
+  await user.type(
+    screen.getByLabelText("Description"),
+    validJobInfoInput.description,
+  );
+
+  return user;
+}
+
+describe("JobInfoForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouter();
+  });
+
+  it("renders empty defaults for a new job info and submits valid data to createJobInfoAction", async () => {
+    mockCreateJobInfoAction.mockResolvedValue({
+      success: true,
+      data: { id: "job-info-new" },
+    });
+
+    render(<JobInfoForm />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText("Job Title")).toHaveValue("");
+    expect(
+      screen.getByRole("combobox", { name: "Experience Level" }),
+    ).toHaveTextContent("Junior");
+    expect(screen.getByLabelText("Description")).toHaveValue("");
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    await waitFor(() => {
+      expect(mockCreateJobInfoAction).toHaveBeenCalledWith(validJobInfoInput);
+    });
+    expect(mockUpdateJobInfoAction).not.toHaveBeenCalled();
+  });
+
+  it("renders existing job info and submits edits to updateJobInfoAction with the job id", async () => {
+    mockUpdateJobInfoAction.mockResolvedValue({
+      success: true,
+      data: { id: "job-info-existing" },
+    });
+
+    render(
+      <JobInfoForm
+        jobInfo={{
+          id: "job-info-existing",
+          name: "Backend prep",
+          title: "Platform Engineer",
+          experienceLevel: "senior",
+          description: "Systems design interview prep.",
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Backend prep");
+    expect(screen.getByLabelText("Job Title")).toHaveValue("Platform Engineer");
+    expect(
+      screen.getByRole("combobox", { name: "Experience Level" }),
+    ).toHaveTextContent("Senior");
+    expect(screen.getByLabelText("Description")).toHaveValue(
+      "Systems design interview prep.",
+    );
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), validJobInfoInput.name);
+    await user.clear(screen.getByLabelText("Job Title"));
+    await user.type(
+      screen.getByLabelText("Job Title"),
+      validJobInfoInput.title,
+    );
+    await user.clear(screen.getByLabelText("Description"));
+    await user.type(
+      screen.getByLabelText("Description"),
+      validJobInfoInput.description,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateJobInfoAction).toHaveBeenCalledWith(
+        "job-info-existing",
+        {
+          ...validJobInfoInput,
+          experienceLevel: "senior",
+        },
+      );
+    });
+    expect(mockCreateJobInfoAction).not.toHaveBeenCalled();
+  });
+
+  it("does not call server actions and shows validation feedback when required fields are invalid", async () => {
+    render(<JobInfoForm />);
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    expect(mockCreateJobInfoAction).not.toHaveBeenCalled();
+    expect(mockUpdateJobInfoAction).not.toHaveBeenCalled();
+    expect(await screen.findAllByText("Required")).toHaveLength(2);
+  });
+
+  it("shows toast.error and does not navigate when the action fails", async () => {
+    mockCreateJobInfoAction.mockResolvedValue({
+      success: false,
+      message: "Unable to save job info.",
+    });
+
+    render(<JobInfoForm />);
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Unable to save job info.");
+    });
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows toast.success, resets the form, and routes to the saved job info when the action succeeds", async () => {
+    mockCreateJobInfoAction.mockResolvedValue({
+      success: true,
+      data: { id: "job-info-created" },
+    });
+
+    render(<JobInfoForm />);
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast.success).toHaveBeenCalledWith(
+        "Job information created!",
+      );
+    });
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText("Job Title")).toHaveValue("");
+    expect(screen.getByLabelText("Description")).toHaveValue("");
+    expect(mockPush).toHaveBeenCalledWith(routes.jobInfo("job-info-created"));
+  });
+});

--- a/core/features/jobInfos/components/JobInfoForm.test.tsx
+++ b/core/features/jobInfos/components/JobInfoForm.test.tsx
@@ -40,6 +40,14 @@ const validJobInfoInput = {
   description: "React and Next.js interview preparation.",
 } as const;
 
+const existingJobInfo = {
+  id: "job-info-existing",
+  name: "Backend prep",
+  title: "Platform Engineer",
+  experienceLevel: "senior",
+  description: "Systems design interview prep.",
+} as const;
+
 function mockRouter() {
   mockUseRouter.mockReturnValue({
     back: jest.fn(),
@@ -102,25 +110,17 @@ describe("JobInfoForm", () => {
       data: { id: "job-info-existing" },
     });
 
-    render(
-      <JobInfoForm
-        jobInfo={{
-          id: "job-info-existing",
-          name: "Backend prep",
-          title: "Platform Engineer",
-          experienceLevel: "senior",
-          description: "Systems design interview prep.",
-        }}
-      />,
-    );
+    render(<JobInfoForm jobInfo={existingJobInfo} />);
 
-    expect(screen.getByLabelText("Name")).toHaveValue("Backend prep");
-    expect(screen.getByLabelText("Job Title")).toHaveValue("Platform Engineer");
+    expect(screen.getByLabelText("Name")).toHaveValue(existingJobInfo.name);
+    expect(screen.getByLabelText("Job Title")).toHaveValue(
+      existingJobInfo.title,
+    );
     expect(
       screen.getByRole("combobox", { name: "Experience Level" }),
     ).toHaveTextContent("Senior");
     expect(screen.getByLabelText("Description")).toHaveValue(
-      "Systems design interview prep.",
+      existingJobInfo.description,
     );
 
     const user = userEvent.setup();
@@ -141,13 +141,10 @@ describe("JobInfoForm", () => {
     );
 
     await waitFor(() => {
-      expect(mockUpdateJobInfoAction).toHaveBeenCalledWith(
-        "job-info-existing",
-        {
-          ...validJobInfoInput,
-          experienceLevel: "senior",
-        },
-      );
+      expect(mockUpdateJobInfoAction).toHaveBeenCalledWith(existingJobInfo.id, {
+        ...validJobInfoInput,
+        experienceLevel: existingJobInfo.experienceLevel,
+      });
     });
     expect(mockCreateJobInfoAction).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Add focused RTL coverage for `JobInfoForm` new and edit submission flows.
- Cover client-side required-field validation, failed action toast behavior, and successful reset/navigation behavior.
- Keep mocks scoped to server actions, router, and toast side effects.

## Verification
- `npm test -- core/features/jobInfos/components/JobInfoForm.test.tsx` hit the known local `npm.ps1` PowerShell signing blocker.
- `npm.cmd test -- core/features/jobInfos/components/JobInfoForm.test.tsx`
- `npm.cmd test`
- `npm.cmd run check:ci`
- `npx.cmd tsc --noEmit`

## Notes
- No production code changes.
- No snapshot tests added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for job information form with validation, navigation, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->