### PR TITLE
test(job-infos): cover experience level selection

### DIFF
--- a/core/features/jobInfos/components/JobInfoForm.test.tsx
+++ b/core/features/jobInfos/components/JobInfoForm.test.tsx
@@ -104,6 +104,32 @@ describe("JobInfoForm", () => {
     expect(mockUpdateJobInfoAction).not.toHaveBeenCalled();
   });
 
+  it("submits the experience level selected through the combobox", async () => {
+    mockCreateJobInfoAction.mockResolvedValue({
+      success: true,
+      data: { id: "job-info-new" },
+    });
+
+    render(<JobInfoForm />);
+
+    const user = await fillRequiredFields();
+    await user.click(
+      screen.getByRole("combobox", { name: "Experience Level" }),
+    );
+    await user.click(await screen.findByRole("option", { name: "Senior" }));
+    await user.click(
+      screen.getByRole("button", { name: "Save Job Information" }),
+    );
+
+    await waitFor(() => {
+      expect(mockCreateJobInfoAction).toHaveBeenCalledWith({
+        ...validJobInfoInput,
+        experienceLevel: "senior",
+      });
+    });
+    expect(mockUpdateJobInfoAction).not.toHaveBeenCalled();
+  });
+
   it("renders existing job info and submits edits to updateJobInfoAction with the job id", async () => {
     mockUpdateJobInfoAction.mockResolvedValue({
       success: true,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,3 +15,23 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
     }),
   });
 }
+
+if (
+  typeof HTMLElement !== "undefined" &&
+  typeof HTMLElement.prototype.hasPointerCapture !== "function"
+) {
+  Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+    writable: true,
+    value: () => false,
+  });
+}
+
+if (
+  typeof Element !== "undefined" &&
+  typeof Element.prototype.scrollIntoView !== "function"
+) {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    writable: true,
+    value: jest.fn(),
+  });
+}


### PR DESCRIPTION
## Summary

- Added a JobInfoForm workflow test that opens the experience level combobox, selects Senior, submits the form, and verifies the create action receives the selected value.
- Added jsdom shims for Radix Select browser APIs used during pointer and scroll interactions.

## Verification

- `npm.cmd test -- core/features/jobInfos/components/JobInfoForm.test.tsx --runInBand --watchman=false`
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --runInBand --watchman=false`
- `npm.cmd run test:coverage -- --runInBand --watchman=false`
- `npm.cmd run check:ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test coverage for form submission with updated selection inputs
  * Enhanced test environment compatibility with additional browser API polyfills

---

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->