### PR TITLE
test(upgrade): cover Stripe error message mapping

### DIFF
--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -1,0 +1,84 @@
+import { getErrorMessage, STRIPE_ERROR_MESSAGES } from "./getErrorMessage";
+
+describe("getErrorMessage", () => {
+  it("returns null when it receives undefined", () => {
+    const inputValue = undefined;
+    const expectedReturnValue = null;
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns null when it receives an empty string", () => {
+    const inputValue = "";
+    const expectedReturnValue = null;
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns null when it receives an empty array", () => {
+    const inputValue: Array<string> = [];
+    const expectedReturnValue = null;
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns null when it receives an array with just one empty string element", () => {
+    const inputValue = [""];
+    const expectedReturnValue = null;
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it.each(Object.entries(STRIPE_ERROR_MESSAGES))(
+    "returns a corresponding error message when it receives a standard code",
+    (code, errorMessage) => {
+      expect(getErrorMessage(code)).toBe(errorMessage);
+    },
+  );
+
+  it("returns a corresponding error message for the first entry in an input array that contains at least one valid item", () => {
+    const checkoutFailedErrorCode = "checkout_failed";
+    const inputValue = [checkoutFailedErrorCode];
+    const expectedReturnValue = STRIPE_ERROR_MESSAGES[checkoutFailedErrorCode];
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns a corresponding error message for the first entry in an input array and skips any other items in this array", () => {
+    const portalFailedErrorCode = "portal_failed";
+    const inputValue = [portalFailedErrorCode, "some_random_text"];
+    const expectedReturnValue = STRIPE_ERROR_MESSAGES[portalFailedErrorCode];
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns the config fallback message when it receives a non-existing error code string", () => {
+    const inputValue = "some_random_text";
+    const expectedReturnValue = STRIPE_ERROR_MESSAGES["config"];
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+
+  it("returns the config fallback message when it receives an array with its first element being a non-existing error code string", () => {
+    const inputValue = ["some_random_text"];
+    const expectedReturnValue = STRIPE_ERROR_MESSAGES["config"];
+
+    const result = getErrorMessage(inputValue);
+
+    expect(result).toBe(expectedReturnValue);
+  });
+});

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -1,48 +1,51 @@
 import { getErrorMessage } from "./getErrorMessage";
 
 describe("getErrorMessage", () => {
-  it("returns null when it receives undefined", () => {
-    expect(getErrorMessage(undefined)).toBeNull();
+  describe("when no error is present", () => {
+    it.each([undefined, "", [], [""]])("returns null for %p", (input) => {
+      expect(getErrorMessage(input)).toBeNull();
+    });
   });
 
-  it("returns null when it receives an empty string", () => {
-    expect(getErrorMessage("")).toBeNull();
+  describe("when code is known", () => {
+    it.each([
+      ["unauthorized", "Please sign in to continue."],
+      [
+        "stripe_not_configured",
+        "Billing is not available right now. Please try again later.",
+      ],
+      ["config", "Something went wrong. Please try again later."],
+      [
+        "no_subscription",
+        "No active subscription found. You are already on the Free plan.",
+      ],
+      [
+        "cancel_failed",
+        "Failed to cancel subscription. Try again or use Manage subscription.",
+      ],
+      ["user_not_found", "We couldn't find your account. Please try again."],
+      ["already_pro", "You already have an active Pro subscription."],
+      [
+        "existing_subscription",
+        "You have an existing subscription. Use Manage subscription on this page to update payment or cancel.",
+      ],
+      ["checkout_failed", "Failed to start checkout. Please try again."],
+      ["no_customer", "No billing customer found. Upgrade to Pro first."],
+      ["portal_failed", "Failed to open billing portal. Please try again."],
+    ])("maps %s to the correct message", (code, errorMessage) => {
+      expect(getErrorMessage(code)).toBe(errorMessage);
+    });
   });
 
-  it("returns null when it receives an empty array", () => {
-    expect(getErrorMessage([])).toBeNull();
-  });
-
-  it("returns null when it receives an array with just one empty string element", () => {
-    expect(getErrorMessage([""])).toBeNull();
-  });
-
-  it.each([
-    ["unauthorized", "Please sign in to continue."],
-    [
-      "stripe_not_configured",
-      "Billing is not available right now. Please try again later.",
-    ],
-    ["config", "Something went wrong. Please try again later."],
-    [
-      "no_subscription",
-      "No active subscription found. You are already on the Free plan.",
-    ],
-    [
-      "cancel_failed",
-      "Failed to cancel subscription. Try again or use Manage subscription.",
-    ],
-    ["user_not_found", "We couldn't find your account. Please try again."],
-    ["already_pro", "You already have an active Pro subscription."],
-    [
-      "existing_subscription",
-      "You have an existing subscription. Use Manage subscription on this page to update payment or cancel.",
-    ],
-    ["checkout_failed", "Failed to start checkout. Please try again."],
-    ["no_customer", "No billing customer found. Upgrade to Pro first."],
-    ["portal_failed", "Failed to open billing portal. Please try again."],
-  ])("maps %s to the correct message", (code, errorMessage) => {
-    expect(getErrorMessage(code)).toBe(errorMessage);
+  describe("when code is unknown", () => {
+    it.each(["some_random_text", ["some_random_text"]])(
+      "falls back to the config message for %p",
+      (input) => {
+        expect(getErrorMessage(input)).toBe(
+          "Something went wrong. Please try again later.",
+        );
+      },
+    );
   });
 
   it("uses the first array element when present", () => {
@@ -54,12 +57,6 @@ describe("getErrorMessage", () => {
   it("ignores additional array elements", () => {
     expect(getErrorMessage(["portal_failed", "some_random_text"])).toBe(
       "Failed to open billing portal. Please try again.",
-    );
-  });
-
-  it("returns the config fallback message when it receives a non-existing error code string", () => {
-    expect(getErrorMessage("some_random_text")).toBe(
-      "Something went wrong. Please try again later.",
     );
   });
 

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -48,15 +48,17 @@ describe("getErrorMessage", () => {
     );
   });
 
-  it("uses the first array element when present", () => {
-    expect(getErrorMessage(["checkout_failed"])).toBe(
-      "Failed to start checkout. Please try again.",
-    );
-  });
+  describe("when code is provided as an array", () => {
+    it("uses the first array element when present", () => {
+      expect(getErrorMessage(["checkout_failed"])).toBe(
+        "Failed to start checkout. Please try again.",
+      );
+    });
 
-  it("ignores additional array elements", () => {
-    expect(getErrorMessage(["portal_failed", "some_random_text"])).toBe(
-      "Failed to open billing portal. Please try again.",
-    );
+    it("ignores additional array elements", () => {
+      expect(getErrorMessage(["portal_failed", "some_random_text"])).toBe(
+        "Failed to open billing portal. Please try again.",
+      );
+    });
   });
 });

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -2,39 +2,19 @@ import { getErrorMessage } from "./getErrorMessage";
 
 describe("getErrorMessage", () => {
   it("returns null when it receives undefined", () => {
-    const inputValue = undefined;
-    const expectedReturnValue = null;
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage(undefined)).toBeNull();
   });
 
   it("returns null when it receives an empty string", () => {
-    const inputValue = "";
-    const expectedReturnValue = null;
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage("")).toBeNull();
   });
 
   it("returns null when it receives an empty array", () => {
-    const inputValue: Array<string> = [];
-    const expectedReturnValue = null;
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage([])).toBeNull();
   });
 
   it("returns null when it receives an array with just one empty string element", () => {
-    const inputValue = [""];
-    const expectedReturnValue = null;
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage([""])).toBeNull();
   });
 
   it.each([
@@ -69,41 +49,26 @@ describe("getErrorMessage", () => {
   );
 
   it("returns a corresponding error message for the first entry in an input array that contains at least one valid item", () => {
-    const checkoutFailedErrorCode = "checkout_failed";
-    const inputValue = [checkoutFailedErrorCode];
-    const expectedReturnValue = "Failed to start checkout. Please try again.";
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage(["checkout_failed"])).toBe(
+      "Failed to start checkout. Please try again.",
+    );
   });
 
   it("returns a corresponding error message for the first entry in an input array and skips any other items in this array", () => {
-    const portalFailedErrorCode = "portal_failed";
-    const inputValue = [portalFailedErrorCode, "some_random_text"];
-    const expectedReturnValue =
-      "Failed to open billing portal. Please try again.";
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage(["portal_failed", "some_random_text"])).toBe(
+      "Failed to open billing portal. Please try again.",
+    );
   });
 
   it("returns the config fallback message when it receives a non-existing error code string", () => {
-    const inputValue = "some_random_text";
-    const expectedReturnValue = "Something went wrong. Please try again later.";
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage("some_random_text")).toBe(
+      "Something went wrong. Please try again later.",
+    );
   });
 
   it("returns the config fallback message when it receives an array with its first element being a non-existing error code string", () => {
-    const inputValue = ["some_random_text"];
-    const expectedReturnValue = "Something went wrong. Please try again later.";
-
-    const result = getErrorMessage(inputValue);
-
-    expect(result).toBe(expectedReturnValue);
+    expect(getErrorMessage(["some_random_text"])).toBe(
+      "Something went wrong. Please try again later.",
+    );
   });
 });

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -45,13 +45,13 @@ describe("getErrorMessage", () => {
     expect(getErrorMessage(code)).toBe(errorMessage);
   });
 
-  it("returns a corresponding error message for the first entry in an input array that contains at least one valid item", () => {
+  it("uses the first array element when present", () => {
     expect(getErrorMessage(["checkout_failed"])).toBe(
       "Failed to start checkout. Please try again.",
     );
   });
 
-  it("returns a corresponding error message for the first entry in an input array and skips any other items in this array", () => {
+  it("ignores additional array elements", () => {
     expect(getErrorMessage(["portal_failed", "some_random_text"])).toBe(
       "Failed to open billing portal. Please try again.",
     );

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -38,14 +38,14 @@ describe("getErrorMessage", () => {
   });
 
   describe("when code is unknown", () => {
-    it.each(["some_random_text", ["some_random_text"]])(
-      "falls back to the config message for %p",
-      (input) => {
-        expect(getErrorMessage(input)).toBe(
-          "Something went wrong. Please try again later.",
-        );
-      },
-    );
+    it.each([
+      "some_random_text",
+      ["some_random_text"],
+    ])("falls back to the config message for %p", (input) => {
+      expect(getErrorMessage(input)).toBe(
+        "Something went wrong. Please try again later.",
+      );
+    });
   });
 
   describe("when code is provided as an array", () => {

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -1,4 +1,4 @@
-import { getErrorMessage, STRIPE_ERROR_MESSAGES } from "./getErrorMessage";
+import { getErrorMessage } from "./getErrorMessage";
 
 describe("getErrorMessage", () => {
   it("returns null when it receives undefined", () => {
@@ -37,7 +37,31 @@ describe("getErrorMessage", () => {
     expect(result).toBe(expectedReturnValue);
   });
 
-  it.each(Object.entries(STRIPE_ERROR_MESSAGES))(
+  it.each([
+    ["unauthorized", "Please sign in to continue."],
+    [
+      "stripe_not_configured",
+      "Billing is not available right now. Please try again later.",
+    ],
+    ["config", "Something went wrong. Please try again later."],
+    [
+      "no_subscription",
+      "No active subscription found. You are already on the Free plan.",
+    ],
+    [
+      "cancel_failed",
+      "Failed to cancel subscription. Try again or use Manage subscription.",
+    ],
+    ["user_not_found", "We couldn't find your account. Please try again."],
+    ["already_pro", "You already have an active Pro subscription."],
+    [
+      "existing_subscription",
+      "You have an existing subscription. Use Manage subscription on this page to update payment or cancel.",
+    ],
+    ["checkout_failed", "Failed to start checkout. Please try again."],
+    ["no_customer", "No billing customer found. Upgrade to Pro first."],
+    ["portal_failed", "Failed to open billing portal. Please try again."],
+  ])(
     "returns a corresponding error message when it receives a standard code",
     (code, errorMessage) => {
       expect(getErrorMessage(code)).toBe(errorMessage);
@@ -47,7 +71,7 @@ describe("getErrorMessage", () => {
   it("returns a corresponding error message for the first entry in an input array that contains at least one valid item", () => {
     const checkoutFailedErrorCode = "checkout_failed";
     const inputValue = [checkoutFailedErrorCode];
-    const expectedReturnValue = STRIPE_ERROR_MESSAGES[checkoutFailedErrorCode];
+    const expectedReturnValue = "Failed to start checkout. Please try again.";
 
     const result = getErrorMessage(inputValue);
 
@@ -57,7 +81,8 @@ describe("getErrorMessage", () => {
   it("returns a corresponding error message for the first entry in an input array and skips any other items in this array", () => {
     const portalFailedErrorCode = "portal_failed";
     const inputValue = [portalFailedErrorCode, "some_random_text"];
-    const expectedReturnValue = STRIPE_ERROR_MESSAGES[portalFailedErrorCode];
+    const expectedReturnValue =
+      "Failed to open billing portal. Please try again.";
 
     const result = getErrorMessage(inputValue);
 
@@ -66,7 +91,7 @@ describe("getErrorMessage", () => {
 
   it("returns the config fallback message when it receives a non-existing error code string", () => {
     const inputValue = "some_random_text";
-    const expectedReturnValue = STRIPE_ERROR_MESSAGES["config"];
+    const expectedReturnValue = "Something went wrong. Please try again later.";
 
     const result = getErrorMessage(inputValue);
 
@@ -75,7 +100,7 @@ describe("getErrorMessage", () => {
 
   it("returns the config fallback message when it receives an array with its first element being a non-existing error code string", () => {
     const inputValue = ["some_random_text"];
-    const expectedReturnValue = STRIPE_ERROR_MESSAGES["config"];
+    const expectedReturnValue = "Something went wrong. Please try again later.";
 
     const result = getErrorMessage(inputValue);
 

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -59,10 +59,4 @@ describe("getErrorMessage", () => {
       "Failed to open billing portal. Please try again.",
     );
   });
-
-  it("returns the config fallback message when it receives an array with its first element being a non-existing error code string", () => {
-    expect(getErrorMessage(["some_random_text"])).toBe(
-      "Something went wrong. Please try again later.",
-    );
-  });
 });

--- a/app/app/upgrade/getErrorMessage.test.ts
+++ b/app/app/upgrade/getErrorMessage.test.ts
@@ -41,12 +41,9 @@ describe("getErrorMessage", () => {
     ["checkout_failed", "Failed to start checkout. Please try again."],
     ["no_customer", "No billing customer found. Upgrade to Pro first."],
     ["portal_failed", "Failed to open billing portal. Please try again."],
-  ])(
-    "returns a corresponding error message when it receives a standard code",
-    (code, errorMessage) => {
-      expect(getErrorMessage(code)).toBe(errorMessage);
-    },
-  );
+  ])("maps %s to the correct message", (code, errorMessage) => {
+    expect(getErrorMessage(code)).toBe(errorMessage);
+  });
 
   it("returns a corresponding error message for the first entry in an input array that contains at least one valid item", () => {
     expect(getErrorMessage(["checkout_failed"])).toBe(

--- a/app/app/upgrade/getErrorMessage.ts
+++ b/app/app/upgrade/getErrorMessage.ts
@@ -1,5 +1,5 @@
 /** User-facing messages for Stripe form POST error redirects. */
-const STRIPE_ERROR_MESSAGES: Record<string, string> = {
+export const STRIPE_ERROR_MESSAGES: Record<string, string> = {
   unauthorized: "Please sign in to continue.",
   stripe_not_configured:
     "Billing is not available right now. Please try again later.",

--- a/app/app/upgrade/getErrorMessage.ts
+++ b/app/app/upgrade/getErrorMessage.ts
@@ -1,5 +1,5 @@
 /** User-facing messages for Stripe form POST error redirects. */
-export const STRIPE_ERROR_MESSAGES: Record<string, string> = {
+const STRIPE_ERROR_MESSAGES: Record<string, string> = {
   unauthorized: "Please sign in to continue.",
   stripe_not_configured:
     "Billing is not available right now. Please try again later.",


### PR DESCRIPTION
## Summary

- Add co-located `getErrorMessage.test.ts` for the upgrade page Stripe error helper.
- Cover null/empty inputs, all 11 known error codes, unknown-code fallback, and array handling (first element only).
- No production code changes; `getErrorMessage.ts` behavior is unchanged.

## Test plan

- [x] `npm.cmd test -- app/app/upgrade/getErrorMessage.test.ts --runInBand`
- [x] `npx.cmd jest app/app/upgrade/getErrorMessage.test.ts --coverage --collectCoverageFrom=app/app/upgrade/getErrorMessage.ts --runInBand`
- [x] `npm.cmd test -- --runInBand`
- [x] `npx.cmd tsc --noEmit`
- [x] `npm.cmd run check:ci`

## Notes

- Tests assert literal user-facing copy (not the internal `STRIPE_ERROR_MESSAGES` map) to avoid mirror testing.
- No customer emails or payment data in fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for error message handling, including validation of error code mappings, null cases, and fallback behavior.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->