### PR TITLE
test(hume): cover chat message condensation

### DIFF
--- a/core/services/hume/lib/condenseChatMessages.test.ts
+++ b/core/services/hume/lib/condenseChatMessages.test.ts
@@ -62,7 +62,9 @@ describe("condenseChatMessages", () => {
         { isUser: false, content: ["assistant message 1"] },
       ]);
     });
+  });
 
+  describe("when message content is missing", () => {
     it("skips messages with null or undefined content", () => {
       expect(
         condenseChatMessages([
@@ -71,6 +73,7 @@ describe("condenseChatMessages", () => {
         ]),
       ).toEqual([]);
     });
+
     it("keeps valid messages after skipping empty content", () => {
       expect(
         condenseChatMessages([

--- a/core/services/hume/lib/condenseChatMessages.test.ts
+++ b/core/services/hume/lib/condenseChatMessages.test.ts
@@ -1,0 +1,64 @@
+import { condenseChatMessages } from "./condenseChatMessages";
+
+describe("condenseChatMessages", () => {
+  it("on empty input returns empty array", () => {
+    expect(condenseChatMessages([])).toEqual([]);
+  });
+
+  it.each([
+    ["user", [{ type: "user_message", message: { content: "message 1" } }]],
+    [
+      "agent",
+      [{ type: "assistant_message", message: { content: "message 1" } }],
+    ],
+  ])(
+    "on receiving one message of type %s returns a formatted message",
+    (type, messages) => {
+      expect(condenseChatMessages(messages)).toEqual([
+        {
+          isUser: type === "user",
+          content: ["message 1"],
+        },
+      ]);
+    },
+  );
+
+  it.each([
+    ["user", [{ type: "USER_MESSAGE", messageText: "message 1" }]],
+    ["agent", [{ type: "AGENT_MESSAGE", messageText: "message 1" }]],
+  ])(
+    "on receiving one message of type %s returns a formatted message",
+    (type, messages) => {
+      expect(condenseChatMessages(messages)).toEqual([
+        {
+          isUser: type === "user",
+          content: ["message 1"],
+        },
+      ]);
+    },
+  );
+
+  it("on receiving multiple consecutive messages from the same speaker merges them into one content array", () => {
+    expect(
+      condenseChatMessages([
+        { type: "user_message", message: { content: "message 1" } },
+        { type: "user_message", message: { content: "message 2" } },
+      ]),
+    ).toEqual([{ isUser: true, content: ["message 1", "message 2"] }]);
+  });
+
+  it("on speaker change creates a new entry", () => {
+    expect(
+      condenseChatMessages([
+        { type: "user_message", message: { content: "user message 1" } },
+        {
+          type: "assistant_message",
+          message: { content: "assistant message 1" },
+        },
+      ]),
+    ).toEqual([
+      { isUser: true, content: ["user message 1"] },
+      { isUser: false, content: ["assistant message 1"] },
+    ]);
+  });
+});

--- a/core/services/hume/lib/condenseChatMessages.test.ts
+++ b/core/services/hume/lib/condenseChatMessages.test.ts
@@ -1,64 +1,66 @@
 import { condenseChatMessages } from "./condenseChatMessages";
 
 describe("condenseChatMessages", () => {
-  it("on empty input returns empty array", () => {
-    expect(condenseChatMessages([])).toEqual([]);
+  describe("when input is empty", () => {
+    it("returns empty array", () => {
+      expect(condenseChatMessages([])).toEqual([]);
+    });
   });
 
-  it.each([
-    ["user", [{ type: "user_message", message: { content: "message 1" } }]],
-    [
-      "agent",
-      [{ type: "assistant_message", message: { content: "message 1" } }],
-    ],
-  ])(
-    "on receiving one message of type %s returns a formatted message",
-    (type, messages) => {
+  describe("when messages use JSON format", () => {
+    it.each([
+      ["user", [{ type: "user_message", message: { content: "message 1" } }]],
+      [
+        "agent",
+        [{ type: "assistant_message", message: { content: "message 1" } }],
+      ],
+    ])("maps one %s JSON chat message", (type, messages) => {
       expect(condenseChatMessages(messages)).toEqual([
         {
           isUser: type === "user",
           content: ["message 1"],
         },
       ]);
-    },
-  );
+    });
+  });
 
-  it.each([
-    ["user", [{ type: "USER_MESSAGE", messageText: "message 1" }]],
-    ["agent", [{ type: "AGENT_MESSAGE", messageText: "message 1" }]],
-  ])(
-    "on receiving one message of type %s returns a formatted message",
-    (type, messages) => {
+  describe("when messages use return event format", () => {
+    it.each([
+      ["user", [{ type: "USER_MESSAGE", messageText: "message 1" }]],
+      ["agent", [{ type: "AGENT_MESSAGE", messageText: "message 1" }]],
+    ])("maps one %s return chat event message", (type, messages) => {
       expect(condenseChatMessages(messages)).toEqual([
         {
           isUser: type === "user",
           content: ["message 1"],
         },
       ]);
-    },
-  );
-
-  it("on receiving multiple consecutive messages from the same speaker merges them into one content array", () => {
-    expect(
-      condenseChatMessages([
-        { type: "user_message", message: { content: "message 1" } },
-        { type: "user_message", message: { content: "message 2" } },
-      ]),
-    ).toEqual([{ isUser: true, content: ["message 1", "message 2"] }]);
+    });
   });
 
-  it("on speaker change creates a new entry", () => {
-    expect(
-      condenseChatMessages([
-        { type: "user_message", message: { content: "user message 1" } },
-        {
-          type: "assistant_message",
-          message: { content: "assistant message 1" },
-        },
-      ]),
-    ).toEqual([
-      { isUser: true, content: ["user message 1"] },
-      { isUser: false, content: ["assistant message 1"] },
-    ]);
+  describe("when condensing multiple messages", () => {
+    it("merges message from one speaker into one content array", () => {
+      expect(
+        condenseChatMessages([
+          { type: "user_message", message: { content: "message 1" } },
+          { type: "user_message", message: { content: "message 2" } },
+        ]),
+      ).toEqual([{ isUser: true, content: ["message 1", "message 2"] }]);
+    });
+
+    it("creates a new entry on speaker change", () => {
+      expect(
+        condenseChatMessages([
+          { type: "user_message", message: { content: "user message 1" } },
+          {
+            type: "assistant_message",
+            message: { content: "assistant message 1" },
+          },
+        ]),
+      ).toEqual([
+        { isUser: true, content: ["user message 1"] },
+        { isUser: false, content: ["assistant message 1"] },
+      ]);
+    });
   });
 });

--- a/core/services/hume/lib/condenseChatMessages.test.ts
+++ b/core/services/hume/lib/condenseChatMessages.test.ts
@@ -62,5 +62,22 @@ describe("condenseChatMessages", () => {
         { isUser: false, content: ["assistant message 1"] },
       ]);
     });
+
+    it("skips messages with null or undefined content", () => {
+      expect(
+        condenseChatMessages([
+          { type: "user_message", message: { content: null } },
+          { type: "USER_MESSAGE", messageText: undefined },
+        ]),
+      ).toEqual([]);
+    });
+    it("keeps valid messages after skipping empty content", () => {
+      expect(
+        condenseChatMessages([
+          { type: "user_message", message: { content: null } },
+          { type: "user_message", message: { content: "kept" } },
+        ]),
+      ).toEqual([{ isUser: true, content: ["kept"] }]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add co-located `condenseChatMessages.test.ts` for the Hume interview chat helper.
- Cover empty input, JSON and return-event message formats, same-speaker merging, speaker changes, and skipping null/undefined content.
- No production code changes; `condenseChatMessages.ts` behavior is unchanged.

## Test plan

- [x] `npm.cmd test -- core/services/hume/lib/condenseChatMessages.test.ts --runInBand`
- [x] `npx.cmd jest core/services/hume/lib/condenseChatMessages.test.ts --coverage --collectCoverageFrom=core/services/hume/lib/condenseChatMessages.ts --runInBand`
- [x] `npm.cmd test -- --runInBand`
- [x] `npx.cmd tsc --noEmit`
- [x] `npm.cmd run check:ci`

## Notes

- Pure unit tests with no mocks; fixtures use only synthetic message text.
- Nullable content cases use TypeScript-valid inputs (`null` / `undefined`) that can occur in Hume API/runtime payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for chat message condensing functionality, including scenarios for empty inputs, message format handling, consecutive messages from the same speaker, and null/undefined content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->