### PR TITLE
test(app): cover canceled subscription notice helper

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -6,9 +6,22 @@ for practical handoff use.
 
 ## Current Status
 
-Date: 2026-06-10
+Date: 2026-06-12
 
 Latest full verification:
+
+- `npm.cmd test -- app/app/_utils.test.ts --runInBand` passed: 1 test suite,
+  10 tests, 0 snapshots.
+- Focused coverage probe passed with 100% statements, branches, functions, and
+  lines for:
+  - `app/app/_utils.ts`
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd run check:ci` passed: 288 files checked.
+- `npm.cmd test -- --runInBand` passed: 78 test suites, 624 tests, 0 snapshots.
+- `npm.cmd run test:coverage -- --runInBand` passed: 78 test suites, 624 tests,
+  0 snapshots.
+
+Previous full verification:
 
 - `npm.cmd test -- proxy.test.ts --runInBand` passed: 1 test suite, 16 tests,
   0 snapshots.
@@ -21,7 +34,7 @@ Latest full verification:
 - `npm.cmd run test:coverage -- --runInBand` passed: 75 test suites, 586 tests,
   0 snapshots.
 
-Previous full verification:
+Earlier full verification:
 
 - `npm.cmd test -- core/features/auth/actions.test.ts` passed: 1 test suite, 10
   tests, 0 snapshots.
@@ -71,26 +84,45 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 97.53% |
-| Branches | 99.73% |
-| Functions | 94.24% |
-| Lines | 98.96% |
+| Statements | 97.45% |
+| Branches | 99.37% |
+| Functions | 94.34% |
+| Lines | 98.83% |
 
 Recent file-specific result:
 
 | File | Statements | Branches | Functions | Lines |
 | --- | ---: | ---: | ---: | ---: |
+| `app/app/_utils.ts` | 100% | 100% | 100% | 100% |
 | `proxy.ts` | 100% | 100% | 100% | 100% |
 | `core/features/auth/actions.ts` | 100% | 100% | 100% | 100% |
 | `core/components/ui/action-button.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/form.tsx` | 94.28% | 80% | 100% | 94.28% |
 | `core/components/ui` aggregate | 93.47% | 96.15% | 94% | 93.33% |
+| `core/services/hume/lib/condenseChatMessages.ts` | 86.95% | 86.36% | 100% | 86.95% |
 
 Latest slice notes:
 
 - Added focused tests:
+  - `app/app/_utils.test.ts`
+- Updated `TEST_COVERAGE_PLAN.md` and `docs/test-coverage-history.md`.
+- Covered early exits for free users, missing Stripe subscription ids, and
+  unavailable Stripe clients without retrieving a subscription.
+- Covered active subscriptions not scheduled to cancel, valid future
+  cancellation notices, invalid or missing `cancel_at` values, expired
+  cancellation times, and Stripe retrieval failures.
+- Fake system time is set relative to `cancel_at` by one second in each
+  direction instead of relying on fixed calendar years.
+- Focused Jest passed for the cancellation notice helper test file (10 tests).
+- Focused coverage probe passed with 100% statements, branches, functions, and
+  lines for `app/app/_utils.ts`.
+- Full Jest, full coverage, TypeScript, and Biome CI verification passed.
+- No production code was changed in this slice.
+
+Previous slice notes:
+
+- Added focused tests:
   - `proxy.test.ts`
-- Updated `TEST_COVERAGE_PLAN.md`.
 - Covered Next.js middleware routing for Arcjet API protection, Stripe webhook
   and cron bypasses, public route redirects, protected route redirects, session
   cookie handling, and matcher config.
@@ -100,7 +132,7 @@ Latest slice notes:
 - Full Jest, full coverage, TypeScript, and Biome CI verification passed.
 - No production code was changed in this slice.
 
-Previous slice notes:
+Earlier slice notes:
 
 - Added focused tests:
   - `core/features/auth/actions.test.ts`
@@ -202,14 +234,17 @@ Known local quirks:
 
 Recommended next slice:
 
-1. Behavior-oriented UI primitive gaps:
+1. Remaining Hume message-condensation branches:
+   - `core/services/hume/lib/condenseChatMessages.ts`
+2. Behavior-oriented UI primitive gaps:
    - `core/components/ui/alert-dialog.tsx` wrapper rendering and prop forwarding.
    - `core/components/ui/select.tsx` exported wrapper rendering where Radix
      behavior can be tested without brittle implementation assertions.
-2. Small residual helper gaps where behavior is meaningful:
+   - `core/components/ui/form.tsx` remaining fallback and message branches.
+3. Small residual helper gaps where behavior is meaningful:
    - `core/features/auth/constants.ts`
    - `core/test-utils/factories/index.ts`
-3. Avoid declaration-only schema tests unless they are backed by integration
+4. Avoid declaration-only schema tests unless they are backed by integration
    behavior, migration behavior, or a documented high-risk database contract.
 
 ## Completed Slices
@@ -260,6 +295,10 @@ Recommended next slice:
 | 2026-06-08 | Action button behavior | `core/components/ui/action-button.tsx` reached 100% coverage with user-visible success, error, click, and pending-dialog behavior. |
 | 2026-06-08 | Form accessibility behavior | Covered `core/components/ui/form.tsx` label, description, validation-message, invalid-state, and empty-message behavior. |
 | 2026-06-08 | Auth server actions | Added direct coverage for auth action validation, duplicate email, bad password, sign-out, current-user cache behavior, and session validation branches. |
+| 2026-06-10 | Proxy middleware | `proxy.ts` reached 100% coverage across Arcjet, auth, redirect, bypass, cookie, and matcher behavior. |
+| 2026-06-10 | Upgrade error messages | Covered Stripe upgrade error-code and fallback-message behavior. |
+| 2026-06-11 | Hume message condensation | Added success and unhappy-path coverage for condensed Hume chat messages. |
+| 2026-06-12 | App cancellation notice | `app/app/_utils.ts` reached 100% coverage for Pro cancellation-banner eligibility and Stripe failure handling. |
 
 ## Archive
 

--- a/app/app/_utils.test.ts
+++ b/app/app/_utils.test.ts
@@ -1,0 +1,180 @@
+jest.mock("@/core/features/billing/stripe", () => ({
+  getStripe: jest.fn(),
+}));
+
+import { getStripe } from "@/core/features/billing/stripe";
+import {
+  makeProUser,
+  makeStripeSubscription,
+  makeUser,
+} from "@/core/test-utils/factories";
+import {
+  asStripeClient,
+  createMockStripe,
+} from "@/core/test-utils/mocks/stripe";
+
+import { getCanceledSubscriptionNotice } from "./_utils";
+
+const mockGetStripe = jest.mocked(getStripe);
+
+describe("_utils", () => {
+  describe("getCanceledSubscriptionNotice", () => {
+    const stripe = createMockStripe();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetStripe.mockReturnValue(asStripeClient(stripe));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("returns null without retrieving Stripe for a free user", async () => {
+      const user = makeUser({
+        stripeSubscriptionId: "sub_test_free",
+      });
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+
+    it("returns null without retrieving Stripe when the Pro user has no subscription id", async () => {
+      const user = makeProUser({
+        stripeSubscriptionId: null,
+      });
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(mockGetStripe).not.toHaveBeenCalled();
+      expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+
+    it("returns null without retrieving a subscription when Stripe is unavailable", async () => {
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_unavailable",
+      });
+      mockGetStripe.mockReturnValue(null);
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(mockGetStripe).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the subscription is not scheduled to cancel", async () => {
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_active",
+      });
+      stripe.subscriptions.retrieve.mockResolvedValue(
+        makeStripeSubscription({
+          cancelAtPeriodEnd: false,
+          id: "sub_test_active",
+        }),
+      );
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_test_active",
+      );
+    });
+
+    it("returns a notice with a valid future cancellation time", async () => {
+      jest
+        .useFakeTimers()
+        .setSystemTime(new Date("2026-01-01T00:00:00.000Z").getTime());
+      const cancelAt = 1_900_000_000;
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_future",
+      });
+      stripe.subscriptions.retrieve.mockResolvedValue({
+        ...makeStripeSubscription({
+          cancelAtPeriodEnd: true,
+          id: "sub_test_future",
+        }),
+        cancel_at: cancelAt,
+      });
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toEqual({
+        subscriptionId: "sub_test_future",
+        periodEndUnix: cancelAt,
+      });
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_test_future",
+      );
+    });
+
+    it.each([
+      ["null", null],
+      ["zero", 0],
+      ["NaN", Number.NaN],
+    ])("returns a notice with no cancellation time when cancel_at is %s", async (_description, cancelAt) => {
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_missing_cancel_at",
+      });
+      stripe.subscriptions.retrieve.mockResolvedValue({
+        ...makeStripeSubscription({
+          cancelAtPeriodEnd: true,
+          id: "sub_test_missing_cancel_at",
+        }),
+        cancel_at: cancelAt,
+      });
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toEqual({
+        subscriptionId: "sub_test_missing_cancel_at",
+        periodEndUnix: null,
+      });
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_test_missing_cancel_at",
+      );
+    });
+
+    it("returns null when the cancellation time is in the past", async () => {
+      jest
+        .useFakeTimers()
+        .setSystemTime(new Date("2031-01-01T00:00:00.000Z").getTime());
+      const cancelAt = 1_900_000_000;
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_past",
+      });
+      stripe.subscriptions.retrieve.mockResolvedValue({
+        ...makeStripeSubscription({
+          cancelAtPeriodEnd: true,
+          id: "sub_test_past",
+        }),
+        cancel_at: cancelAt,
+      });
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_test_past",
+      );
+    });
+
+    it("returns null when retrieving the subscription fails", async () => {
+      const user = makeProUser({
+        stripeSubscriptionId: "sub_test_error",
+      });
+      stripe.subscriptions.retrieve.mockRejectedValue(
+        new Error("Stripe unavailable"),
+      );
+
+      await expect(getCanceledSubscriptionNotice(user)).resolves.toBeNull();
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledTimes(1);
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_test_error",
+      );
+    });
+  });
+});

--- a/app/app/_utils.test.ts
+++ b/app/app/_utils.test.ts
@@ -16,6 +16,7 @@ import {
 import { getCanceledSubscriptionNotice } from "./_utils";
 
 const mockGetStripe = jest.mocked(getStripe);
+const MILLISECONDS_PER_SECOND = 1_000;
 
 describe("_utils", () => {
   describe("getCanceledSubscriptionNotice", () => {
@@ -84,10 +85,10 @@ describe("_utils", () => {
     });
 
     it("returns a notice with a valid future cancellation time", async () => {
+      const cancelAt = 1_900_000_000;
       jest
         .useFakeTimers()
-        .setSystemTime(new Date("2026-01-01T00:00:00.000Z").getTime());
-      const cancelAt = 1_900_000_000;
+        .setSystemTime((cancelAt - 1) * MILLISECONDS_PER_SECOND);
       const user = makeProUser({
         stripeSubscriptionId: "sub_test_future",
       });
@@ -138,10 +139,10 @@ describe("_utils", () => {
     });
 
     it("returns null when the cancellation time is in the past", async () => {
+      const cancelAt = 1_900_000_000;
       jest
         .useFakeTimers()
-        .setSystemTime(new Date("2031-01-01T00:00:00.000Z").getTime());
-      const cancelAt = 1_900_000_000;
+        .setSystemTime((cancelAt + 1) * MILLISECONDS_PER_SECOND);
       const user = makeProUser({
         stripeSubscriptionId: "sub_test_past",
       });

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -1902,76 +1902,118 @@ helper branches in `core/features/auth/permissions.ts`,
 `core/features/interviews/permissions.ts`, and
 `core/features/questions/permissions.ts`.
 
+### Cumulative Coverage Catch-up and App Cancellation Notice - 2026-06-12
+
+Files added/updated in this slice:
+
+- `app/app/_utils.test.ts`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- app/app/_utils.test.ts --runInBand`
+- `npx.cmd jest app/app/_utils.test.ts --coverage --collectCoverageFrom=app/app/_utils.ts --runInBand`
+- `npm.cmd test -- --runInBand`
+- `npm.cmd run test:coverage -- --runInBand`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run check:ci`
+
+Result:
+
+- Focused cancellation notice Jest passed: 1 test suite, 10 tests, 0
+  snapshots.
+- Focused cancellation notice coverage passed with
+  `app/app/_utils.ts` at 100% statements, 100% branches, 100% functions, and
+  100% lines.
+- Full Jest passed: 78 test suites, 624 tests, 0 snapshots.
+- Full coverage passed: 78 test suites, 624 tests, 0 snapshots.
+- Updated coverage summary: 97.45% statements, 99.37% branches, 94.34%
+  functions, and 98.83% lines.
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd run check:ci` passed: 288 files checked.
+
+Coverage history catch-up:
+
+- The previous entry ended at 62 test suites and 478 tests. The current
+  snapshot incorporates the testing work merged since then, including UI
+  primitives and accessibility, AI and Stripe cron route branches, OAuth
+  validation, job-info form and card behavior, auth server actions, proxy
+  routing and Arcjet behavior, Stripe upgrade error messages, and Hume chat
+  message condensation.
+- Current full-coverage areas include the app cancellation notice and upgrade
+  helpers, API routes, auth OAuth modules, billing helpers, DAL helpers,
+  feature actions and services, permissions, and core utilities.
+
+Cancellation notice coverage:
+
+- Added early-return coverage for free users, Pro users without a Stripe
+  subscription id, and unavailable Stripe configuration, including assertions
+  that Stripe subscription retrieval is skipped.
+- Added coverage for active subscriptions not scheduled to cancel, valid
+  future cancellation notices, invalid or missing `cancel_at` values, expired
+  cancellation times, and Stripe retrieval failures.
+- Used synthetic Stripe ids and existing `@test.local` user factories only.
+- Fake system time is defined relative to `cancel_at` by one second in each
+  direction, so the tests express the boundary directly without depending on
+  fixed calendar years.
+- Made no production code changes.
+
+Recommendation:
+
+Prioritize the remaining partial coverage in `core/components/ui`, Drizzle
+schema declarations, and `core/services/hume/lib/condenseChatMessages.ts`.
+
 ## Coverage Priorities
 
-1. Cover pure logic first.
+1. Close remaining UI primitive gaps.
 
-   Start with fast, stable units that do not need framework or service mocks:
+   Add focused behavior and accessibility tests for:
 
-   - `core/lib/*`
-   - `core/features/*/schemas.ts`
-   - `formatters.ts`
-   - Permission helpers such as:
-     - `core/features/questions/permissions.ts`
-     - `core/features/resumeAnalysis/permissions.ts`
-     - `core/features/interviews/permissions.ts`
+   - `core/components/ui/alert-dialog.tsx`
+   - `core/components/ui/form.tsx`
+   - `core/components/ui/select.tsx`
 
-2. Add service-layer tests.
+2. Finish Hume message-condensation branches.
 
-   Prioritize business logic and permission behavior in:
+   Cover the remaining defensive paths in:
 
-   - `core/features/jobInfos/service.ts`
-   - `core/features/interviews/service.ts`
-   - `core/features/questions/service.ts`
+   - `core/services/hume/lib/condenseChatMessages.ts`
 
-   Mock database and cache boundaries with the existing helpers in
-   `core/test-utils/mocks/db.ts`.
+3. Review Drizzle schema coverage separately.
 
-3. Add server action tests.
+   The remaining function gaps are primarily declarative schema modules:
 
-   Cover validation, authorization, redirects, and success paths for:
+   - `core/drizzle/schema/interview.ts`
+   - `core/drizzle/schema/jobInfo.ts`
+   - `core/drizzle/schema/question.ts`
+   - `core/drizzle/schema/session.ts`
+   - `core/drizzle/schema/token.ts`
+   - `core/drizzle/schema/user.ts`
+   - `core/drizzle/schema/userOAuthAccount.ts`
 
-   - `core/features/jobInfos/actions.ts`
-   - `core/features/interviews/actions.ts`
-   - `core/features/questions/actions.ts`
-   - `core/features/users/actions.ts`
+   Prefer meaningful schema constraint and relation tests over assertions added
+   only to increase coverage percentages.
 
-4. Add API route tests.
+4. Protect full-coverage areas when behavior changes.
 
-   The Stripe webhook route already has coverage. Expand next into:
+   Keep focused regression tests alongside changes to:
 
-   - Checkout route
-   - Billing portal route
-   - Cancel subscription route
-   - Auth validate-session route
-   - AI routes
-   - Cron routes
+   - API routes and proxy routing
+   - Auth actions, OAuth modules, and auth components
+   - Billing and Stripe synchronization
+   - Feature actions, services, permissions, and formatters
+   - App upgrade and subscription-notice helpers
 
-   Keep all external services mocked at the module boundary, including Stripe,
-   Google AI, Hume, Arcjet, and the database.
+5. Keep external systems mocked at module boundaries.
 
-5. Add focused component tests.
-
-   Prioritize user interaction and meaningful rendering behavior over broad
-   snapshot coverage:
-
-   - Auth forms
-   - Job info form, card, and list components
-   - Upgrade plan and billing action components
-   - Resume, question, and interview client pages where user interaction matters
-
-6. Add factories and mocks only when needed.
-
-   Grow `core/test-utils` incrementally with the first test that needs each
-   helper:
-
-   - `jobInfo`, `interview`, and `question` factories
-   - AI SDK mocks
-   - Hume mocks
-   - Arcjet mocks
+   Continue using the existing Stripe, database, Next.js, AI, Hume, and Arcjet
+   boundaries. Add factories or mock surfaces only with the first test that
+   requires them.
 
 ## Recommended Starting Point
 
-Start with a baseline `npm test` run and `npm run test:coverage`, then add
-coverage for `core/lib`, schemas, formatters, and permission helpers. That path
-should produce useful coverage quickly without fighting framework mocks.
+Start the next slice with the remaining
+`core/services/hume/lib/condenseChatMessages.ts` branches or one focused UI
+primitive. Run the full coverage report afterward, and treat Drizzle schema
+declarations as a separate quality decision rather than chasing their function
+percentage mechanically.

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -1907,6 +1907,7 @@ helper branches in `core/features/auth/permissions.ts`,
 Files added/updated in this slice:
 
 - `app/app/_utils.test.ts`
+- `TEST_COVERAGE_PLAN.md`
 - `docs/test-coverage-history.md`
 
 Commands run:
@@ -1939,7 +1940,8 @@ Coverage history catch-up:
   primitives and accessibility, AI and Stripe cron route branches, OAuth
   validation, job-info form and card behavior, auth server actions, proxy
   routing and Arcjet behavior, Stripe upgrade error messages, and Hume chat
-  message condensation.
+  message condensation, plus app cancellation-notice tests for banner
+  eligibility and Stripe failure handling.
 - Current full-coverage areas include the app cancellation notice and upgrade
   helpers, API routes, auth OAuth modules, billing helpers, DAL helpers,
   feature actions and services, permissions, and core utilities.


### PR DESCRIPTION
## Summary

- Add co-located tests for `getCanceledSubscriptionNotice`
- Cover early exits, Stripe failures, cancellation states, and invalid dates
- Use relative fake timers for future and expired cancellation boundaries
- Update coverage plan and history documentation
- Keep production code unchanged

## Verification

- 624 tests passed across 78 suites
- `app/app/_utils.ts`: 100% statements, branches, functions, and lines
- `npx.cmd tsc --noEmit`
- `npm.cmd run check:ci`

## Notes

- Stripe is mocked at the module boundary
- Fixtures use synthetic Stripe IDs and `@test.local` emails only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for subscription cancellation functionality, including edge cases and error scenarios.

* **Documentation**
  * Updated test coverage documentation with latest verification results, coverage metrics, and revised testing priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->