### PR TITLE
test(billing): cover Stripe helper contracts

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -6,22 +6,20 @@ for practical handoff use.
 
 ## Current Status
 
-Date: 2026-06-12
+Date: 2026-06-13
 
 Latest full verification:
 
-- `npm.cmd test -- core/components/ui/alert-dialog.test.tsx --runInBand`
-  passed: 1 test suite, 6 tests, 0 snapshots.
-- Focused coverage reported 100% statements, branches, functions, and lines
-  for `core/components/ui/alert-dialog.tsx`.
-- `npm.cmd run check -- core/components/ui/alert-dialog.test.tsx` passed: 290
-  files checked and 1 file formatted.
+- `npm.cmd test -- core/features/billing/stripe.test.ts --runInBand` passed:
+  1 test suite, 25 tests, 0 snapshots.
+- Focused coverage reported 97.72% statements, 91.17% branches, 100%
+  functions, and 97.43% lines for `core/features/billing/stripe.ts`.
+- `npx.cmd biome format --write core/features/billing/stripe.test.ts` passed
+  with no fixes needed.
 - `npm test` was attempted but remains blocked by the unsigned `npm.ps1`
   PowerShell execution-policy restriction.
-- `npm.cmd run check:ci` passed: 290 files checked.
-- `npm.cmd test -- --runInBand` passed: 80 test suites, 641 tests, 0 snapshots.
-- `npm.cmd run test:coverage -- --runInBand` passed: 80 test suites, 641 tests,
-  0 snapshots.
+- `npm.cmd run check:ci` passed: 291 files checked.
+- `npm.cmd test -- --runInBand` passed: 81 test suites, 666 tests, 0 snapshots.
 - `npx.cmd tsc --noEmit` passed.
 
 Latest coverage:
@@ -44,22 +42,26 @@ Recent file-specific result:
 | `core/components/ui/alert-dialog.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui/form.tsx` | 94.28% | 80% | 100% | 94.28% |
 | `core/components/ui` aggregate | 94.92% | 96.15% | 94% | 94.81% |
+| `core/features/billing/stripe.ts` | 97.72% | 91.17% | 100% | 97.43% |
 | `core/services/hume/lib/api.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/condenseChatMessages.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
 - Added focused tests:
-  - `core/components/ui/alert-dialog.test.tsx`
+  - `core/features/billing/stripe.test.ts`
 - Updated `TEST_COVERAGE_PLAN.md` and `docs/test-coverage-history.md`.
-- Covered public portal and overlay composition, slot and custom-class
-  forwarding, trigger-driven opening, cancel dismissal, confirm execution and
-  dismissal, and accessible name and description wiring.
-- Focused Jest passed for the alert dialog test file (6 tests).
-- Full coverage reported 100% statements, branches, functions, and lines for
-  `core/components/ui/alert-dialog.tsx`.
-- Full Jest, full coverage, TypeScript, scoped Biome, and Biome CI verification
-  passed through `npm.cmd`.
+- Covered fail-closed Stripe base URLs, configuration gating, encoded upgrade
+  redirects, JSON and form idempotency parsing and normalization, parse
+  failures, unsupported content types, and Stripe client construction.
+- The development localhost branch runs in a guarded child Jest process with
+  `NODE_ENV=development` because Next's Jest transform compile-folds
+  `NODE_ENV` in the parent test process.
+- Focused Jest passed for the Stripe helper test file (25 tests).
+- Focused coverage does not merge the guarded child process and therefore
+  reports the localhost return as uncovered in the parent report.
+- Full Jest, TypeScript, scoped Biome, and Biome CI verification passed through
+  `npm.cmd`.
 - Made no production code changes.
 
 ## Working Rules
@@ -181,6 +183,7 @@ Recommended next slice:
 | 2026-06-12 | Hume chat event retrieval | `core/services/hume/lib/api.ts` reached 100% coverage for ordered and empty event streams, SDK calls, and error propagation. |
 | 2026-06-12 | App cancellation notice | `app/app/_utils.ts` reached 100% coverage for Pro cancellation-banner eligibility and Stripe failure handling. |
 | 2026-06-12 | Alert dialog UI primitive | `core/components/ui/alert-dialog.tsx` reached 100% coverage for composition, prop forwarding, interactions, and accessibility. |
+| 2026-06-13 | Billing Stripe helpers | Added 25 direct contract tests for Stripe configuration, redirect, idempotency, and client helpers. |
 
 ## Archive
 

--- a/core/features/billing/stripe.test.ts
+++ b/core/features/billing/stripe.test.ts
@@ -1,0 +1,342 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+let mockEnv: import("@core/test-utils/env").TestServerEnv;
+
+jest.mock("@/core/data/env/server", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+
+jest.mock("stripe", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ client: "stripe-test-client" })),
+}));
+
+import Stripe from "stripe";
+
+import {
+  getIdempotencyKeyFromRequest,
+  getStripe,
+  getStripeBaseUrl,
+  getUpgradeErrorRedirect,
+  isStripeConfigured,
+} from "@/core/features/billing/stripe";
+import { createTestServerEnv } from "@core/test-utils/env";
+
+const mockStripeConstructor = jest.mocked(Stripe);
+const originalVercelUrl = process.env.VERCEL_URL;
+const isDevelopmentProbe =
+  process.env["STRIPE_BASE_URL_DEVELOPMENT_PROBE"] === "true";
+
+function buildJsonRequest(body: string): Request {
+  return new Request("https://app.test/api/stripe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+function buildUrlEncodedRequest(body: URLSearchParams): Request {
+  return new Request("https://app.test/api/stripe", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+}
+
+function buildMultipartRequest(body: FormData): Request {
+  return new Request("https://app.test/api/stripe", {
+    method: "POST",
+    body,
+  });
+}
+
+beforeEach(() => {
+  mockEnv = createTestServerEnv();
+  delete process.env.VERCEL_URL;
+});
+
+afterAll(() => {
+  if (originalVercelUrl === undefined) {
+    delete process.env.VERCEL_URL;
+    return;
+  }
+
+  process.env.VERCEL_URL = originalVercelUrl;
+});
+
+describe("getStripeBaseUrl", () => {
+  it("returns APP_URL when both application and Vercel URLs are set", () => {
+    mockEnv = createTestServerEnv({ APP_URL: "https://app.test" });
+    process.env.VERCEL_URL = "preview.vercel.app";
+
+    const result = getStripeBaseUrl();
+
+    expect(result).toBe("https://app.test");
+  });
+
+  it("falls back to an HTTPS Vercel URL when APP_URL is unset", () => {
+    mockEnv = createTestServerEnv({ APP_URL: undefined });
+    process.env.VERCEL_URL = "preview.vercel.app";
+
+    const result = getStripeBaseUrl();
+
+    expect(result).toBe("https://preview.vercel.app");
+  });
+
+  it("returns localhost only in development when no configured URL exists", () => {
+    if (!isDevelopmentProbe) {
+      const testResult = spawnSync(
+        process.execPath,
+        [
+          join(process.cwd(), "node_modules", "jest", "bin", "jest.js"),
+          "core/features/billing/stripe.test.ts",
+          "--runInBand",
+          "--no-cache",
+          "--testNamePattern=returns localhost only",
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            NODE_ENV: "development",
+            STRIPE_BASE_URL_DEVELOPMENT_PROBE: "true",
+          },
+        },
+      );
+
+      expect(testResult.status).toBe(0);
+      return;
+    }
+
+    mockEnv = createTestServerEnv({ APP_URL: undefined });
+
+    const result = getStripeBaseUrl();
+
+    expect(result).toBe("http://localhost:3000");
+  });
+
+  it("returns null outside development when no configured URL exists", () => {
+    mockEnv = createTestServerEnv({ APP_URL: undefined });
+
+    const result = getStripeBaseUrl();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("isStripeConfigured", () => {
+  it.each([
+    {
+      label: "a price id",
+      overrides: {
+        STRIPE_PRO_PRICE_ID: "price_test_pro",
+        STRIPE_PRO_PRODUCT_ID: undefined,
+      },
+    },
+    {
+      label: "a product id",
+      overrides: {
+        STRIPE_PRO_PRICE_ID: undefined,
+        STRIPE_PRO_PRODUCT_ID: "prod_test_pro",
+      },
+    },
+  ])("returns true with all required values and $label", ({ overrides }) => {
+    mockEnv = createTestServerEnv({
+      APP_URL: "https://app.test",
+      STRIPE_SECRET_KEY: "sk_test_configured",
+      STRIPE_WEBHOOK_SECRET: "whsec_test_configured",
+      ...overrides,
+    });
+
+    const result = isStripeConfigured();
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "secret key",
+      overrides: { STRIPE_SECRET_KEY: undefined },
+    },
+    {
+      label: "webhook secret",
+      overrides: { STRIPE_WEBHOOK_SECRET: undefined },
+    },
+    {
+      label: "price and product ids",
+      overrides: {
+        STRIPE_PRO_PRICE_ID: undefined,
+        STRIPE_PRO_PRODUCT_ID: undefined,
+      },
+    },
+    {
+      label: "base URL",
+      overrides: { APP_URL: undefined },
+    },
+  ])("returns false when the $label is missing", ({ overrides }) => {
+    mockEnv = createTestServerEnv(overrides);
+
+    const result = isStripeConfigured();
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("getUpgradeErrorRedirect", () => {
+  it("builds an absolute upgrade redirect with an encoded error code", () => {
+    const result = getUpgradeErrorRedirect(
+      "checkout failed & retry",
+      "https://app.test",
+    );
+
+    expect(result).toBe(
+      "https://app.test/app/upgrade?error=checkout%20failed%20%26%20retry",
+    );
+  });
+});
+
+describe("getIdempotencyKeyFromRequest", () => {
+  it("reads and trims a camelCase key from JSON", async () => {
+    const request = buildJsonRequest(
+      JSON.stringify({ idempotencyKey: "  idem_json  " }),
+    );
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBe("idem_json");
+  });
+
+  it("reads a snake_case key from JSON", async () => {
+    const request = buildJsonRequest(
+      JSON.stringify({ idempotency_key: "idem_snake" }),
+    );
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBe("idem_snake");
+  });
+
+  it("prefers the camelCase JSON key when both names are present", async () => {
+    const request = buildJsonRequest(
+      JSON.stringify({
+        idempotencyKey: "idem_camel",
+        idempotency_key: "idem_snake",
+      }),
+    );
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBe("idem_camel");
+  });
+
+  it("reads a key from a URL-encoded form", async () => {
+    const request = buildUrlEncodedRequest(
+      new URLSearchParams({ idempotency_key: "  idem_urlencoded  " }),
+    );
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBe("idem_urlencoded");
+  });
+
+  it("reads a key from multipart form data", async () => {
+    const formData = new FormData();
+    formData.set("idempotencyKey", "idem_multipart");
+    const request = buildMultipartRequest(formData);
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBe("idem_multipart");
+  });
+
+  it.each([
+    {
+      label: "empty after trimming",
+      value: "   ",
+    },
+    {
+      label: "not a string",
+      value: 123,
+    },
+    {
+      label: "longer than 255 characters",
+      value: "a".repeat(256),
+    },
+  ])("rejects a JSON key that is $label", async ({ value }) => {
+    const request = buildJsonRequest(JSON.stringify({ idempotencyKey: value }));
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for malformed JSON", async () => {
+    const request = buildJsonRequest("{");
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when form parsing throws", async () => {
+    const request = buildUrlEncodedRequest(
+      new URLSearchParams({ idempotencyKey: "idem_form" }),
+    );
+    jest
+      .spyOn(request, "formData")
+      .mockRejectedValueOnce(new Error("form parse failed"));
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "unsupported",
+      headers: { "content-type": "text/plain" },
+    },
+    {
+      label: "missing",
+      headers: undefined,
+    },
+  ])("returns undefined for $label content type", async ({ headers }) => {
+    const request = new Request("https://app.test/api/stripe", {
+      method: "POST",
+      headers,
+      body: "idempotencyKey=idem_ignored",
+    });
+
+    const result = await getIdempotencyKeyFromRequest(request);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getStripe", () => {
+  it("returns null when the Stripe secret key is missing", () => {
+    mockEnv = createTestServerEnv({ STRIPE_SECRET_KEY: "" });
+
+    const result = getStripe();
+
+    expect(result).toBeNull();
+    expect(mockStripeConstructor).not.toHaveBeenCalled();
+  });
+
+  it("returns a Stripe client configured for TypeScript", () => {
+    mockEnv = createTestServerEnv({
+      STRIPE_SECRET_KEY: "sk_test_client",
+    });
+
+    const result = getStripe();
+
+    expect(result).toBe(mockStripeConstructor.mock.results[0]?.value);
+    expect(mockStripeConstructor).toHaveBeenCalledWith("sk_test_client", {
+      typescript: true,
+    });
+  });
+});

--- a/core/features/billing/stripe.test.ts
+++ b/core/features/billing/stripe.test.ts
@@ -67,276 +67,280 @@ afterAll(() => {
   process.env.VERCEL_URL = originalVercelUrl;
 });
 
-describe("getStripeBaseUrl", () => {
-  it("returns APP_URL when both application and Vercel URLs are set", () => {
-    mockEnv = createTestServerEnv({ APP_URL: "https://app.test" });
-    process.env.VERCEL_URL = "preview.vercel.app";
+describe("billing Stripe helpers", () => {
+  describe("getStripeBaseUrl", () => {
+    it("returns APP_URL when both application and Vercel URLs are set", () => {
+      mockEnv = createTestServerEnv({ APP_URL: "https://app.test" });
+      process.env.VERCEL_URL = "preview.vercel.app";
 
-    const result = getStripeBaseUrl();
+      const result = getStripeBaseUrl();
 
-    expect(result).toBe("https://app.test");
-  });
+      expect(result).toBe("https://app.test");
+    });
 
-  it("falls back to an HTTPS Vercel URL when APP_URL is unset", () => {
-    mockEnv = createTestServerEnv({ APP_URL: undefined });
-    process.env.VERCEL_URL = "preview.vercel.app";
+    it("falls back to an HTTPS Vercel URL when APP_URL is unset", () => {
+      mockEnv = createTestServerEnv({ APP_URL: undefined });
+      process.env.VERCEL_URL = "preview.vercel.app";
 
-    const result = getStripeBaseUrl();
+      const result = getStripeBaseUrl();
 
-    expect(result).toBe("https://preview.vercel.app");
-  });
+      expect(result).toBe("https://preview.vercel.app");
+    });
 
-  it("returns localhost only in development when no configured URL exists", () => {
-    if (!isDevelopmentProbe) {
-      const testResult = spawnSync(
-        process.execPath,
-        [
-          join(process.cwd(), "node_modules", "jest", "bin", "jest.js"),
-          "core/features/billing/stripe.test.ts",
-          "--runInBand",
-          "--no-cache",
-          "--testNamePattern=returns localhost only",
-        ],
-        {
-          cwd: process.cwd(),
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            NODE_ENV: "development",
-            STRIPE_BASE_URL_DEVELOPMENT_PROBE: "true",
+    it("returns localhost only in development when no configured URL exists", () => {
+      if (!isDevelopmentProbe) {
+        const testResult = spawnSync(
+          process.execPath,
+          [
+            join(process.cwd(), "node_modules", "jest", "bin", "jest.js"),
+            "core/features/billing/stripe.test.ts",
+            "--runInBand",
+            "--no-cache",
+            "--testNamePattern=returns localhost only",
+          ],
+          {
+            cwd: process.cwd(),
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              NODE_ENV: "development",
+              STRIPE_BASE_URL_DEVELOPMENT_PROBE: "true",
+            },
           },
+        );
+
+        expect(testResult.status).toBe(0);
+        return;
+      }
+
+      mockEnv = createTestServerEnv({ APP_URL: undefined });
+
+      const result = getStripeBaseUrl();
+
+      expect(result).toBe("http://localhost:3000");
+    });
+
+    it("returns null outside development when no configured URL exists", () => {
+      mockEnv = createTestServerEnv({ APP_URL: undefined });
+
+      const result = getStripeBaseUrl();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("isStripeConfigured", () => {
+    it.each([
+      {
+        label: "a price id",
+        overrides: {
+          STRIPE_PRO_PRICE_ID: "price_test_pro",
+          STRIPE_PRO_PRODUCT_ID: undefined,
         },
+      },
+      {
+        label: "a product id",
+        overrides: {
+          STRIPE_PRO_PRICE_ID: undefined,
+          STRIPE_PRO_PRODUCT_ID: "prod_test_pro",
+        },
+      },
+    ])("returns true with all required values and $label", ({ overrides }) => {
+      mockEnv = createTestServerEnv({
+        APP_URL: "https://app.test",
+        STRIPE_SECRET_KEY: "sk_test_configured",
+        STRIPE_WEBHOOK_SECRET: "whsec_test_configured",
+        ...overrides,
+      });
+
+      const result = isStripeConfigured();
+
+      expect(result).toBe(true);
+    });
+
+    it.each([
+      {
+        label: "secret key",
+        overrides: { STRIPE_SECRET_KEY: undefined },
+      },
+      {
+        label: "webhook secret",
+        overrides: { STRIPE_WEBHOOK_SECRET: undefined },
+      },
+      {
+        label: "price and product ids",
+        overrides: {
+          STRIPE_PRO_PRICE_ID: undefined,
+          STRIPE_PRO_PRODUCT_ID: undefined,
+        },
+      },
+      {
+        label: "base URL",
+        overrides: { APP_URL: undefined },
+      },
+    ])("returns false when the $label is missing", ({ overrides }) => {
+      mockEnv = createTestServerEnv(overrides);
+
+      const result = isStripeConfigured();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getUpgradeErrorRedirect", () => {
+    it("builds an absolute upgrade redirect with an encoded error code", () => {
+      const result = getUpgradeErrorRedirect(
+        "checkout failed & retry",
+        "https://app.test",
       );
 
-      expect(testResult.status).toBe(0);
-      return;
-    }
-
-    mockEnv = createTestServerEnv({ APP_URL: undefined });
-
-    const result = getStripeBaseUrl();
-
-    expect(result).toBe("http://localhost:3000");
+      expect(result).toBe(
+        "https://app.test/app/upgrade?error=checkout%20failed%20%26%20retry",
+      );
+    });
   });
 
-  it("returns null outside development when no configured URL exists", () => {
-    mockEnv = createTestServerEnv({ APP_URL: undefined });
+  describe("getIdempotencyKeyFromRequest", () => {
+    it("reads and trims a camelCase key from JSON", async () => {
+      const request = buildJsonRequest(
+        JSON.stringify({ idempotencyKey: "  idem_json  " }),
+      );
 
-    const result = getStripeBaseUrl();
+      const result = await getIdempotencyKeyFromRequest(request);
 
-    expect(result).toBeNull();
-  });
-});
-
-describe("isStripeConfigured", () => {
-  it.each([
-    {
-      label: "a price id",
-      overrides: {
-        STRIPE_PRO_PRICE_ID: "price_test_pro",
-        STRIPE_PRO_PRODUCT_ID: undefined,
-      },
-    },
-    {
-      label: "a product id",
-      overrides: {
-        STRIPE_PRO_PRICE_ID: undefined,
-        STRIPE_PRO_PRODUCT_ID: "prod_test_pro",
-      },
-    },
-  ])("returns true with all required values and $label", ({ overrides }) => {
-    mockEnv = createTestServerEnv({
-      APP_URL: "https://app.test",
-      STRIPE_SECRET_KEY: "sk_test_configured",
-      STRIPE_WEBHOOK_SECRET: "whsec_test_configured",
-      ...overrides,
+      expect(result).toBe("idem_json");
     });
 
-    const result = isStripeConfigured();
+    it("reads a snake_case key from JSON", async () => {
+      const request = buildJsonRequest(
+        JSON.stringify({ idempotency_key: "idem_snake" }),
+      );
 
-    expect(result).toBe(true);
-  });
+      const result = await getIdempotencyKeyFromRequest(request);
 
-  it.each([
-    {
-      label: "secret key",
-      overrides: { STRIPE_SECRET_KEY: undefined },
-    },
-    {
-      label: "webhook secret",
-      overrides: { STRIPE_WEBHOOK_SECRET: undefined },
-    },
-    {
-      label: "price and product ids",
-      overrides: {
-        STRIPE_PRO_PRICE_ID: undefined,
-        STRIPE_PRO_PRODUCT_ID: undefined,
+      expect(result).toBe("idem_snake");
+    });
+
+    it("prefers the camelCase JSON key when both names are present", async () => {
+      const request = buildJsonRequest(
+        JSON.stringify({
+          idempotencyKey: "idem_camel",
+          idempotency_key: "idem_snake",
+        }),
+      );
+
+      const result = await getIdempotencyKeyFromRequest(request);
+
+      expect(result).toBe("idem_camel");
+    });
+
+    it("reads a key from a URL-encoded form", async () => {
+      const request = buildUrlEncodedRequest(
+        new URLSearchParams({ idempotency_key: "  idem_urlencoded  " }),
+      );
+
+      const result = await getIdempotencyKeyFromRequest(request);
+
+      expect(result).toBe("idem_urlencoded");
+    });
+
+    it("reads a key from multipart form data", async () => {
+      const formData = new FormData();
+      formData.set("idempotencyKey", "idem_multipart");
+      const request = buildMultipartRequest(formData);
+
+      const result = await getIdempotencyKeyFromRequest(request);
+
+      expect(result).toBe("idem_multipart");
+    });
+
+    it.each([
+      {
+        label: "empty after trimming",
+        value: "   ",
       },
-    },
-    {
-      label: "base URL",
-      overrides: { APP_URL: undefined },
-    },
-  ])("returns false when the $label is missing", ({ overrides }) => {
-    mockEnv = createTestServerEnv(overrides);
+      {
+        label: "not a string",
+        value: 123,
+      },
+      {
+        label: "longer than 255 characters",
+        value: "a".repeat(256),
+      },
+    ])("rejects a JSON key that is $label", async ({ value }) => {
+      const request = buildJsonRequest(
+        JSON.stringify({ idempotencyKey: value }),
+      );
 
-    const result = isStripeConfigured();
+      const result = await getIdempotencyKeyFromRequest(request);
 
-    expect(result).toBe(false);
-  });
-});
-
-describe("getUpgradeErrorRedirect", () => {
-  it("builds an absolute upgrade redirect with an encoded error code", () => {
-    const result = getUpgradeErrorRedirect(
-      "checkout failed & retry",
-      "https://app.test",
-    );
-
-    expect(result).toBe(
-      "https://app.test/app/upgrade?error=checkout%20failed%20%26%20retry",
-    );
-  });
-});
-
-describe("getIdempotencyKeyFromRequest", () => {
-  it("reads and trims a camelCase key from JSON", async () => {
-    const request = buildJsonRequest(
-      JSON.stringify({ idempotencyKey: "  idem_json  " }),
-    );
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBe("idem_json");
-  });
-
-  it("reads a snake_case key from JSON", async () => {
-    const request = buildJsonRequest(
-      JSON.stringify({ idempotency_key: "idem_snake" }),
-    );
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBe("idem_snake");
-  });
-
-  it("prefers the camelCase JSON key when both names are present", async () => {
-    const request = buildJsonRequest(
-      JSON.stringify({
-        idempotencyKey: "idem_camel",
-        idempotency_key: "idem_snake",
-      }),
-    );
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBe("idem_camel");
-  });
-
-  it("reads a key from a URL-encoded form", async () => {
-    const request = buildUrlEncodedRequest(
-      new URLSearchParams({ idempotency_key: "  idem_urlencoded  " }),
-    );
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBe("idem_urlencoded");
-  });
-
-  it("reads a key from multipart form data", async () => {
-    const formData = new FormData();
-    formData.set("idempotencyKey", "idem_multipart");
-    const request = buildMultipartRequest(formData);
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBe("idem_multipart");
-  });
-
-  it.each([
-    {
-      label: "empty after trimming",
-      value: "   ",
-    },
-    {
-      label: "not a string",
-      value: 123,
-    },
-    {
-      label: "longer than 255 characters",
-      value: "a".repeat(256),
-    },
-  ])("rejects a JSON key that is $label", async ({ value }) => {
-    const request = buildJsonRequest(JSON.stringify({ idempotencyKey: value }));
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBeUndefined();
-  });
-
-  it("returns undefined for malformed JSON", async () => {
-    const request = buildJsonRequest("{");
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBeUndefined();
-  });
-
-  it("returns undefined when form parsing throws", async () => {
-    const request = buildUrlEncodedRequest(
-      new URLSearchParams({ idempotencyKey: "idem_form" }),
-    );
-    jest
-      .spyOn(request, "formData")
-      .mockRejectedValueOnce(new Error("form parse failed"));
-
-    const result = await getIdempotencyKeyFromRequest(request);
-
-    expect(result).toBeUndefined();
-  });
-
-  it.each([
-    {
-      label: "unsupported",
-      headers: { "content-type": "text/plain" },
-    },
-    {
-      label: "missing",
-      headers: undefined,
-    },
-  ])("returns undefined for $label content type", async ({ headers }) => {
-    const request = new Request("https://app.test/api/stripe", {
-      method: "POST",
-      headers,
-      body: "idempotencyKey=idem_ignored",
+      expect(result).toBeUndefined();
     });
 
-    const result = await getIdempotencyKeyFromRequest(request);
+    it("returns undefined for malformed JSON", async () => {
+      const request = buildJsonRequest("{");
 
-    expect(result).toBeUndefined();
-  });
-});
+      const result = await getIdempotencyKeyFromRequest(request);
 
-describe("getStripe", () => {
-  it("returns null when the Stripe secret key is missing", () => {
-    mockEnv = createTestServerEnv({ STRIPE_SECRET_KEY: "" });
-
-    const result = getStripe();
-
-    expect(result).toBeNull();
-    expect(mockStripeConstructor).not.toHaveBeenCalled();
-  });
-
-  it("returns a Stripe client configured for TypeScript", () => {
-    mockEnv = createTestServerEnv({
-      STRIPE_SECRET_KEY: "sk_test_client",
+      expect(result).toBeUndefined();
     });
 
-    const result = getStripe();
+    it("returns undefined when form parsing throws", async () => {
+      const request = buildUrlEncodedRequest(
+        new URLSearchParams({ idempotencyKey: "idem_form" }),
+      );
+      jest
+        .spyOn(request, "formData")
+        .mockRejectedValueOnce(new Error("form parse failed"));
 
-    expect(result).toBe(mockStripeConstructor.mock.results[0]?.value);
-    expect(mockStripeConstructor).toHaveBeenCalledWith("sk_test_client", {
-      typescript: true,
+      const result = await getIdempotencyKeyFromRequest(request);
+
+      expect(result).toBeUndefined();
+    });
+
+    it.each([
+      {
+        label: "unsupported",
+        headers: { "content-type": "text/plain" },
+      },
+      {
+        label: "missing",
+        headers: undefined,
+      },
+    ])("returns undefined for $label content type", async ({ headers }) => {
+      const request = new Request("https://app.test/api/stripe", {
+        method: "POST",
+        headers,
+        body: "idempotencyKey=idem_ignored",
+      });
+
+      const result = await getIdempotencyKeyFromRequest(request);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("getStripe", () => {
+    it("returns null when the Stripe secret key is missing", () => {
+      mockEnv = createTestServerEnv({ STRIPE_SECRET_KEY: "" });
+
+      const result = getStripe();
+
+      expect(result).toBeNull();
+      expect(mockStripeConstructor).not.toHaveBeenCalled();
+    });
+
+    it("returns a Stripe client configured for TypeScript", () => {
+      mockEnv = createTestServerEnv({
+        STRIPE_SECRET_KEY: "sk_test_client",
+      });
+
+      const result = getStripe();
+
+      expect(result).toBe(mockStripeConstructor.mock.results[0]?.value);
+      expect(mockStripeConstructor).toHaveBeenCalledWith("sk_test_client", {
+        typescript: true,
+      });
     });
   });
 });

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -2081,6 +2081,49 @@ Notes:
 - Made no production code changes and did not touch auth session or cookie
   files.
 
+### Billing Stripe Helper Contracts - 2026-06-13
+
+Files added/updated:
+
+- `core/features/billing/stripe.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- core/features/billing/stripe.test.ts --runInBand`
+- `npx.cmd jest core/features/billing/stripe.test.ts --coverage --collectCoverageFrom=core/features/billing/stripe.ts --runInBand`
+- `npx.cmd biome format --write core/features/billing/stripe.test.ts`
+- `npm test`
+- `npm.cmd run check:ci`
+- `npm.cmd test -- --runInBand`
+- `npx.cmd tsc --noEmit`
+
+Result:
+
+- Focused Stripe helper Jest passed: 1 test suite, 25 tests, 0 snapshots.
+- Focused coverage reported 97.72% statements, 91.17% branches, 100%
+  functions, and 97.43% lines for `core/features/billing/stripe.ts`.
+- Biome CI passed: 291 files checked.
+- Full Jest passed: 81 test suites, 666 tests, 0 snapshots.
+- TypeScript passed.
+- Raw `npm test` remains blocked by the unsigned `npm.ps1` PowerShell shim.
+
+Notes:
+
+- Covered APP_URL and Vercel URL precedence, development-only localhost,
+  fail-closed non-development URLs, representative Stripe configuration gaps,
+  encoded upgrade redirects, JSON and form idempotency keys, normalization and
+  rejection limits, parse failures, unsupported content types, and Stripe
+  constructor options.
+- The localhost contract uses a guarded child Jest process with
+  `NODE_ENV=development` because the Next Jest transform compile-folds
+  `NODE_ENV` in the parent process. The focused parent coverage report cannot
+  merge that subprocess, so it lists the localhost return as uncovered even
+  though the behavior test passes.
+- Mocked the Stripe package constructor and server environment boundary.
+- Made no production changes and did not touch auth session or cookie work.
+
 ## Coverage Priorities
 
 1. Close remaining UI primitive gaps.


### PR DESCRIPTION
## Summary

- Add focused unit tests for Stripe billing helpers
- Cover fail-closed base URLs and configuration gating
- Cover idempotency key parsing, normalization, and failures
- Cover encoded upgrade redirects and Stripe client construction
- Update test coverage documentation
- No production or auth session/cookie changes

## Verification

- `npm.cmd test -- core/features/billing/stripe.test.ts --runInBand`
- `npx.cmd jest core/features/billing/stripe.test.ts --coverage --collectCoverageFrom=core/features/billing/stripe.ts --runInBand`
- `npx.cmd biome format --write core/features/billing/stripe.test.ts`
- `npm.cmd run check:ci`
- `npm.cmd test -- --runInBand`
- `npx.cmd tsc --noEmit`

Full Jest result: 81 suites and 666 tests passed.

## Notes

- Stripe is mocked at the package boundary; no API calls are made.
- The development-only localhost case uses a guarded Jest subprocess because
  Next's Jest transform fixes `NODE_ENV` for the parent process.