### PR TITLE
test(billing): cover upgrade revalidation after Stripe return

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -6,20 +6,20 @@ for practical handoff use.
 
 ## Current Status
 
-Date: 2026-06-13
+Date: 2026-06-15
 
 Latest full verification:
 
-- `npm.cmd test -- core/features/billing/stripe.test.ts --runInBand` passed:
-  1 test suite, 25 tests, 0 snapshots.
-- Focused coverage reported 97.72% statements, 91.17% branches, 100%
-  functions, and 97.43% lines for `core/features/billing/stripe.ts`.
-- `npx.cmd biome format --write core/features/billing/stripe.test.ts` passed
-  with no fixes needed.
+- Focused upgrade action Jest passed: 1 test suite, 2 tests, 0 snapshots.
+- Focused Stripe-return client Jest passed: 1 test suite, 6 tests, 0
+  snapshots.
+- Focused coverage reported 100% statements, branches, functions, and lines
+  for both upgrade revalidation modules.
+- `npx.cmd biome format --write` formatted both new test files and fixed one.
 - `npm test` was attempted but remains blocked by the unsigned `npm.ps1`
   PowerShell execution-policy restriction.
-- `npm.cmd run check:ci` passed: 291 files checked.
-- `npm.cmd test -- --runInBand` passed: 81 test suites, 666 tests, 0 snapshots.
+- `npm.cmd run check:ci` passed: 293 files checked.
+- `npm.cmd test -- --runInBand` passed: 83 test suites, 674 tests, 0 snapshots.
 - `npx.cmd tsc --noEmit` passed.
 
 Latest coverage:
@@ -36,6 +36,8 @@ Recent file-specific result:
 | File | Statements | Branches | Functions | Lines |
 | --- | ---: | ---: | ---: | ---: |
 | `app/app/_utils.ts` | 100% | 100% | 100% | 100% |
+| `app/app/upgrade/actions.ts` | 100% | 100% | 100% | 100% |
+| `app/app/upgrade/_RevalidateOnStripeReturn.tsx` | 100% | 100% | 100% | 100% |
 | `proxy.ts` | 100% | 100% | 100% | 100% |
 | `core/features/auth/actions.ts` | 100% | 100% | 100% | 100% |
 | `core/components/ui/action-button.tsx` | 100% | 100% | 100% | 100% |
@@ -49,20 +51,19 @@ Recent file-specific result:
 Latest slice notes:
 
 - Added focused tests:
-  - `core/features/billing/stripe.test.ts`
+  - `app/app/upgrade/actions.test.ts`
+  - `app/app/upgrade/_RevalidateOnStripeReturn.test.tsx`
 - Updated `TEST_COVERAGE_PLAN.md` and `docs/test-coverage-history.md`.
-- Covered fail-closed Stripe base URLs, configuration gating, encoded upgrade
-  redirects, JSON and form idempotency parsing and normalization, parse
-  failures, unsupported content types, and Stripe client construction.
-- The development localhost branch runs in a guarded child Jest process with
-  `NODE_ENV=development` because Next's Jest transform compile-folds
-  `NODE_ENV` in the parent test process.
-- Focused Jest passed for the Stripe helper test file (25 tests).
-- Focused coverage does not merge the guarded child process and therefore
-  reports the localhost return as uncovered in the parent report.
-- Full Jest, TypeScript, scoped Biome, and Biome CI verification passed through
-  `npm.cmd`.
+- Covered signed-in and anonymous upgrade revalidation, including the upgrade
+  path and current-user cache boundary.
+- Covered all Stripe return flags, refresh-after-settlement ordering, rejected
+  revalidation logging with refresh fallback, and the single-run ref guard.
+- Focused Jest passed for both upgrade revalidation test files (8 tests total).
+- Both target modules reached 100% focused coverage.
+- Full Jest, TypeScript, scoped Biome formatting, and Biome CI verification
+  passed.
 - Made no production code changes.
+- Did not touch auth session, cookie, or token work.
 
 ## Working Rules
 
@@ -184,6 +185,7 @@ Recommended next slice:
 | 2026-06-12 | App cancellation notice | `app/app/_utils.ts` reached 100% coverage for Pro cancellation-banner eligibility and Stripe failure handling. |
 | 2026-06-12 | Alert dialog UI primitive | `core/components/ui/alert-dialog.tsx` reached 100% coverage for composition, prop forwarding, interactions, and accessibility. |
 | 2026-06-13 | Billing Stripe helpers | Added 25 direct contract tests for Stripe configuration, redirect, idempotency, and client helpers. |
+| 2026-06-15 | Upgrade return revalidation | Covered server revalidation and the Stripe-return client refresh flow at 100%. |
 
 ## Archive
 

--- a/app/app/upgrade/_RevalidateOnStripeReturn.test.tsx
+++ b/app/app/upgrade/_RevalidateOnStripeReturn.test.tsx
@@ -1,0 +1,137 @@
+jest.mock("./actions", () => ({
+  revalidateUpgradePage: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+import { useRouter } from "next/navigation";
+
+import { render, waitFor } from "@/core/test-utils/render";
+
+import { RevalidateOnStripeReturn } from "./_RevalidateOnStripeReturn";
+import { revalidateUpgradePage } from "./actions";
+
+const mockRevalidateUpgradePage = jest.mocked(revalidateUpgradePage);
+const mockUseRouter = jest.mocked(useRouter);
+const mockRefresh = jest.fn();
+
+function mockRouter(): void {
+  mockUseRouter.mockReturnValue({
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+    push: jest.fn(),
+    refresh: mockRefresh,
+    replace: jest.fn(),
+  });
+}
+
+describe("RevalidateOnStripeReturn", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouter();
+    mockRevalidateUpgradePage.mockResolvedValue();
+  });
+
+  it("does not revalidate or refresh without Stripe return flags", () => {
+    render(
+      <RevalidateOnStripeReturn
+        success={false}
+        canceled={false}
+        canceledSubscription={false}
+      />,
+    );
+
+    expect(mockRevalidateUpgradePage).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "success",
+      { success: true, canceled: false, canceledSubscription: false },
+    ],
+    [
+      "canceled",
+      { success: false, canceled: true, canceledSubscription: false },
+    ],
+    [
+      "canceled subscription",
+      { success: false, canceled: false, canceledSubscription: true },
+    ],
+  ])("revalidates and refreshes after a %s return", async (_name, props) => {
+    let settleRevalidation: (() => void) | undefined;
+    mockRevalidateUpgradePage.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        settleRevalidation = resolve;
+      }),
+    );
+
+    render(<RevalidateOnStripeReturn {...props} />);
+
+    await waitFor(() => {
+      expect(mockRevalidateUpgradePage).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    settleRevalidation?.();
+
+    await waitFor(() => {
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("logs revalidation failures and still refreshes", async () => {
+    const error = new Error("cache unavailable");
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockRevalidateUpgradePage.mockRejectedValueOnce(error);
+
+    render(
+      <RevalidateOnStripeReturn
+        success
+        canceled={false}
+        canceledSubscription={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "revalidateUpgradePage failed:",
+        error,
+      );
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("runs revalidation only once across rerenders", async () => {
+    const { rerender } = render(
+      <RevalidateOnStripeReturn
+        success
+        canceled={false}
+        canceledSubscription={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockRevalidateUpgradePage).toHaveBeenCalledTimes(1);
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <RevalidateOnStripeReturn
+        success={false}
+        canceled
+        canceledSubscription={false}
+      />,
+    );
+
+    expect(mockRevalidateUpgradePage).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/app/upgrade/_RevalidateOnStripeReturn.test.tsx
+++ b/app/app/upgrade/_RevalidateOnStripeReturn.test.tsx
@@ -88,25 +88,28 @@ describe("RevalidateOnStripeReturn", () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    mockRevalidateUpgradePage.mockRejectedValueOnce(error);
 
-    render(
-      <RevalidateOnStripeReturn
-        success
-        canceled={false}
-        canceledSubscription={false}
-      />,
-    );
+    try {
+      mockRevalidateUpgradePage.mockRejectedValueOnce(error);
 
-    await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "revalidateUpgradePage failed:",
-        error,
+      render(
+        <RevalidateOnStripeReturn
+          success
+          canceled={false}
+          canceledSubscription={false}
+        />,
       );
-      expect(mockRefresh).toHaveBeenCalledTimes(1);
-    });
 
-    consoleErrorSpy.mockRestore();
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "revalidateUpgradePage failed:",
+          error,
+        );
+        expect(mockRefresh).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("runs revalidation only once across rerenders", async () => {

--- a/app/app/upgrade/actions.test.ts
+++ b/app/app/upgrade/actions.test.ts
@@ -1,0 +1,61 @@
+jest.mock("next/cache", () => {
+  const { createNextCacheMock } = jest.requireActual<
+    typeof import("@core/test-utils/mocks/next")
+  >("@core/test-utils/mocks/next");
+
+  return createNextCacheMock();
+});
+
+jest.mock("@/core/features/auth/actions", () => ({
+  getCurrentUserAction: jest.fn(),
+}));
+
+jest.mock("@/core/features/users/dbCache", () => ({
+  revalidateUserCache: jest.fn(),
+}));
+
+import { revalidatePath } from "next/cache";
+
+import { routes } from "@/core/data/routes";
+import { getCurrentUserAction } from "@/core/features/auth/actions";
+import { revalidateUserCache } from "@/core/features/users/dbCache";
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeCurrentUser } from "@/core/test-utils/factories";
+
+import { revalidateUpgradePage } from "./actions";
+
+const mockGetCurrentUserAction = jest.mocked(getCurrentUserAction);
+const mockRevalidatePath = jest.mocked(revalidatePath);
+const mockRevalidateUserCache = jest.mocked(revalidateUserCache);
+
+describe("revalidateUpgradePage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("revalidates the upgrade path and signed-in user cache", async () => {
+    mockGetCurrentUserAction.mockResolvedValue(
+      makeCurrentUser({ userId: TEST_USER_ID }),
+    );
+
+    await expect(revalidateUpgradePage()).resolves.toBeUndefined();
+
+    expect(routes.upgrade).toBe("/app/upgrade");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/app/upgrade");
+    expect(mockGetCurrentUserAction).toHaveBeenCalledTimes(1);
+    expect(mockRevalidateUserCache).toHaveBeenCalledTimes(1);
+    expect(mockRevalidateUserCache).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it("revalidates the upgrade path without a user cache for anonymous users", async () => {
+    mockGetCurrentUserAction.mockResolvedValue(
+      makeCurrentUser({ userId: null }),
+    );
+
+    await expect(revalidateUpgradePage()).resolves.toBeUndefined();
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/app/upgrade");
+    expect(mockGetCurrentUserAction).toHaveBeenCalledTimes(1);
+    expect(mockRevalidateUserCache).not.toHaveBeenCalled();
+  });
+});

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -2124,6 +2124,48 @@ Notes:
 - Mocked the Stripe package constructor and server environment boundary.
 - Made no production changes and did not touch auth session or cookie work.
 
+### Upgrade Return Revalidation - 2026-06-15
+
+Files added/updated:
+
+- `app/app/upgrade/actions.test.ts`
+- `app/app/upgrade/_RevalidateOnStripeReturn.test.tsx`
+- `TEST_COVERAGE_PLAN.md`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- app/app/upgrade/actions.test.ts --runInBand`
+- `npm.cmd test -- app/app/upgrade/_RevalidateOnStripeReturn.test.tsx --runInBand`
+- `npx.cmd jest app/app/upgrade/actions.test.ts --coverage --collectCoverageFrom=app/app/upgrade/actions.ts --runInBand`
+- `npx.cmd jest app/app/upgrade/_RevalidateOnStripeReturn.test.tsx --coverage --collectCoverageFrom=app/app/upgrade/_RevalidateOnStripeReturn.tsx --runInBand`
+- `npx.cmd biome format --write app/app/upgrade/actions.test.ts app/app/upgrade/_RevalidateOnStripeReturn.test.tsx`
+- `npm test`
+- `npm.cmd run check:ci`
+- `npm.cmd test -- --runInBand`
+- `npx.cmd tsc --noEmit`
+
+Result:
+
+- Focused action Jest passed: 1 test suite, 2 tests, 0 snapshots.
+- Focused client-effect Jest passed: 1 test suite, 6 tests, 0 snapshots.
+- Both target modules reached 100% statements, branches, functions, and lines.
+- Raw `npm test` remains blocked by the unsigned `npm.ps1` PowerShell shim.
+- Biome CI passed: 293 files checked.
+- Full Jest passed: 83 test suites, 674 tests, 0 snapshots.
+- TypeScript passed.
+
+Notes:
+
+- Covered signed-in and anonymous server revalidation without real Next cache
+  or auth calls.
+- Covered each Stripe return flag, refresh ordering after the action settles,
+  rejection logging with the `.finally()` refresh, and the single-run ref
+  guard across a dependency-changing rerender.
+- Used shared synthetic current-user factories and `TEST_USER_ID`.
+- Made no production changes and did not touch auth session, cookie, or token
+  work.
+
 ## Coverage Priorities
 
 1. Close remaining UI primitive gaps.


### PR DESCRIPTION
## Summary

- Add server-action tests for signed-in and anonymous upgrade revalidation
- Add client-effect tests for all Stripe return flags, refresh ordering, failure handling, and single-run behavior
- Update test coverage documentation
- Make no production or auth session/cookie/token changes

## Verification

- Focused Jest: 8 tests passed
- Focused coverage: 100% for both target modules
- Biome CI: 293 files checked
- Full Jest: 83 suites, 674 tests passed
- TypeScript: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for upgrade page revalidation and Stripe return handling, including signed-in and anonymous user scenarios, refresh logic, error handling, and single-run guards.

* **Documentation**
  * Updated test coverage documentation to record verification results and newly added test entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->