### PR TITLE
test(auth): cover session helpers

### DIFF
--- a/core/features/auth/db.ts
+++ b/core/features/auth/db.ts
@@ -31,12 +31,14 @@ export async function createSessionDb(sessionData: {
 }
 
 export async function validateSessionDb(token: string) {
-  return await db.query.SessionTable.findFirst({
-    where: and(
-      eq(SessionTable.token, token),
-      gt(SessionTable.expiresAt, new Date()),
-    ),
-  });
+  return (
+    (await db.query.SessionTable.findFirst({
+      where: and(
+        eq(SessionTable.token, token),
+        gt(SessionTable.expiresAt, new Date()),
+      ),
+    })) ?? null
+  );
 }
 
 export async function extendSessionDb(sessionId: string, expiresAt: Date) {

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -49,6 +49,13 @@ const mockGenerateSecureToken = jest.mocked(generateSecureToken);
 describe("session helpers", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
+  const testToken = "test-token-abc";
+  const testSession = makeSession({
+    userId: TEST_USER_ID,
+    token: testToken,
+    expiresAt: new Date("2026-05-31T12:00:00.000Z"),
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
@@ -60,20 +67,12 @@ describe("session helpers", () => {
   });
 
   describe("createSession", () => {
-    const testToken = "test-token-abc";
-
     mockGenerateSecureToken.mockReturnValue(testToken);
     jest
       .useFakeTimers()
       .setSystemTime(new Date("2026-05-01T12:00:00.000Z").getTime()); // should return "2026-05-31T12:00:00.000Z"
 
     it("creates a new session and persists it via the database", async () => {
-      const testSession = makeSession({
-        userId: TEST_USER_ID,
-        token: testToken,
-        expiresAt: new Date("2026-05-31T12:00:00.000Z"),
-      });
-
       mockCreateSessionDb.mockResolvedValue([testSession]);
 
       const result = await createSession(TEST_USER_ID);
@@ -96,6 +95,38 @@ describe("session helpers", () => {
       await expect(createSession(TEST_USER_ID)).rejects.toThrow(DatabaseError);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error creating session:",
+        error,
+      );
+    });
+  });
+
+  describe("validateSession", () => {
+    it("returns session object if session is valid", async () => {
+      mockValidateSessionDb.mockResolvedValue(testSession);
+
+      const result = await validateSession(testToken);
+
+      expect(mockValidateSessionDb).toHaveBeenCalledWith(testToken);
+      expect(result).toEqual(testSession);
+    });
+
+    it("returns null if session is not valid", async () => {
+      mockValidateSessionDb.mockResolvedValue(undefined);
+
+      const result = await validateSession(testToken);
+
+      expect(mockValidateSessionDb).toHaveBeenCalledWith(testToken);
+      expect(result).toBeNull();
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const error = new Error("find failed");
+
+      mockValidateSessionDb.mockRejectedValueOnce(error);
+
+      await expect(validateSession(testToken)).rejects.toThrow(DatabaseError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error validating session:",
         error,
       );
     });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -22,6 +22,7 @@ import {
   validateSessionDb,
 } from "@/core/features/auth/db";
 import { generateSecureToken } from "@/core/features/auth/tokens";
+import { DatabaseError } from "@/core/dal/errors";
 
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeSession } from "@core/test-utils/factories";
@@ -46,26 +47,33 @@ const mockValidateSessionDb = jest.mocked(validateSessionDb);
 const mockGenerateSecureToken = jest.mocked(generateSecureToken);
 
 describe("session helpers", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   });
+
   afterEach(() => {
     jest.useRealTimers();
+    consoleErrorSpy.mockRestore();
   });
 
   describe("createSession", () => {
+    const testToken = "test-token-abc";
+
+    mockGenerateSecureToken.mockReturnValue(testToken);
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date("2026-05-01T12:00:00.000Z").getTime()); // should return "2026-05-31T12:00:00.000Z"
+
     it("creates a new session and persists it via the database", async () => {
-      const testToken = "test-token-abc";
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
         expiresAt: new Date("2026-05-31T12:00:00.000Z"),
       });
 
-      mockGenerateSecureToken.mockReturnValue(testToken);
-      jest
-        .useFakeTimers()
-        .setSystemTime(new Date("2026-05-01T12:00:00.000Z").getTime()); // should return "2026-05-31T12:00:00.000Z"
       mockCreateSessionDb.mockResolvedValue([testSession]);
 
       const result = await createSession(TEST_USER_ID);
@@ -78,6 +86,18 @@ describe("session helpers", () => {
         expiresAt: new Date("2026-05-31T12:00:00.000Z"),
       });
       expect(result).toEqual(testSession);
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const error = new Error("insert failed");
+
+      mockCreateSessionDb.mockRejectedValueOnce(error);
+
+      await expect(createSession(TEST_USER_ID)).rejects.toThrow(DatabaseError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error creating session:",
+        error,
+      );
     });
   });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -265,7 +265,7 @@ describe("session helpers", () => {
         fields: [],
       });
 
-      await expect(deleteSession(testToken)).resolves.toBe(undefined);
+      await expect(deleteSession(testToken)).resolves.toBeUndefined();
       expect(deleteSessionDb).toHaveBeenCalledTimes(1);
     });
 
@@ -291,6 +291,51 @@ describe("session helpers", () => {
 
       expect(error).toBeInstanceOf(DatabaseError);
       expect(error.message).toBe("Failed to delete session");
+      expect(error.cause).toBeDefined();
+    });
+  });
+
+  describe("deleteAllUserSessions", () => {
+    it("deletes all sessions for a user", async () => {
+      mockDeleteAllUserSessionsDb.mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+        command: "",
+        oid: 1,
+        fields: [],
+      });
+
+      await expect(
+        deleteAllUserSessions(TEST_USER_ID),
+      ).resolves.toBeUndefined();
+      expect(mockDeleteAllUserSessionsDb).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteAllUserSessionsDb.mockRejectedValueOnce(dbError);
+
+      await expect(deleteAllUserSessions(TEST_USER_ID)).rejects.toThrow(
+        DatabaseError,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error deleting user sessions:",
+        dbError,
+      );
+    });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteAllUserSessionsDb.mockRejectedValueOnce(dbError);
+
+      const error = await deleteAllUserSessions(TEST_USER_ID).catch(
+        (err) => err,
+      );
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to delete user sessions");
       expect(error.cause).toBeDefined();
     });
   });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -254,4 +254,44 @@ describe("session helpers", () => {
       expect(error.cause).toBeDefined();
     });
   });
+
+  describe("deleteSession", () => {
+    it("deletes a session", async () => {
+      mockDeleteSessionDb.mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+        command: "",
+        oid: 1,
+        fields: [],
+      });
+
+      await expect(deleteSession(testToken)).resolves.toBe(undefined);
+      expect(deleteSessionDb).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteSessionDb.mockRejectedValueOnce(dbError);
+
+      await expect(deleteSession(testToken)).rejects.toThrow(DatabaseError);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error deleting session:",
+        dbError,
+      );
+    });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteSessionDb.mockRejectedValueOnce(dbError);
+
+      const error = await deleteSession(testToken).catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to delete session");
+      expect(error.cause).toBeDefined();
+    });
+  });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -339,4 +339,43 @@ describe("session helpers", () => {
       expect(error.cause).toBeDefined();
     });
   });
+
+  describe("deleteExpiredSessions", () => {
+    it("deletes all expired sessions", async () => {
+      mockDeleteExpiredSessionsDb.mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+        command: "",
+        oid: 1,
+        fields: [],
+      });
+
+      await expect(deleteExpiredSessions()).resolves.toBeUndefined();
+      expect(mockDeleteExpiredSessionsDb).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteExpiredSessionsDb.mockRejectedValueOnce(dbError);
+
+      await expect(deleteExpiredSessions()).rejects.toThrow(DatabaseError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error deleting expired sessions:",
+        dbError,
+      );
+    });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("delete failed");
+
+      mockDeleteExpiredSessionsDb.mockRejectedValueOnce(dbError);
+
+      const error = await deleteExpiredSessions().catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to delete expired sessions");
+      expect(error.cause).toBeDefined();
+    });
+  });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -22,6 +22,7 @@ import {
   validateSessionDb,
 } from "@/core/features/auth/db";
 import { generateSecureToken } from "@/core/features/auth/tokens";
+import { SESSION_DURATION_MS } from "@/core/features/auth/constants";
 import { DatabaseError } from "@/core/dal/errors";
 
 import { TEST_USER_ID } from "@/core/test-utils/constants";
@@ -163,5 +164,94 @@ describe("session helpers", () => {
     });
   });
 
+  describe("extendSessionIfNeeded", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
+
+    it("extends session if it is close to expiring", async () => {
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date("2026-05-10"), // expires in just 10 days, so session will be extended
+      });
+      const newExpiresAt = new Date(Date.now() + SESSION_DURATION_MS);
+
+      mockValidateSessionDb.mockResolvedValueOnce(testSession);
+      mockExtendSessionDb.mockResolvedValueOnce([
+        {
+          ...testSession,
+          expiresAt: newExpiresAt,
+        },
+      ]);
+
+      const result = await extendSessionIfNeeded(testToken);
+
+      expect(mockExtendSessionDb).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        ...testSession,
+        expiresAt: newExpiresAt,
+      });
+    });
+
+    it("returns unchanged session if extension is not needed", async () => {
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date("2026-06-31"),
+      });
+
+      mockValidateSessionDb.mockResolvedValueOnce(testSession);
+
+      const result = await extendSessionIfNeeded(testToken);
+
+      expect(mockExtendSessionDb).not.toHaveBeenCalled();
+      expect(result).toEqual(testSession);
+    });
+
+    it("returns null if session is invalid", async () => {
+      mockValidateSessionDb.mockResolvedValueOnce(undefined);
+
+      const result = await extendSessionIfNeeded(testToken);
+
+      expect(mockExtendSessionDb).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const error = new Error("update failed");
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date(),
+      });
+
+      mockValidateSessionDb.mockResolvedValueOnce(testSession);
+      mockExtendSessionDb.mockRejectedValueOnce(error);
+
+      await expect(extendSessionIfNeeded(testToken)).rejects.toThrow(
+        DatabaseError,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error extending session:",
+        error,
+      );
+    });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("update failed");
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date(),
+      });
+
+      mockValidateSessionDb.mockResolvedValueOnce(testSession);
+      mockExtendSessionDb.mockRejectedValueOnce(dbError);
+
+      const error = await extendSessionIfNeeded(testToken).catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to extend session");
+      expect(error.cause).toBeDefined();
+    });
   });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -213,7 +213,7 @@ describe("session helpers", () => {
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
-        expiresAt: new Date("2026-06-15"), // not hitting extension path
+        expiresAt: new Date(), // need to hit extension path to test this error
       });
 
       mockValidateSessionDb.mockResolvedValueOnce(testSession);

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -378,4 +378,48 @@ describe("session helpers", () => {
       expect(error.cause).toBeDefined();
     });
   });
+
+  describe("getUserSessions", () => {
+    it("returns sessions", async () => {
+      const sessions = [
+        makeSession({ id: "abc_1" }),
+        makeSession({ id: "abc_2" }),
+      ];
+
+      mockGetUserSessionsDb.mockResolvedValueOnce(sessions);
+
+      const result = await getUserSessions(TEST_USER_ID);
+
+      expect(mockGetUserSessionsDb).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("abc_1");
+      expect(result[1].id).toBe("abc_2");
+    });
+
+    it("throws DatabaseError in case of error", async () => {
+      const dbError = new Error("select failed");
+
+      mockGetUserSessionsDb.mockRejectedValueOnce(dbError);
+
+      await expect(getUserSessions(TEST_USER_ID)).rejects.toThrow(
+        DatabaseError,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Database error getting user sessions:",
+        dbError,
+      );
+    });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("select failed");
+
+      mockGetUserSessionsDb.mockRejectedValueOnce(dbError);
+
+      const error = await getUserSessions(TEST_USER_ID).catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to get user sessions");
+      expect(error.cause).toBeDefined();
+    });
+  });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -88,14 +88,14 @@ describe("session helpers", () => {
     });
 
     it("throws DatabaseError in case of error", async () => {
-      const error = new Error("insert failed");
+      const dbError = new Error("insert failed");
 
-      mockCreateSessionDb.mockRejectedValueOnce(error);
+      mockCreateSessionDb.mockRejectedValueOnce(dbError);
 
       await expect(createSession(TEST_USER_ID)).rejects.toThrow(DatabaseError);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error creating session:",
-        error,
+        dbError,
       );
     });
 
@@ -140,14 +140,14 @@ describe("session helpers", () => {
     });
 
     it("throws DatabaseError in case of error", async () => {
-      const error = new Error("find failed");
+      const dbError = new Error("find failed");
 
-      mockValidateSessionDb.mockRejectedValueOnce(error);
+      mockValidateSessionDb.mockRejectedValueOnce(dbError);
 
       await expect(validateSession(testToken)).rejects.toThrow(DatabaseError);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error validating session:",
-        error,
+        dbError,
       );
     });
 
@@ -217,7 +217,7 @@ describe("session helpers", () => {
     });
 
     it("throws DatabaseError in case of error", async () => {
-      const error = new Error("update failed");
+      const dbError = new Error("update failed");
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
@@ -225,14 +225,14 @@ describe("session helpers", () => {
       });
 
       mockValidateSessionDb.mockResolvedValueOnce(testSession);
-      mockExtendSessionDb.mockRejectedValueOnce(error);
+      mockExtendSessionDb.mockRejectedValueOnce(dbError);
 
       await expect(extendSessionIfNeeded(testToken)).rejects.toThrow(
         DatabaseError,
       );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error extending session:",
-        error,
+        dbError,
       );
     });
 

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -23,7 +23,6 @@ import {
 } from "@/core/features/auth/db";
 import { generateSecureToken } from "@/core/features/auth/tokens";
 import { SESSION_DURATION_MS } from "@/core/features/auth/constants";
-import { DatabaseError } from "@/core/dal/errors";
 
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeSession } from "@core/test-utils/factories";
@@ -47,6 +46,10 @@ const mockGetUserSessionsDb = jest.mocked(getUserSessionsDb);
 const mockValidateSessionDb = jest.mocked(validateSessionDb);
 const mockGenerateSecureToken = jest.mocked(generateSecureToken);
 
+function mockDeleteResult() {
+  return { rows: [], rowCount: 1, command: "", oid: 1, fields: [] };
+}
+
 describe("session helpers", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -63,16 +66,18 @@ describe("session helpers", () => {
   });
 
   describe("createSession", () => {
-    mockGenerateSecureToken.mockReturnValue(testToken);
-    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
-
-    const testSession = makeSession({
-      userId: TEST_USER_ID,
-      token: testToken,
-      expiresAt: new Date(), // "2026-05-01"
+    beforeEach(() => {
+      mockGenerateSecureToken.mockReturnValue(testToken);
+      jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
     });
 
     it("creates a new session and persists it via the database", async () => {
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date(), // "2026-05-01"
+      });
+
       mockCreateSessionDb.mockResolvedValue([testSession]);
 
       const result = await createSession(TEST_USER_ID);
@@ -92,36 +97,27 @@ describe("session helpers", () => {
 
       mockCreateSessionDb.mockRejectedValueOnce(dbError);
 
-      await expect(createSession(TEST_USER_ID)).rejects.toThrow(DatabaseError);
+      await expect(createSession(TEST_USER_ID)).rejects.toMatchObject({
+        message: "Failed to create session",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error creating session:",
         dbError,
       );
     });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("insert failed");
-
-      mockCreateSessionDb.mockRejectedValueOnce(dbError);
-
-      const error = await createSession(TEST_USER_ID).catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to create session");
-      expect(error.cause).toBeDefined();
-    });
   });
 
   describe("validateSession", () => {
-    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
-
-    const testSession = makeSession({
-      userId: TEST_USER_ID,
-      token: testToken,
-      expiresAt: new Date(), // "2026-05-01"
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
     });
 
     it("returns session object if session is valid", async () => {
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date(), // "2026-05-01"
+      });
       mockValidateSessionDb.mockResolvedValue(testSession);
 
       const result = await validateSession(testToken);
@@ -131,7 +127,7 @@ describe("session helpers", () => {
     });
 
     it("returns null if session is not valid", async () => {
-      mockValidateSessionDb.mockResolvedValue(undefined);
+      mockValidateSessionDb.mockResolvedValue(null);
 
       const result = await validateSession(testToken);
 
@@ -144,34 +140,26 @@ describe("session helpers", () => {
 
       mockValidateSessionDb.mockRejectedValueOnce(dbError);
 
-      await expect(validateSession(testToken)).rejects.toThrow(DatabaseError);
+      await expect(validateSession(testToken)).rejects.toMatchObject({
+        message: "Failed to validate session",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error validating session:",
         dbError,
       );
     });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("find failed");
-
-      mockValidateSessionDb.mockRejectedValueOnce(dbError);
-
-      const error = await validateSession(testToken).catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to validate session");
-      expect(error.cause).toBeDefined();
-    });
   });
 
   describe("extendSessionIfNeeded", () => {
-    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date("2026-05-05").getTime());
+    });
 
     it("extends session if it is close to expiring", async () => {
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
-        expiresAt: new Date("2026-05-10"), // expires in just 10 days, so session will be extended
+        expiresAt: new Date("2026-05-10"), // expires in just 5 days; session will be extended because the minimum is SESSION_REFRESH_THRESHOLD_MS (7 days)
       });
       const newExpiresAt = new Date(Date.now() + SESSION_DURATION_MS);
 
@@ -186,6 +174,10 @@ describe("session helpers", () => {
       const result = await extendSessionIfNeeded(testToken);
 
       expect(mockExtendSessionDb).toHaveBeenCalledTimes(1);
+      expect(mockExtendSessionDb).toHaveBeenCalledWith(
+        testSession.id,
+        newExpiresAt,
+      );
       expect(result).toEqual({
         ...testSession,
         expiresAt: newExpiresAt,
@@ -196,7 +188,7 @@ describe("session helpers", () => {
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
-        expiresAt: new Date("2026-06-31"),
+        expiresAt: new Date("2026-06-15"), // not hitting extension path
       });
 
       mockValidateSessionDb.mockResolvedValueOnce(testSession);
@@ -208,7 +200,7 @@ describe("session helpers", () => {
     });
 
     it("returns null if session is invalid", async () => {
-      mockValidateSessionDb.mockResolvedValueOnce(undefined);
+      mockValidateSessionDb.mockResolvedValueOnce(null);
 
       const result = await extendSessionIfNeeded(testToken);
 
@@ -221,52 +213,29 @@ describe("session helpers", () => {
       const testSession = makeSession({
         userId: TEST_USER_ID,
         token: testToken,
-        expiresAt: new Date(),
+        expiresAt: new Date("2026-06-15"), // not hitting extension path
       });
 
       mockValidateSessionDb.mockResolvedValueOnce(testSession);
       mockExtendSessionDb.mockRejectedValueOnce(dbError);
 
-      await expect(extendSessionIfNeeded(testToken)).rejects.toThrow(
-        DatabaseError,
-      );
+      await expect(extendSessionIfNeeded(testToken)).rejects.toMatchObject({
+        message: "Failed to extend session",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error extending session:",
         dbError,
       );
     });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("update failed");
-      const testSession = makeSession({
-        userId: TEST_USER_ID,
-        token: testToken,
-        expiresAt: new Date(),
-      });
-
-      mockValidateSessionDb.mockResolvedValueOnce(testSession);
-      mockExtendSessionDb.mockRejectedValueOnce(dbError);
-
-      const error = await extendSessionIfNeeded(testToken).catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to extend session");
-      expect(error.cause).toBeDefined();
-    });
   });
 
   describe("deleteSession", () => {
     it("deletes a session", async () => {
-      mockDeleteSessionDb.mockResolvedValueOnce({
-        rows: [],
-        rowCount: 0,
-        command: "",
-        oid: 1,
-        fields: [],
-      });
+      mockDeleteSessionDb.mockResolvedValueOnce(mockDeleteResult());
 
       await expect(deleteSession(testToken)).resolves.toBeUndefined();
-      expect(deleteSessionDb).toHaveBeenCalledTimes(1);
+      expect(mockDeleteSessionDb).toHaveBeenCalledTimes(1);
+      expect(mockDeleteSessionDb).toHaveBeenCalledWith(testToken);
     });
 
     it("throws DatabaseError in case of error", async () => {
@@ -274,41 +243,26 @@ describe("session helpers", () => {
 
       mockDeleteSessionDb.mockRejectedValueOnce(dbError);
 
-      await expect(deleteSession(testToken)).rejects.toThrow(DatabaseError);
+      await expect(deleteSession(testToken)).rejects.toMatchObject({
+        message: "Failed to delete session",
+      });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error deleting session:",
         dbError,
       );
     });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("delete failed");
-
-      mockDeleteSessionDb.mockRejectedValueOnce(dbError);
-
-      const error = await deleteSession(testToken).catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to delete session");
-      expect(error.cause).toBeDefined();
-    });
   });
 
   describe("deleteAllUserSessions", () => {
     it("deletes all sessions for a user", async () => {
-      mockDeleteAllUserSessionsDb.mockResolvedValueOnce({
-        rows: [],
-        rowCount: 0,
-        command: "",
-        oid: 1,
-        fields: [],
-      });
+      mockDeleteAllUserSessionsDb.mockResolvedValueOnce(mockDeleteResult());
 
       await expect(
         deleteAllUserSessions(TEST_USER_ID),
       ).resolves.toBeUndefined();
       expect(mockDeleteAllUserSessionsDb).toHaveBeenCalledTimes(1);
+      expect(mockDeleteAllUserSessionsDb).toHaveBeenCalledWith(TEST_USER_ID);
     });
 
     it("throws DatabaseError in case of error", async () => {
@@ -316,39 +270,19 @@ describe("session helpers", () => {
 
       mockDeleteAllUserSessionsDb.mockRejectedValueOnce(dbError);
 
-      await expect(deleteAllUserSessions(TEST_USER_ID)).rejects.toThrow(
-        DatabaseError,
-      );
+      await expect(deleteAllUserSessions(TEST_USER_ID)).rejects.toMatchObject({
+        message: "Failed to delete user sessions",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error deleting user sessions:",
         dbError,
       );
     });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("delete failed");
-
-      mockDeleteAllUserSessionsDb.mockRejectedValueOnce(dbError);
-
-      const error = await deleteAllUserSessions(TEST_USER_ID).catch(
-        (err) => err,
-      );
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to delete user sessions");
-      expect(error.cause).toBeDefined();
-    });
   });
 
   describe("deleteExpiredSessions", () => {
     it("deletes all expired sessions", async () => {
-      mockDeleteExpiredSessionsDb.mockResolvedValueOnce({
-        rows: [],
-        rowCount: 0,
-        command: "",
-        oid: 1,
-        fields: [],
-      });
+      mockDeleteExpiredSessionsDb.mockResolvedValueOnce(mockDeleteResult());
 
       await expect(deleteExpiredSessions()).resolves.toBeUndefined();
       expect(mockDeleteExpiredSessionsDb).toHaveBeenCalledTimes(1);
@@ -359,23 +293,13 @@ describe("session helpers", () => {
 
       mockDeleteExpiredSessionsDb.mockRejectedValueOnce(dbError);
 
-      await expect(deleteExpiredSessions()).rejects.toThrow(DatabaseError);
+      await expect(deleteExpiredSessions()).rejects.toMatchObject({
+        message: "Failed to delete expired sessions",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error deleting expired sessions:",
         dbError,
       );
-    });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("delete failed");
-
-      mockDeleteExpiredSessionsDb.mockRejectedValueOnce(dbError);
-
-      const error = await deleteExpiredSessions().catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to delete expired sessions");
-      expect(error.cause).toBeDefined();
     });
   });
 
@@ -391,9 +315,18 @@ describe("session helpers", () => {
       const result = await getUserSessions(TEST_USER_ID);
 
       expect(mockGetUserSessionsDb).toHaveBeenCalledTimes(1);
-      expect(result).toHaveLength(2);
-      expect(result[0].id).toBe("abc_1");
-      expect(result[1].id).toBe("abc_2");
+      expect(mockGetUserSessionsDb).toHaveBeenCalledWith(TEST_USER_ID);
+      expect(result).toEqual(sessions);
+    });
+
+    it("returns empty array if there are no sessions", async () => {
+      mockGetUserSessionsDb.mockResolvedValueOnce([]);
+
+      const result = await getUserSessions(TEST_USER_ID);
+
+      expect(mockGetUserSessionsDb).toHaveBeenCalledTimes(1);
+      expect(mockGetUserSessionsDb).toHaveBeenCalledWith(TEST_USER_ID);
+      expect(result).toEqual([]);
     });
 
     it("throws DatabaseError in case of error", async () => {
@@ -401,25 +334,13 @@ describe("session helpers", () => {
 
       mockGetUserSessionsDb.mockRejectedValueOnce(dbError);
 
-      await expect(getUserSessions(TEST_USER_ID)).rejects.toThrow(
-        DatabaseError,
-      );
+      await expect(getUserSessions(TEST_USER_ID)).rejects.toMatchObject({
+        message: "Failed to get user sessions",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Database error getting user sessions:",
         dbError,
       );
-    });
-
-    it("throws DatabaseError with the defined message", async () => {
-      const dbError = new Error("select failed");
-
-      mockGetUserSessionsDb.mockRejectedValueOnce(dbError);
-
-      const error = await getUserSessions(TEST_USER_ID).catch((err) => err);
-
-      expect(error).toBeInstanceOf(DatabaseError);
-      expect(error.message).toBe("Failed to get user sessions");
-      expect(error.cause).toBeDefined();
     });
   });
 });

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -1,0 +1,83 @@
+jest.mock("@/core/features/auth/db", () => ({
+  createSessionDb: jest.fn(),
+  deleteAllUserSessionsDb: jest.fn(),
+  deleteExpiredSessionsDb: jest.fn(),
+  deleteSessionDb: jest.fn(),
+  extendSessionDb: jest.fn(),
+  getUserSessionsDb: jest.fn(),
+  validateSessionDb: jest.fn(),
+}));
+
+jest.mock("@/core/features/auth/tokens", () => ({
+  generateSecureToken: jest.fn(),
+}));
+
+import {
+  createSessionDb,
+  deleteAllUserSessionsDb,
+  deleteExpiredSessionsDb,
+  deleteSessionDb,
+  extendSessionDb,
+  getUserSessionsDb,
+  validateSessionDb,
+} from "@/core/features/auth/db";
+import { generateSecureToken } from "@/core/features/auth/tokens";
+
+import { TEST_USER_ID } from "@/core/test-utils/constants";
+import { makeSession } from "@core/test-utils/factories";
+
+import {
+  createSession,
+  validateSession,
+  extendSessionIfNeeded,
+  deleteSession,
+  deleteAllUserSessions,
+  deleteExpiredSessions,
+  getUserSessions,
+} from "./session";
+
+const mockCreateSessionDb = jest.mocked(createSessionDb);
+const mockDeleteAllUserSessionsDb = jest.mocked(deleteAllUserSessionsDb);
+const mockDeleteExpiredSessionsDb = jest.mocked(deleteExpiredSessionsDb);
+const mockDeleteSessionDb = jest.mocked(deleteSessionDb);
+const mockExtendSessionDb = jest.mocked(extendSessionDb);
+const mockGetUserSessionsDb = jest.mocked(getUserSessionsDb);
+const mockValidateSessionDb = jest.mocked(validateSessionDb);
+const mockGenerateSecureToken = jest.mocked(generateSecureToken);
+
+describe("session helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("createSession", () => {
+    it("creates a new session and persists it via the database", async () => {
+      const testToken = "test-token-abc";
+      const testSession = makeSession({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date("2026-05-31T12:00:00.000Z"),
+      });
+
+      mockGenerateSecureToken.mockReturnValue(testToken);
+      jest
+        .useFakeTimers()
+        .setSystemTime(new Date("2026-05-01T12:00:00.000Z").getTime()); // should return "2026-05-31T12:00:00.000Z"
+      mockCreateSessionDb.mockResolvedValue([testSession]);
+
+      const result = await createSession(TEST_USER_ID);
+
+      expect(mockGenerateSecureToken).toHaveBeenCalledTimes(1);
+      expect(mockCreateSessionDb).toHaveBeenCalledTimes(1);
+      expect(mockCreateSessionDb).toHaveBeenCalledWith({
+        userId: TEST_USER_ID,
+        token: testToken,
+        expiresAt: new Date("2026-05-31T12:00:00.000Z"),
+      });
+      expect(result).toEqual(testSession);
+    });
+  });
+});

--- a/core/features/auth/session.test.ts
+++ b/core/features/auth/session.test.ts
@@ -50,11 +50,6 @@ describe("session helpers", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
   const testToken = "test-token-abc";
-  const testSession = makeSession({
-    userId: TEST_USER_ID,
-    token: testToken,
-    expiresAt: new Date("2026-05-31T12:00:00.000Z"),
-  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -68,9 +63,13 @@ describe("session helpers", () => {
 
   describe("createSession", () => {
     mockGenerateSecureToken.mockReturnValue(testToken);
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date("2026-05-01T12:00:00.000Z").getTime()); // should return "2026-05-31T12:00:00.000Z"
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
+
+    const testSession = makeSession({
+      userId: TEST_USER_ID,
+      token: testToken,
+      expiresAt: new Date(), // "2026-05-01"
+    });
 
     it("creates a new session and persists it via the database", async () => {
       mockCreateSessionDb.mockResolvedValue([testSession]);
@@ -82,7 +81,7 @@ describe("session helpers", () => {
       expect(mockCreateSessionDb).toHaveBeenCalledWith({
         userId: TEST_USER_ID,
         token: testToken,
-        expiresAt: new Date("2026-05-31T12:00:00.000Z"),
+        expiresAt: new Date("2026-05-31"), // "2026-05-01" + 30 days
       });
       expect(result).toEqual(testSession);
     });
@@ -98,9 +97,29 @@ describe("session helpers", () => {
         error,
       );
     });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("insert failed");
+
+      mockCreateSessionDb.mockRejectedValueOnce(dbError);
+
+      const error = await createSession(TEST_USER_ID).catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to create session");
+      expect(error.cause).toBeDefined();
+    });
   });
 
   describe("validateSession", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-01").getTime());
+
+    const testSession = makeSession({
+      userId: TEST_USER_ID,
+      token: testToken,
+      expiresAt: new Date(), // "2026-05-01"
+    });
+
     it("returns session object if session is valid", async () => {
       mockValidateSessionDb.mockResolvedValue(testSession);
 
@@ -130,5 +149,19 @@ describe("session helpers", () => {
         error,
       );
     });
+
+    it("throws DatabaseError with the defined message", async () => {
+      const dbError = new Error("find failed");
+
+      mockValidateSessionDb.mockRejectedValueOnce(dbError);
+
+      const error = await validateSession(testToken).catch((err) => err);
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toBe("Failed to validate session");
+      expect(error.cause).toBeDefined();
+    });
+  });
+
   });
 });


### PR DESCRIPTION
## Summary

- Add co-located Jest coverage for all exported helpers in `core/features/auth/session.ts`.
- Mock auth DB and token generation at module boundaries — no real database or crypto in tests.
- Normalize `validateSessionDb` to return `null` instead of `undefined` when no session is found, so it matches `validateSession`’s `Session | null` contract.

## What's covered

- **`createSession`** — token generation, 30-day `expiresAt`, DB persistence, `DatabaseError` on failure
- **`validateSession`** — valid session, missing session (`null`), DB failure
- **`extendSessionIfNeeded`** — extend when within 7-day threshold, skip when not needed, invalid session, DB failure on extend
- **`deleteSession`** / **`deleteAllUserSessions`** / **`deleteExpiredSessions`** — success + `DatabaseError`
- **`getUserSessions`** — multiple sessions, empty array, `DatabaseError`

## Production change

- `validateSessionDb` now coalesces a missing row to `null` (`?? null`) so callers always get `Session | null`, not `undefined`.

## Out of scope (follow-up)

- `core/features/auth/cookies.ts` — planned separately

## Test plan

- [x] `npm.cmd test -- core/features/auth/session.test.ts`
- [x] `npm.cmd test`
- [x] `npx.cmd tsc --noEmit`
- [x] `npm.cmd run check:ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session validation query handling.

* **Tests**
  * Added comprehensive test coverage for session management functions, including session creation, validation, extension, and deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->