### PR TITLE
test(auth): cover session helpers and session cookies

### DIFF
--- a/core/features/auth/cookies.test.ts
+++ b/core/features/auth/cookies.test.ts
@@ -75,7 +75,7 @@ describe("cookie helpers", () => {
       expect(result).toBe("");
     });
 
-    it("returns null is no session token is present", async () => {
+    it("returns null if no session token is present", async () => {
       const store = mockCookieStore();
 
       const result = await getSessionToken();

--- a/core/features/auth/cookies.test.ts
+++ b/core/features/auth/cookies.test.ts
@@ -35,8 +35,8 @@ function mockCookieStore(rawValue?: string) {
 describe("cookie helpers", () => {
   const testToken = "test-token-abc";
 
-  afterEach(() => {
-    jest.resetAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe("setSessionCookie", () => {
@@ -58,15 +58,24 @@ describe("cookie helpers", () => {
 
   describe("getSessionToken", () => {
     it("returns session token if present", async () => {
-      const store = mockCookieStore("session_token");
+      const store = mockCookieStore(testToken);
 
       const result = await getSessionToken();
 
       expect(store.get).toHaveBeenCalledWith(SESSION_COOKIE_NAME);
-      expect(result).toBe("session_token");
+      expect(result).toBe(testToken);
     });
 
-    it("return null is no session token is present", async () => {
+    it("returns session token even if it is an empty string", async () => {
+      const store = mockCookieStore("");
+
+      const result = await getSessionToken();
+
+      expect(store.get).toHaveBeenCalledWith(SESSION_COOKIE_NAME);
+      expect(result).toBe("");
+    });
+
+    it("returns null is no session token is present", async () => {
       const store = mockCookieStore();
 
       const result = await getSessionToken();

--- a/core/features/auth/cookies.test.ts
+++ b/core/features/auth/cookies.test.ts
@@ -1,0 +1,88 @@
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+
+import {
+  SESSION_COOKIE_NAME,
+  COOKIE_OPTIONS,
+} from "@/core/features/auth/constants";
+import {
+  setSessionCookie,
+  getSessionToken,
+  deleteSessionCookie,
+} from "./cookies";
+
+const mockCookies = jest.mocked(cookies);
+
+function mockCookieStore(rawValue?: string) {
+  const store = {
+    get: jest.fn(() =>
+      rawValue === undefined ? undefined : { value: rawValue },
+    ),
+    set: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  mockCookies.mockResolvedValue(
+    store as unknown as Awaited<ReturnType<typeof cookies>>,
+  );
+
+  return store;
+}
+
+describe("cookie helpers", () => {
+  const testToken = "test-token-abc";
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("setSessionCookie", () => {
+    it("sets session cookie with the provided expiresAt date", async () => {
+      const store = mockCookieStore();
+
+      await setSessionCookie(testToken, new Date("2026-01-01"));
+
+      expect(store.set).toHaveBeenCalledWith(
+        SESSION_COOKIE_NAME,
+        testToken,
+        expect.objectContaining({
+          ...COOKIE_OPTIONS,
+          expires: new Date("2026-01-01"),
+        }),
+      );
+    });
+  });
+
+  describe("getSessionToken", () => {
+    it("returns session token if present", async () => {
+      const store = mockCookieStore("session_token");
+
+      const result = await getSessionToken();
+
+      expect(store.get).toHaveBeenCalledWith(SESSION_COOKIE_NAME);
+      expect(result).toBe("session_token");
+    });
+
+    it("return null is no session token is present", async () => {
+      const store = mockCookieStore();
+
+      const result = await getSessionToken();
+
+      expect(store.get).toHaveBeenCalledWith(SESSION_COOKIE_NAME);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteSessionCookie", () => {
+    it("deletes session token", async () => {
+      const store = mockCookieStore();
+
+      await deleteSessionCookie();
+
+      expect(store.delete).toHaveBeenCalledWith(SESSION_COOKIE_NAME);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add co-located Jest coverage for `core/features/auth/cookies.ts`.
- Mock `next/headers` `cookies()` at the module boundary so tests never touch a real cookie store.
- Follow the same local `mockCookieStore` pattern used in OAuth cookie helper tests.

## What's covered

- **`setSessionCookie`** — writes `SESSION_COOKIE_NAME` with the token, shared `COOKIE_OPTIONS`, and the provided `expiresAt` date
- **`getSessionToken`** — returns the stored token when present, preserves empty string values, returns `null` when the cookie is missing
- **`deleteSessionCookie`** — deletes the session cookie by name

## Context

- Completes the auth session layer started with `session.test.ts` (already on `main`).
- No production code changes in this PR.

## Test plan

- [x] `npm.cmd test -- core/features/auth/cookies.test.ts`
- [x] `npm.cmd test`
- [x] `npx.cmd tsc --noEmit`
- [x] `npm.cmd run check:ci`

## Notes

- 5 tests across 3 exported helpers.
- Branch name `test/auth-session-cookies` reflects the broader auth-session work; this PR is the cookie slice only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for session cookie operations, verifying proper handling of authentication tokens during creation, retrieval, and deletion to ensure authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->