### PR TITLE
test(auth): cover token generation and hashing helpers

### DIFF
--- a/core/features/auth/tokens.test.ts
+++ b/core/features/auth/tokens.test.ts
@@ -1,10 +1,17 @@
 const mockToString = jest.fn();
+const mockRandomBytes = jest
+  .fn()
+  .mockImplementation(() => ({ toString: mockToString }));
 const mockDigest = jest.fn();
+const mockUpdate = jest.fn().mockImplementation(() => ({ digest: mockDigest }));
+const mockCreateHash = jest
+  .fn()
+  .mockImplementation(() => ({ update: mockUpdate }));
 
 jest.mock("crypto", () => ({
-  randomBytes: () => ({ toString: mockToString }),
+  randomBytes: (...args: unknown[]) => mockRandomBytes(...args),
   randomUUID: jest.fn(),
-  createHash: () => ({ update: () => ({ digest: mockDigest }) }),
+  createHash: (...args: unknown[]) => mockCreateHash(...args),
 }));
 
 import crypto from "crypto";
@@ -19,23 +26,25 @@ describe("token helpers", () => {
   });
 
   describe("generateSecureToken", () => {
-    it("generates a token with 32 characters length by default", () => {
+    it("generates a token with 32 bytes by default", () => {
+      const returnValue = "x".repeat(64); // 32 bytes = 64 characters
+
+      mockToString.mockReturnValue(returnValue);
+
+      const result = generateSecureToken();
+
+      expect(mockRandomBytes).toHaveBeenCalledWith(32);
+      expect(result).toBe(returnValue);
+    });
+
+    it("generates a token with the specified number of bytes", () => {
       const returnValue = "x".repeat(32);
 
       mockToString.mockReturnValue(returnValue);
 
-      const result = generateSecureToken();
+      const result = generateSecureToken(16);
 
-      expect(result).toBe(returnValue);
-    });
-
-    it("it generates a token with the provided length", () => {
-      const returnValue = "x".repeat(77);
-
-      mockToString.mockReturnValue(returnValue);
-
-      const result = generateSecureToken();
-
+      expect(mockRandomBytes).toHaveBeenCalledWith(16);
       expect(mockToString).toHaveBeenCalledTimes(1);
       expect(result).toBe(returnValue);
     });
@@ -58,7 +67,9 @@ describe("token helpers", () => {
 
       const result = hashToken("some_token");
 
-      expect(mockDigest).toHaveBeenCalledTimes(1);
+      expect(mockCreateHash).toHaveBeenCalledWith("sha256");
+      expect(mockUpdate).toHaveBeenCalledWith("some_token");
+      expect(mockDigest).toHaveBeenCalledWith("hex");
       expect(result).toBe("abc");
     });
   });

--- a/core/features/auth/tokens.test.ts
+++ b/core/features/auth/tokens.test.ts
@@ -34,6 +34,7 @@ describe("token helpers", () => {
       const result = generateSecureToken();
 
       expect(mockRandomBytes).toHaveBeenCalledWith(32);
+      expect(mockToString).toHaveBeenCalledWith("hex");
       expect(result).toBe(returnValue);
     });
 
@@ -45,7 +46,7 @@ describe("token helpers", () => {
       const result = generateSecureToken(16);
 
       expect(mockRandomBytes).toHaveBeenCalledWith(16);
-      expect(mockToString).toHaveBeenCalledTimes(1);
+      expect(mockToString).toHaveBeenCalledWith("hex");
       expect(result).toBe(returnValue);
     });
   });

--- a/core/features/auth/tokens.test.ts
+++ b/core/features/auth/tokens.test.ts
@@ -1,0 +1,65 @@
+const mockToString = jest.fn();
+const mockDigest = jest.fn();
+
+jest.mock("crypto", () => ({
+  randomBytes: () => ({ toString: mockToString }),
+  randomUUID: jest.fn(),
+  createHash: () => ({ update: () => ({ digest: mockDigest }) }),
+}));
+
+import crypto from "crypto";
+
+import { generateSecureToken, generateUserId, hashToken } from "./tokens";
+
+const mockCrypto = jest.mocked(crypto);
+
+describe("token helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("generateSecureToken", () => {
+    it("generates a token with 32 characters length by default", () => {
+      const returnValue = "x".repeat(32);
+
+      mockToString.mockReturnValue(returnValue);
+
+      const result = generateSecureToken();
+
+      expect(result).toBe(returnValue);
+    });
+
+    it("it generates a token with the provided length", () => {
+      const returnValue = "x".repeat(77);
+
+      mockToString.mockReturnValue(returnValue);
+
+      const result = generateSecureToken();
+
+      expect(mockToString).toHaveBeenCalledTimes(1);
+      expect(result).toBe(returnValue);
+    });
+  });
+
+  describe("generateUserId", () => {
+    it("returns a generated id", () => {
+      mockCrypto.randomUUID.mockReturnValueOnce("abc-123-abc-123-abc");
+
+      const result = generateUserId();
+
+      expect(mockCrypto.randomUUID).toHaveBeenCalledTimes(1);
+      expect(result).toBe("abc-123-abc-123-abc");
+    });
+  });
+
+  describe("hashToken", () => {
+    it("returns a hashed token", () => {
+      mockDigest.mockReturnValueOnce("abc");
+
+      const result = hashToken("some_token");
+
+      expect(mockDigest).toHaveBeenCalledTimes(1);
+      expect(result).toBe("abc");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add co-located Jest coverage for `core/features/auth/tokens.ts`.
- Mock `crypto` at the module boundary so tests never perform real random generation or hashing.
- Follow the same helper-test patterns used in `session.test.ts` and `cookies.test.ts`.

## What's covered

- **`generateSecureToken`** — default 32-byte length, custom byte length, `randomBytes` + hex encoding via `toString("hex")`, and return value pass-through
- **`generateUserId`** — delegates to `crypto.randomUUID()` and returns the generated id
- **`hashToken`** — SHA-256 hash pipeline (`createHash("sha256")` → `update(token)` → `digest("hex")`) and return value pass-through

## Context

- Completes the auth helper learning track started with `session.test.ts` and `cookies.test.ts`.
- No production code changes in this PR.

## Test plan

- [x] `npm.cmd test -- core/features/auth/tokens.test.ts`
- [x] `npm.cmd test`
- [x] `npx.cmd tsc --noEmit`
- [x] `npm.cmd run check:ci`

## Notes

- 4 tests across 3 exported helpers.
- Synthetic fixture values only; no real tokens or customer data in assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for authentication token operations, including secure token generation with configurable parameters, unique user identifier creation, and cryptographic token hashing. Test coverage validates the reliability and correctness of token-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->