### PR TITLE
test(ai): cover interview feedback generation

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,6 +10,18 @@ Date: 2026-06-16
 
 Latest full verification:
 
+- Focused AI interview feedback Jest passed: 1 test suite, 6 tests, 0
+  snapshots.
+- Focused AI interview feedback coverage reported 100% statements, branches,
+  functions, and lines for `core/services/ai/interviews.ts`.
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd test -- core/services/ai/interviews.test.ts` passed: 1 test suite,
+  6 tests, 0 snapshots.
+- `npm.cmd test` passed: 87 test suites, 717 tests, 0 snapshots.
+- `npm.cmd run test:coverage` passed: 87 test suites, 717 tests, 0 snapshots.
+- `npm.cmd run check:ci` passed: 297 files checked.
+- `npm test` was attempted but remains blocked by the unsigned `npm.ps1`
+  PowerShell execution-policy restriction.
 - Focused Form UI primitive Jest passed: 1 test suite, 10 tests, 0 snapshots.
 - Focused Form coverage reported 100% statements, branches, functions, and
   lines for `core/components/ui/form.tsx`.
@@ -39,9 +51,9 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 98.2% |
+| Statements | 98.21% |
 | Branches | 99.53% |
-| Functions | 95.53% |
+| Functions | 95.56% |
 | Lines | 99.43% |
 
 Recent file-specific result:
@@ -59,11 +71,22 @@ Recent file-specific result:
 | `core/components/ui/select.tsx` | 100% | 100% | 100% | 100% |
 | `core/components/ui` aggregate | 100% | 100% | 100% | 100% |
 | `core/features/billing/stripe.ts` | 97.72% | 91.17% | 100% | 97.43% |
+| `core/services/ai/interviews.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/api.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/condenseChatMessages.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
+- Added focused tests:
+  - `core/services/ai/interviews.test.ts`
+- Covered Hume chat-event formatting into transcript JSON, system prompt
+  dynamic inserts, Gemini model and stop condition wiring, empty transcripts,
+  interview-event filtering, user-only emotion features, and Hume/AI error
+  propagation.
+- `core/services/ai/interviews.ts` reached 100% statements, branches,
+  functions, and lines.
+- Made no production code changes and did not touch auth session, cookie, or
+  token work.
 - Added focused tests:
   - `core/components/ui/form.test.tsx`
 - Covered FormMessage empty-string and undefined validation-error messages,
@@ -211,6 +234,7 @@ Recommended next slice:
 | 2026-06-15 | Upgrade return revalidation | Covered server revalidation and the Stripe-return client refresh flow at 100%. |
 | 2026-06-16 | Select UI primitive | `core/components/ui/select.tsx` reached 100% coverage for wrapper composition, sizing, content positioning, option roles, and selection flow. |
 | 2026-06-16 | Form UI primitive | `core/components/ui/form.tsx` and the `core/components/ui` aggregate reached 100% coverage for message, label, item, control, and hook guard behavior. |
+| 2026-06-16 | AI interview feedback service | `core/services/ai/interviews.ts` reached 100% coverage for Hume transcript formatting, AI SDK call wiring, pass-through text, and dependency error propagation. |
 
 ## Archive
 

--- a/core/services/ai/interviews.test.ts
+++ b/core/services/ai/interviews.test.ts
@@ -1,0 +1,249 @@
+const mockFetchChatMessages = jest.fn();
+const mockGenerateText = jest.fn();
+const mockGoogle = jest.fn((model: string) => ({ provider: "google", model }));
+const mockStepCountIs = jest.fn((count: number) => ({
+  type: "step-count",
+  count,
+}));
+
+jest.mock("@/core/services/hume/lib/api", () => ({
+  fetchChatMessages: (...args: unknown[]) => mockFetchChatMessages(...args),
+}));
+
+jest.mock("ai", () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  stepCountIs: (count: number) => mockStepCountIs(count),
+}));
+
+jest.mock("@/core/services/ai/models/google", () => ({
+  google: (model: string) => mockGoogle(model),
+}));
+
+import type { Hume } from "hume";
+
+import { makeJobInfo } from "@core/test-utils/factories";
+
+import { generateAiInterviewFeedback } from "./interviews";
+
+type ReturnChatEvent = Hume.empathicVoice.ReturnChatEvent;
+
+type HumeEventOverrides = Partial<
+  Omit<ReturnChatEvent, "emotionFeatures" | "messageText">
+> & {
+  emotionFeatures?: unknown;
+  messageText?: string | null;
+};
+
+function makeHumeEvent(overrides: HumeEventOverrides = {}): ReturnChatEvent {
+  const event = {
+    chatId: "chat-123",
+    id: "event-1",
+    messageText: "Hello",
+    role: "USER",
+    timestamp: 1,
+    type: "USER_MESSAGE",
+    ...overrides,
+  };
+
+  // The mocked service boundary can return runtime payloads that are narrower
+  // or richer than the SDK type, including object emotion features.
+  return event as unknown as ReturnChatEvent;
+}
+
+function getGenerateTextOptions() {
+  return mockGenerateText.mock.calls[0][0];
+}
+
+describe("generateAiInterviewFeedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateText.mockResolvedValue({
+      text: "## Overall rating: 8/10\n\nGood job.",
+    });
+    mockFetchChatMessages.mockResolvedValue([]);
+  });
+
+  describe("when Hume returns interview messages", () => {
+    it("formats the transcript and returns the AI feedback text", async () => {
+      const jobInfo = makeJobInfo({
+        title: "Frontend Engineer",
+        description: "Build polished React interview tools.",
+        experienceLevel: "senior",
+      });
+      const userName = "Alex Candidate";
+      mockFetchChatMessages.mockResolvedValue([
+        makeHumeEvent({
+          id: "event-1",
+          messageText: "I focus on accessible component systems.",
+          role: "USER",
+          emotionFeatures: { joy: 0.8 },
+          type: "USER_MESSAGE",
+        }),
+        makeHumeEvent({
+          id: "event-2",
+          messageText: "Tell me about a difficult frontend tradeoff.",
+          role: "AGENT",
+          type: "AGENT_MESSAGE",
+        }),
+      ]);
+
+      const result = await generateAiInterviewFeedback({
+        humeChatId: "chat-123",
+        jobInfo,
+        userName,
+      });
+
+      expect(result).toBe("## Overall rating: 8/10\n\nGood job.");
+      expect(mockFetchChatMessages).toHaveBeenCalledWith("chat-123");
+      expect(mockGenerateText).toHaveBeenCalledTimes(1);
+
+      const { prompt, system, stopWhen, model } = getGenerateTextOptions();
+      expect(JSON.parse(prompt)).toEqual([
+        {
+          speaker: "interviewee",
+          text: "I focus on accessible component systems.",
+          emotionFeatures: { joy: 0.8 },
+        },
+        {
+          speaker: "interviewer",
+          text: "Tell me about a difficult frontend tradeoff.",
+          emotionFeatures: undefined,
+        },
+      ]);
+      expect(system).toContain(userName);
+      expect(system).toContain(jobInfo.title);
+      expect(system).toContain(jobInfo.description);
+      expect(system).toContain(jobInfo.experienceLevel);
+      expect(model).toEqual({
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+      expect(stopWhen).toEqual({ type: "step-count", count: 10 });
+    });
+
+    it("skips non-interview Hume events and empty content", async () => {
+      const jobInfo = makeJobInfo();
+      mockFetchChatMessages.mockResolvedValue([
+        makeHumeEvent({
+          id: "event-1",
+          messageText: "System setup",
+          role: "SYSTEM",
+          type: "SYSTEM_PROMPT",
+        }),
+        makeHumeEvent({
+          id: "event-2",
+          messageText: null,
+          role: "USER",
+          type: "USER_MESSAGE",
+        }),
+        makeHumeEvent({
+          id: "event-3",
+          messageText: "My strongest project involved Next.js caching.",
+          role: "USER",
+          type: "USER_MESSAGE",
+        }),
+      ]);
+
+      await generateAiInterviewFeedback({
+        humeChatId: "chat-123",
+        jobInfo,
+        userName: "Alex Candidate",
+      });
+
+      const { prompt } = getGenerateTextOptions();
+      expect(JSON.parse(prompt)).toEqual([
+        {
+          speaker: "interviewee",
+          text: "My strongest project involved Next.js caching.",
+          emotionFeatures: undefined,
+        },
+      ]);
+    });
+
+    it("includes emotion features only for user-role messages", async () => {
+      const jobInfo = makeJobInfo();
+      mockFetchChatMessages.mockResolvedValue([
+        makeHumeEvent({
+          id: "event-1",
+          messageText: "I am relaying a tool response.",
+          role: "AGENT",
+          emotionFeatures: { confusion: 0.7 },
+          type: "USER_MESSAGE",
+        }),
+        makeHumeEvent({
+          id: "event-2",
+          messageText: "I stayed calm under production pressure.",
+          role: "USER",
+          emotionFeatures: { calmness: 0.9 },
+          type: "USER_MESSAGE",
+        }),
+      ]);
+
+      await generateAiInterviewFeedback({
+        humeChatId: "chat-123",
+        jobInfo,
+        userName: "Alex Candidate",
+      });
+
+      const { prompt } = getGenerateTextOptions();
+      expect(JSON.parse(prompt)).toEqual([
+        {
+          speaker: "interviewee",
+          text: "I am relaying a tool response.",
+          emotionFeatures: undefined,
+        },
+        {
+          speaker: "interviewee",
+          text: "I stayed calm under production pressure.",
+          emotionFeatures: { calmness: 0.9 },
+        },
+      ]);
+    });
+  });
+
+  describe("when the transcript is empty", () => {
+    it("still calls the AI SDK with an empty transcript", async () => {
+      const jobInfo = makeJobInfo();
+
+      const result = await generateAiInterviewFeedback({
+        humeChatId: "chat-123",
+        jobInfo,
+        userName: "Alex Candidate",
+      });
+
+      const { prompt } = getGenerateTextOptions();
+      expect(result).toBe("## Overall rating: 8/10\n\nGood job.");
+      expect(prompt).toBe("[]");
+    });
+  });
+
+  describe("when dependencies fail", () => {
+    it("propagates Hume fetch failures without calling the AI SDK", async () => {
+      const error = new Error("Hume unavailable");
+      mockFetchChatMessages.mockRejectedValue(error);
+
+      await expect(
+        generateAiInterviewFeedback({
+          humeChatId: "chat-123",
+          jobInfo: makeJobInfo(),
+          userName: "Alex Candidate",
+        }),
+      ).rejects.toBe(error);
+
+      expect(mockGenerateText).not.toHaveBeenCalled();
+    });
+
+    it("propagates AI SDK failures", async () => {
+      const error = new Error("Gemini unavailable");
+      mockGenerateText.mockRejectedValue(error);
+
+      await expect(
+        generateAiInterviewFeedback({
+          humeChatId: "chat-123",
+          jobInfo: makeJobInfo(),
+          userName: "Alex Candidate",
+        }),
+      ).rejects.toBe(error);
+    });
+  });
+});

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -2272,6 +2272,54 @@ Notes:
   runs before deriving field state.
 - Did not touch auth session, cookie, or token work.
 
+### AI Interview Feedback Service Coverage - 2026-06-16
+
+Files added/updated:
+
+- `core/services/ai/interviews.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- core/services/ai/interviews.test.ts`
+- `npx.cmd jest core/services/ai/interviews.test.ts --coverage --collectCoverageFrom=core/services/ai/interviews.ts --runInBand`
+- `npx.cmd biome format --write core/services/ai/interviews.test.ts`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd test -- core/services/ai/interviews.test.ts`
+- `npm.cmd test`
+- `npm.cmd run test:coverage`
+- `npm.cmd run check:ci`
+- `npm test`
+
+Result:
+
+- Focused AI interview feedback Jest passed: 1 test suite, 6 tests, 0
+  snapshots.
+- Focused AI interview feedback coverage reported 100% statements, branches,
+  functions, and lines for `core/services/ai/interviews.ts`.
+- TypeScript passed.
+- Full Jest passed: 87 test suites, 717 tests, 0 snapshots.
+- Full coverage passed: 87 test suites, 717 tests, 0 snapshots.
+- Updated coverage summary: 98.21% statements, 99.53% branches, 95.56%
+  functions, and 99.43% lines.
+- Biome CI passed: 297 files checked.
+- Raw `npm test` remains blocked by the unsigned `C:\nvm4w\nodejs\npm.ps1`
+  PowerShell execution-policy restriction.
+
+Notes:
+
+- Mocked Hume chat retrieval, the AI SDK, and the Google model factory at
+  module boundaries so no real Hume, Gemini, or network calls are made.
+- Covered transcript JSON formatting for user and agent messages, skipping
+  non-interview and empty-content events, user-role-only emotion features,
+  empty transcripts, returned text pass-through, dynamic system prompt inserts,
+  Gemini model selection, stop condition wiring, and Hume/AI error propagation.
+- Used `makeJobInfo` fixtures and the fixed synthetic user name
+  `Alex Candidate`.
+- Made no production code changes and did not touch auth session, cookie, or
+  token work.
+
 ## Coverage Priorities
 
 1. Review Drizzle schema coverage separately.


### PR DESCRIPTION
## Summary

- Added direct Jest unit coverage for `generateAiInterviewFeedback`
- Mocked Hume chat retrieval, AI SDK `generateText`, and the Google model factory at module boundaries
- Covered transcript formatting, dynamic prompt inputs, Gemini model/stop condition wiring, empty transcripts, and dependency error propagation
- Updated the coverage plan and history docs for the completed slice

## Verification

- `npx.cmd tsc --noEmit`
- `npm.cmd test -- core/services/ai/interviews.test.ts`
- `npm.cmd test`
- `npm.cmd run test:coverage`
- `npm.cmd run check:ci`

## Notes / Risks

- No production code changes
- No real Hume, Gemini, or network calls in tests