### PR TITLE
test(ai): add questions service coverage

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -6,10 +6,24 @@ for practical handoff use.
 
 ## Current Status
 
-Date: 2026-06-16
+Date: 2026-06-17
 
 Latest full verification:
 
+- Focused AI questions service Jest passed: 1 test suite, 4 tests, 0
+  snapshots.
+- Focused AI questions service coverage reported 100% statements, branches,
+  functions, and lines for `core/services/ai/questions.ts`.
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd run check -- core/services/ai/questions.test.ts` passed: 299 files
+  checked.
+- `npm.cmd run check:ci` passed: 299 files checked.
+- `npm.cmd test -- core/services/ai/questions.test.ts` passed: 1 test suite,
+  4 tests, 0 snapshots.
+- `npm.cmd test` passed: 89 test suites, 725 tests, 0 snapshots.
+- `npm.cmd run test:coverage` passed: 89 test suites, 725 tests, 0 snapshots.
+- `npm test` was attempted but remains blocked by the unsigned `npm.ps1`
+  PowerShell execution-policy restriction.
 - Focused AI interview feedback Jest passed: 1 test suite, 6 tests, 0
   snapshots.
 - Focused AI interview feedback coverage reported 100% statements, branches,
@@ -51,10 +65,10 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 98.21% |
+| Statements | 98.22% |
 | Branches | 99.53% |
-| Functions | 95.56% |
-| Lines | 99.43% |
+| Functions | 95.65% |
+| Lines | 99.44% |
 
 Recent file-specific result:
 
@@ -72,11 +86,22 @@ Recent file-specific result:
 | `core/components/ui` aggregate | 100% | 100% | 100% | 100% |
 | `core/features/billing/stripe.ts` | 97.72% | 91.17% | 100% | 97.43% |
 | `core/services/ai/interviews.ts` | 100% | 100% | 100% | 100% |
+| `core/services/ai/questions.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/api.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/condenseChatMessages.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
+- Added focused tests:
+  - `core/services/ai/questions.test.ts`
+- Covered question-generation message history, title-present and title-empty
+  system prompt branches, Gemini model and stop condition wiring,
+  stream-result pass-through, `onFinish` text forwarding, and feedback prompt
+  wiring.
+- `core/services/ai/questions.ts` reached 100% statements, branches, functions,
+  and lines.
+- Made no production code changes and did not touch route tests, auth session,
+  cookie, token, or interview service files.
 - Added focused tests:
   - `core/services/ai/interviews.test.ts`
 - Covered Hume chat-event formatting into transcript JSON, system prompt
@@ -235,6 +260,7 @@ Recommended next slice:
 | 2026-06-16 | Select UI primitive | `core/components/ui/select.tsx` reached 100% coverage for wrapper composition, sizing, content positioning, option roles, and selection flow. |
 | 2026-06-16 | Form UI primitive | `core/components/ui/form.tsx` and the `core/components/ui` aggregate reached 100% coverage for message, label, item, control, and hook guard behavior. |
 | 2026-06-16 | AI interview feedback service | `core/services/ai/interviews.ts` reached 100% coverage for Hume transcript formatting, AI SDK call wiring, pass-through text, and dependency error propagation. |
+| 2026-06-17 | AI questions service | `core/services/ai/questions.ts` reached 100% coverage for AI SDK stream wiring, prompt inserts, history mapping, and finish callbacks. |
 
 ## Archive
 

--- a/core/services/ai/questions.test.ts
+++ b/core/services/ai/questions.test.ts
@@ -1,0 +1,148 @@
+const mockStreamText = jest.fn();
+const mockGoogle = jest.fn((model: string) => ({ provider: "google", model }));
+const mockStepCountIs = jest.fn((count: number) => ({
+  type: "step-count",
+  count,
+}));
+
+jest.mock("ai", () => ({
+  streamText: (...args: unknown[]) => mockStreamText(...args),
+  stepCountIs: (count: number) => mockStepCountIs(count),
+}));
+
+jest.mock("@/core/services/ai/models/google", () => ({
+  google: (model: string) => mockGoogle(model),
+}));
+
+import { makeJobInfo, makeQuestion } from "@core/test-utils/factories";
+
+import { generateAiQuestion, generateAiQuestionFeedback } from "./questions";
+
+function getStreamTextOptions() {
+  return mockStreamText.mock.calls[0][0];
+}
+
+describe("generateAiQuestion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamText.mockReturnValue({ kind: "question-stream" });
+  });
+
+  describe("when previous questions exist", () => {
+    it("builds message history from previous questions and requests a new question", () => {
+      const jobInfo = makeJobInfo({
+        title: "Frontend Engineer",
+        description: "Build polished React interview tools.",
+        experienceLevel: "senior",
+      });
+      const previousQuestions = [
+        makeQuestion({
+          text: "How do React keys affect reconciliation?",
+          difficulty: "easy",
+        }),
+        makeQuestion({
+          text: "Design a resilient Suspense data flow.",
+          difficulty: "medium",
+        }),
+      ];
+      const onFinish = jest.fn();
+
+      const stream = generateAiQuestion({
+        jobInfo,
+        previousQuestions,
+        difficulty: "hard",
+        onFinish,
+      });
+
+      expect(stream).toEqual({ kind: "question-stream" });
+      expect(mockStreamText).toHaveBeenCalledTimes(1);
+
+      const {
+        messages,
+        system,
+        model,
+        stopWhen,
+        onFinish: sdkOnFinish,
+      } = getStreamTextOptions();
+      expect(messages).toEqual([
+        { role: "user", content: previousQuestions[0].difficulty },
+        { role: "assistant", content: previousQuestions[0].text },
+        { role: "user", content: previousQuestions[1].difficulty },
+        { role: "assistant", content: previousQuestions[1].text },
+        { role: "user", content: "hard" },
+      ]);
+      expect(system).toContain(jobInfo.description);
+      expect(system).toContain(jobInfo.experienceLevel);
+      expect(system).toContain(jobInfo.title);
+      expect(model).toEqual({ provider: "google", model: "gemini-2.5-flash" });
+      expect(stopWhen).toEqual({ type: "step-count", count: 10 });
+      expect(sdkOnFinish).toEqual(expect.any(Function));
+    });
+  });
+
+  describe("when job title is empty", () => {
+    it("omits job title from the system prompt", () => {
+      const jobInfo = makeJobInfo({
+        title: "",
+        description: "Build synthetic interview practice flows.",
+        experienceLevel: "junior",
+      });
+
+      generateAiQuestion({
+        jobInfo,
+        previousQuestions: [],
+        difficulty: "easy",
+        onFinish: jest.fn(),
+      });
+
+      const { messages, system } = getStreamTextOptions();
+      expect(system).not.toContain("Job Title:");
+      expect(messages).toEqual([{ role: "user", content: "easy" }]);
+    });
+  });
+
+  describe("when streaming finishes", () => {
+    it("invokes the caller onFinish callback with streamed text", () => {
+      const jobInfo = makeJobInfo();
+      const onFinish = jest.fn();
+      mockStreamText.mockImplementation(({ onFinish: sdkOnFinish }) => {
+        sdkOnFinish?.({ text: "## What is React?" });
+
+        return { kind: "question-stream" };
+      });
+
+      generateAiQuestion({
+        jobInfo,
+        previousQuestions: [],
+        difficulty: "medium",
+        onFinish,
+      });
+
+      expect(onFinish).toHaveBeenCalledWith("## What is React?");
+    });
+  });
+});
+
+describe("generateAiQuestionFeedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamText.mockReturnValue({ kind: "question-stream" });
+  });
+
+  describe("when feedback is requested", () => {
+    it("sends the answer as prompt and embeds the question in the system prompt", () => {
+      const question = "Explain useEffect cleanup.";
+      const answer = "Cleanup runs before re-render and on unmount.";
+
+      const stream = generateAiQuestionFeedback({ question, answer });
+
+      expect(stream).toEqual({ kind: "question-stream" });
+
+      const { prompt, system, model, stopWhen } = getStreamTextOptions();
+      expect(prompt).toBe(answer);
+      expect(system).toContain(question);
+      expect(model).toEqual({ provider: "google", model: "gemini-2.5-flash" });
+      expect(stopWhen).toEqual({ type: "step-count", count: 10 });
+    });
+  });
+});

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -2320,6 +2320,55 @@ Notes:
 - Made no production code changes and did not touch auth session, cookie, or
   token work.
 
+### AI Questions Service Coverage - 2026-06-17
+
+Files added/updated:
+
+- `core/services/ai/questions.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- core/services/ai/questions.test.ts`
+- `npx.cmd jest core/services/ai/questions.test.ts --coverage --collectCoverageFrom=core/services/ai/questions.ts --runInBand`
+- `npm.cmd run check -- core/services/ai/questions.test.ts`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd test`
+- `npm.cmd run check:ci`
+- `npm test`
+- `npm.cmd run test:coverage`
+
+Result:
+
+- Focused AI questions service Jest passed: 1 test suite, 4 tests, 0
+  snapshots.
+- Focused AI questions service coverage reported 100% statements, branches,
+  functions, and lines for `core/services/ai/questions.ts`.
+- Scoped Biome passed: 299 files checked.
+- TypeScript passed.
+- Biome CI passed: 299 files checked.
+- Full Jest passed: 89 test suites, 725 tests, 0 snapshots.
+- Full coverage passed: 89 test suites, 725 tests, 0 snapshots.
+- Updated coverage summary: 98.22% statements, 99.53% branches, 95.65%
+  functions, and 99.44% lines.
+- Raw `npm test` remains blocked by the unsigned `C:\nvm4w\nodejs\npm.ps1`
+  PowerShell execution-policy restriction.
+
+Notes:
+
+- Mocked the AI SDK `streamText`, AI SDK `stepCountIs`, and the Google model
+  factory at module boundaries so no real Gemini or network calls are made.
+- Covered previous-question history mapping into alternating user/assistant
+  messages, title-present and title-empty system prompt branches, new
+  difficulty message appending, Gemini model selection, stop condition wiring,
+  returned stream pass-through, `onFinish` streamed text forwarding, feedback
+  answer prompt wiring, and original-question system prompt embedding.
+- Used `makeJobInfo` and `makeQuestion` fixtures with synthetic question text
+  only.
+- Made no production code changes and did not touch route tests, auth session,
+  cookie, token, or interview service files.
+
 ## Coverage Priorities
 
 1. Review Drizzle schema coverage separately.


### PR DESCRIPTION
## Summary

- Added co-located Jest coverage for `core/services/ai/questions.ts`
- Covered AI SDK `streamText` wiring for question generation and feedback
- Verified message history mapping, dynamic system prompt inserts, model/stop condition setup, stream pass-through, and `onFinish` forwarding
- Updated coverage tracking docs with the slice results

## Verification

- `npm.cmd test -- core/services/ai/questions.test.ts`
- `npx.cmd jest core/services/ai/questions.test.ts --coverage --collectCoverageFrom=core/services/ai/questions.ts --runInBand`
- `npx.cmd tsc --noEmit`
- `npm.cmd run check -- core/services/ai/questions.test.ts`
- `npm.cmd run check:ci`
- `npm.cmd test`
- `npm.cmd run test:coverage`

## Notes

- `core/services/ai/questions.ts` reports 100% statements, branches, functions, and lines.
- No production code changes.