### PR TITLE
test(ai): cover resume analysis service

### DIFF
--- a/TEST_COVERAGE_PLAN.md
+++ b/TEST_COVERAGE_PLAN.md
@@ -10,6 +10,20 @@ Date: 2026-06-17
 
 Latest full verification:
 
+- Focused AI resume analysis service Jest passed: 1 test suite, 2 tests, 0
+  snapshots.
+- Focused AI resume analysis service coverage reported 100% statements,
+  branches, functions, and lines for `core/services/ai/resumes/ai.ts`.
+- `npx.cmd tsc --noEmit` passed.
+- `npm.cmd run check -- core/services/ai/resumes/ai.test.ts` passed: 300 files
+  checked.
+- `npm.cmd run check:ci` passed: 300 files checked.
+- `npm.cmd test -- core/services/ai/resumes/ai.test.ts` passed: 1 test suite,
+  2 tests, 0 snapshots.
+- `npm.cmd test` passed: 90 test suites, 727 tests, 0 snapshots.
+- `npm.cmd run test:coverage` passed: 90 test suites, 727 tests, 0 snapshots.
+- `npm test` was attempted but remains blocked by the unsigned `npm.ps1`
+  PowerShell execution-policy restriction.
 - Focused AI questions service Jest passed: 1 test suite, 4 tests, 0
   snapshots.
 - Focused AI questions service coverage reported 100% statements, branches,
@@ -65,9 +79,9 @@ Latest coverage:
 
 | Metric | Coverage |
 | --- | ---: |
-| Statements | 98.22% |
+| Statements | 98.23% |
 | Branches | 99.53% |
-| Functions | 95.65% |
+| Functions | 95.66% |
 | Lines | 99.44% |
 
 Recent file-specific result:
@@ -87,11 +101,22 @@ Recent file-specific result:
 | `core/features/billing/stripe.ts` | 97.72% | 91.17% | 100% | 97.43% |
 | `core/services/ai/interviews.ts` | 100% | 100% | 100% | 100% |
 | `core/services/ai/questions.ts` | 100% | 100% | 100% | 100% |
+| `core/services/ai/resumes/ai.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/api.ts` | 100% | 100% | 100% | 100% |
 | `core/services/hume/lib/condenseChatMessages.ts` | 100% | 100% | 100% | 100% |
 
 Latest slice notes:
 
+- Added focused tests:
+  - `core/services/ai/resumes/ai.test.ts`
+- Covered resume file byte forwarding, uploaded media type forwarding, Gemini
+  model selection, real schema wiring, stream-result pass-through, dynamic job
+  description and experience-level prompt inserts, and title-present/title-empty
+  system prompt branches.
+- `core/services/ai/resumes/ai.ts` reached 100% statements, branches,
+  functions, and lines.
+- Made no production code changes and did not touch route tests, auth session,
+  cookie, token, interview service, or questions service files.
 - Added focused tests:
   - `core/services/ai/questions.test.ts`
 - Covered question-generation message history, title-present and title-empty
@@ -261,6 +286,7 @@ Recommended next slice:
 | 2026-06-16 | Form UI primitive | `core/components/ui/form.tsx` and the `core/components/ui` aggregate reached 100% coverage for message, label, item, control, and hook guard behavior. |
 | 2026-06-16 | AI interview feedback service | `core/services/ai/interviews.ts` reached 100% coverage for Hume transcript formatting, AI SDK call wiring, pass-through text, and dependency error propagation. |
 | 2026-06-17 | AI questions service | `core/services/ai/questions.ts` reached 100% coverage for AI SDK stream wiring, prompt inserts, history mapping, and finish callbacks. |
+| 2026-06-17 | AI resume analysis service | `core/services/ai/resumes/ai.ts` reached 100% coverage for AI SDK object-stream wiring, file forwarding, prompt inserts, and title branches. |
 
 ## Archive
 

--- a/core/services/ai/resumes/ai.test.ts
+++ b/core/services/ai/resumes/ai.test.ts
@@ -1,0 +1,109 @@
+const mockStreamObject = jest.fn();
+const mockGoogle = jest.fn((model: string) => ({ provider: "google", model }));
+
+jest.mock("ai", () => ({
+  streamObject: (...args: unknown[]) => mockStreamObject(...args),
+}));
+
+jest.mock("@/core/services/ai/models/google", () => ({
+  google: (model: string) => mockGoogle(model),
+}));
+
+import { makeJobInfo } from "@core/test-utils/factories";
+
+import { aiAnalyzeSchema } from "@/core/services/ai/resumes/schemas";
+
+import { analyzeResumeForJob } from "./ai";
+
+interface StreamObjectOptions {
+  model: unknown;
+  schema: unknown;
+  messages: unknown;
+  system: string;
+}
+
+function makeResumeFile(
+  content = "Synthetic resume content",
+  overrides: Partial<FilePropertyBag> = {},
+): File {
+  return new File([content], "resume.txt", {
+    type: "text/plain",
+    ...overrides,
+  });
+}
+
+function getStreamObjectOptions(): StreamObjectOptions {
+  const [options] = mockStreamObject.mock.calls[0] ?? [];
+
+  if (typeof options !== "object" || options === null) {
+    throw new Error("streamObject was not called with options");
+  }
+
+  return options as StreamObjectOptions;
+}
+
+describe("analyzeResumeForJob", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamObject.mockResolvedValue({ kind: "resume-analysis-stream" });
+  });
+
+  describe("when a job title is present", () => {
+    it("sends resume file bytes and job context to streamObject", async () => {
+      const resumeFile = makeResumeFile("Resume body for ATS review.", {
+        type: "application/pdf",
+      });
+      const expectedBuffer = await resumeFile.arrayBuffer();
+      const jobInfo = makeJobInfo({
+        title: "Frontend Engineer",
+        description: "Build polished React interview tools.",
+        experienceLevel: "senior",
+      });
+
+      const stream = await analyzeResumeForJob({ resumeFile, jobInfo });
+
+      expect(stream).toEqual({ kind: "resume-analysis-stream" });
+      expect(mockStreamObject).toHaveBeenCalledTimes(1);
+
+      const { model, schema, messages, system } = getStreamObjectOptions();
+      expect(model).toEqual({
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+      expect(schema).toBe(aiAnalyzeSchema);
+      expect(messages).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: expectedBuffer,
+              mediaType: "application/pdf",
+            },
+          ],
+        },
+      ]);
+      expect(system).toContain(jobInfo.description);
+      expect(system).toContain(jobInfo.experienceLevel);
+      expect(system).toContain(`Job Title: ${jobInfo.title}`);
+    });
+  });
+
+  describe("when the job title is empty", () => {
+    it("omits job title from the system prompt", async () => {
+      const jobInfo = makeJobInfo({
+        title: "",
+        description: "Support junior developers with interview prep.",
+        experienceLevel: "junior",
+      });
+
+      await analyzeResumeForJob({
+        resumeFile: makeResumeFile(),
+        jobInfo,
+      });
+
+      const { system } = getStreamObjectOptions();
+      expect(system).not.toContain("Job Title:");
+    });
+  });
+});

--- a/docs/test-coverage-history.md
+++ b/docs/test-coverage-history.md
@@ -2369,6 +2369,55 @@ Notes:
 - Made no production code changes and did not touch route tests, auth session,
   cookie, token, or interview service files.
 
+### AI Resume Analysis Service Coverage - 2026-06-17
+
+Files added/updated:
+
+- `core/services/ai/resumes/ai.test.ts`
+- `TEST_COVERAGE_PLAN.md`
+- `docs/test-coverage-history.md`
+
+Commands run:
+
+- `npm.cmd test -- core/services/ai/resumes/ai.test.ts`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd run check -- core/services/ai/resumes/ai.test.ts`
+- `npx.cmd jest core/services/ai/resumes/ai.test.ts --coverage --collectCoverageFrom=core/services/ai/resumes/ai.ts --runInBand`
+- `npm.cmd run check:ci`
+- `npm.cmd test`
+- `npm.cmd run test:coverage`
+- `npm test`
+
+Result:
+
+- Focused AI resume analysis service Jest passed: 1 test suite, 2 tests, 0
+  snapshots.
+- Focused AI resume analysis service coverage reported 100% statements,
+  branches, functions, and lines for `core/services/ai/resumes/ai.ts`.
+- TypeScript passed.
+- Scoped Biome passed: 300 files checked.
+- Biome CI passed: 300 files checked.
+- Full Jest passed: 90 test suites, 727 tests, 0 snapshots.
+- Full coverage passed: 90 test suites, 727 tests, 0 snapshots.
+- Updated coverage summary: 98.23% statements, 99.53% branches, 95.66%
+  functions, and 99.44% lines.
+- Raw `npm test` remains blocked by the unsigned `C:\nvm4w\nodejs\npm.ps1`
+  PowerShell execution-policy restriction.
+
+Notes:
+
+- Mocked the AI SDK `streamObject` and the Google model factory at module
+  boundaries so no real Gemini or network calls are made.
+- Imported the real resume analysis schema and verified it is passed through to
+  `streamObject`.
+- Covered resume file byte forwarding, uploaded media type forwarding, Gemini
+  model selection, returned stream pass-through, dynamic job description and
+  experience-level prompt inserts, and title-present/title-empty system prompt
+  branches.
+- Used `makeJobInfo` fixtures and synthetic resume file content only.
+- Made no production code changes and did not touch route tests, auth session,
+  cookie, token, interview service, or questions service files.
+
 ## Coverage Priorities
 
 1. Review Drizzle schema coverage separately.


### PR DESCRIPTION
## Summary

- Added direct Jest coverage for `analyzeResumeForJob`
- Verified resume file bytes, media type, schema, Gemini model, and `streamObject` wiring
- Covered title-present and title-empty system prompt branches
- Updated coverage tracking docs

## Verification

- `npx.cmd tsc --noEmit`
- `npm.cmd run check -- core/services/ai/resumes/ai.test.ts`
- `npm.cmd run check:ci`
- `npm.cmd test -- core/services/ai/resumes/ai.test.ts`
- `npx.cmd jest core/services/ai/resumes/ai.test.ts --coverage --collectCoverageFrom=core/services/ai/resumes/ai.ts --runInBand`
- `npm.cmd test`
- `npm.cmd run test:coverage`

## Notes

- `core/services/ai/resumes/ai.ts` now reports 100% statements, branches, functions, and lines.
- No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for AI resume analysis service with comprehensive validation.

* **Documentation**
  * Updated test coverage documentation with verification results and coverage history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->