### PR TITLE
docs(e2e): document Playwright test setup

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,37 @@
+# Copy this file to .env.test. The .env.test file is gitignored.
+# Use a dedicated test database only; never point E2E tests at dev or prod.
+# For local Docker Postgres, run `docker compose up -d`, set DB_HOST=localhost,
+# and omit DB_SSLMODE or leave it blank.
+# For Neon, use a separate branch/database and set DB_SSLMODE=require.
+# Optional E2E_DB_HOST: e2e/resetDatabase.ts refuses to truncate unless the
+# derived DATABASE_URL hostname matches E2E_DB_HOST or DB_HOST.
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=test_user
+DB_PASSWORD=test_password
+DB_NAME=offerpilot_test
+# DB_SSLMODE=require
+# E2E_DB_HOST=localhost
+
+ARCJET_KEY=test_arcjet_key
+HUME_API_KEY=test_hume_api_key
+HUME_SECRET_KEY=test_hume_secret_key
+GEMINI_API_KEY=test_gemini_api_key
+NEXT_PUBLIC_HUME_CONFIG_ID=test_hume_config_id
+
+CRON_SECRET=123456789012345
+OAUTH_REDIRECT_URL_BASE=http://localhost:3000/api/oauth/
+APP_URL=http://localhost:3000
+
+# Optional local/billing/OAuth credentials.
+STRIPE_SECRET_KEY=sk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_placeholder
+STRIPE_PRO_PRICE_ID=price_placeholder
+STRIPE_PRO_PRODUCT_ID=prod_placeholder
+DISCORD_CLIENT_ID=discord_client_id
+DISCORD_CLIENT_SECRET=discord_client_secret
+GOOGLE_CLIENT_ID=google_client_id
+GOOGLE_CLIENT_SECRET=google_client_secret
+GITHUB_CLIENT_ID=github_client_id
+GITHUB_CLIENT_SECRET=github_client_secret

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.test.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -229,12 +229,45 @@ npm test
 
 ### Continuous integration
 
-Every pull request and push to `main` runs [`.github/workflows/ci.yml`](.github/workflows/ci.yml):
+CI is split across two workflows:
 
-- Biome lint and format checks (`npm run check:ci`)
-- Jest tests (`npm test`)
+- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) - Biome lint and format checks (`npm run check:ci`) and Jest tests (`npm test`)
+- [`.github/workflows/playwright.yml`](.github/workflows/playwright.yml) - Playwright smoke tests (`npm run test:e2e`)
 
 After the workflow has run at least once on `main`, enable **Require status checks to pass before merging** in GitHub branch protection and select the **Lint and test** check.
+
+### End-to-end tests (Playwright)
+
+Playwright tests require a dedicated test database. Copy `.env.test.example` to `.env.test`, point it at that database, and apply the schema once against that same environment:
+
+```bash
+npx dotenv -e .env.test -- npm run db:push
+```
+
+For local Docker Postgres, run `docker compose up -d`, use `DB_HOST=localhost`, and omit `DB_SSLMODE`. For Neon, use a separate branch/database and set `DB_SSLMODE=require`.
+
+Run the E2E suite with:
+
+```bash
+npm run test:e2e
+npm run test:e2e:ui
+npm run test:e2e:headed
+```
+
+The smoke specs live in `e2e/smoke/` and cover the landing page plus auth/job creation flows. Shared setup helpers live in `e2e/helpers/`.
+
+`e2e/globalSetup.ts` resets the database before each run by truncating test data. Keep this pointed at a separate test database: `e2e/resetDatabase.ts` refuses to truncate unless the derived `DATABASE_URL` hostname matches `E2E_DB_HOST` or `DB_HOST`.
+
+CI runs Playwright from [`.github/workflows/playwright.yml`](.github/workflows/playwright.yml) on pull requests and pushes to `main`/`master`. It expects a GitHub secret named `E2E_ENV_FILE` containing the full `.env.test` contents. Failed runs upload the `playwright-report` artifact, and traces are collected on the first retry.
+
+Out of scope for E2E for now:
+
+- Stripe checkout and webhooks
+- AI generation
+- Hume voice
+- Resume upload
+
+Keep those covered by Jest or integration tests until the E2E scope expands.
 
 ### Database tasks
 


### PR DESCRIPTION
## Summary

- Add `.env.test.example` with placeholder values for the E2E environment
- Allow `.env.test.example` to be committed despite the `.env*` ignore rule
- Document local Playwright setup, test DB requirements, reset safety guard, CI behavior, and current E2E scope

## Verification

- `git add --dry-run .env.test.example`
- `git diff --check -- .env.test.example .gitignore README.md`

## Notes

- No test logic, Playwright config, CI workflows, or npm scripts were changed.
- `npm test` / `npm run check:ci` were not run because only docs, `.gitignore`, and an env example changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup guidance for end-to-end testing, including required test database configuration, local environment preparation, available test commands, and CI behavior.
  * Clarified which features are currently out of scope for end-to-end coverage.

* **Chores**
  * Added a shared test environment template with placeholder values for required service settings.
  * Updated ignore rules so the test environment template is included in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->