### PR TITLE
test(e2e): add signed-in user flow smoke test and limit local runs to Chromium

### DIFF
--- a/e2e/smoke/userFlow.spec.ts
+++ b/e2e/smoke/userFlow.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  createAuthenticatedUser,
+  applySessionCookie,
+  expectAppHome,
+} from "../helpers";
+
+test.describe("User Flow ->", () => {
+  test("signed-in user sees upgrade link in navbar", async ({ page }) => {
+    const session = await createAuthenticatedUser("user-flow-plan-ui-");
+    await applySessionCookie(page, session);
+    await page.goto("/app");
+
+    await expectAppHome(page);
+    await expect(page.getByText(/current plan/i)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /upgrade plan/i }),
+    ).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,11 +45,13 @@ export default defineConfig({
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
+      testIgnore: process.env.CI ? undefined : "**/*",
     },
 
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      testIgnore: process.env.CI ? undefined : "**/*",
     },
 
     /* Test against mobile viewports. */


### PR DESCRIPTION
## Summary

- Add `e2e/smoke/userFlow.spec.ts` covering the signed-in app home experience: authenticated users see the current plan label and the upgrade plan link in the navbar.
- Update `playwright.config.ts` so Firefox and WebKit projects are skipped locally (`testIgnore`) while still running all browsers in CI, keeping local E2E feedback fast.

## Test plan

- [ ] `npx playwright test e2e/smoke/userFlow.spec.ts` passes locally (Chromium only)
- [ ] Full smoke suite passes: `npx playwright test e2e/smoke`
- [ ] CI runs Chromium, Firefox, and WebKit as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end smoke test for the user flow, verifying authenticated access to the app home, the current plan indicator, and the upgrade plan link.
* **Chores**
  * Adjusted browser test settings so Firefox and WebKit tests are skipped locally but continue to run in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->