### PR TITLE
test(auth): cover sign-in and sign-up error paths

### DIFF
--- a/e2e/smoke/auth.spec.ts
+++ b/e2e/smoke/auth.spec.ts
@@ -96,3 +96,38 @@ test.describe("Auth", () => {
     await expect(page).toHaveURL("/sign-in");
   });
 });
+
+test.describe("Auth errors", () => {
+  test("a wrong password stays on Sign In and shows an error", async ({
+    page,
+  }) => {
+    const session = await createAuthenticatedUser("auth-wrong-password-");
+
+    await signInViaUI(page, {
+      email: session.email,
+      password: "wrong-password",
+    });
+
+    await expect(page).toHaveURL("/sign-in");
+    await expect(page.getByText("Invalid email or password")).toBeVisible();
+    await expect(page).not.toHaveURL("/app");
+  });
+
+  test("a duplicate email stays on Sign Up and shows an error", async ({
+    page,
+  }) => {
+    const session = await createAuthenticatedUser("auth-duplicate-email-");
+
+    await signUpViaUI(page, {
+      email: session.email,
+      password: "password2",
+      name: "Duplicate User",
+    });
+
+    await expect(page).toHaveURL("/sign-up");
+    await expect(
+      page.getByText("An account with this email already exists").first(),
+    ).toBeVisible();
+    await expect(page).not.toHaveURL("/app");
+  });
+});


### PR DESCRIPTION
## Summary

- Add an e2e test for sign-in with an incorrect password
- Add an e2e test for sign-up with an existing email
- Verify errors remain visible without redirecting to `/app`

## Verification

- `npx tsc --noEmit` — passed