### PR TITLE
test(e2e): add free-plan questions limit redirect coverage

### DIFF
--- a/e2e/helpers/createTestQuestion.ts
+++ b/e2e/helpers/createTestQuestion.ts
@@ -1,0 +1,26 @@
+import { QuestionTable } from "@/core/drizzle/schema";
+import { insertQuestionDb } from "@core/features/questions/db";
+
+type TestQuestionOverrides = Partial<
+  Omit<typeof QuestionTable.$inferInsert, "jobInfoId">
+>;
+
+export async function createTestQuestion(
+  jobInfoId: string,
+  overrides: TestQuestionOverrides = {},
+) {
+  const testQuestion: typeof QuestionTable.$inferInsert = {
+    text: "E2E test question",
+    difficulty: "easy" as const,
+    ...overrides,
+    jobInfoId,
+  };
+
+  try {
+    return await insertQuestionDb(testQuestion);
+  } catch (error) {
+    throw new Error(`Failed to seed question for job info "${jobInfoId}".`, {
+      cause: error,
+    });
+  }
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -5,6 +5,7 @@ export {
 } from "./createUser";
 export { createTestJobInfo } from "./createJobInfo";
 export { createTestInterview } from "./createTestInterview";
+export { createTestQuestion } from "./createTestQuestion";
 export { createTestJobInfoUI } from "./createJobInfoUI";
 export { signInViaUI, signUpViaUI, logOutViaUI } from "./authViaUi";
 export { expectAppHome } from "./expectAppHome";

--- a/e2e/smoke/planLimits.spec.ts
+++ b/e2e/smoke/planLimits.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from "@playwright/test";
 
 import { authedTest } from "../fixtures/auth";
-import { createTestInterview, createTestJobInfo } from "../helpers";
+import {
+  createTestInterview,
+  createTestQuestion,
+  createTestJobInfo,
+} from "../helpers";
 
 authedTest.describe("Plan limits", () => {
   authedTest.use({ authEmailPrefix: "interview-plan-limit-" });
@@ -29,6 +33,29 @@ authedTest.describe("Plan limits", () => {
       await expect(upgradeLink).toBeVisible();
       await expect(upgradeLink).toHaveAttribute("href", "/app/upgrade");
       await expect(authedPage).toHaveURL(interviewsUrl);
+    },
+  );
+
+  authedTest.use({ authEmailPrefix: "questions-plan-limit-" });
+  authedTest(
+    "free user at questions limit is redirected to upgrade",
+    async ({ authedPage, session }) => {
+      const jobInfo = await createTestJobInfo(session.userId);
+
+      const insertPromises = Array.from({ length: 10 }, (_, idx) =>
+        createTestQuestion(jobInfo.id, {
+          text: `E2E test question ${idx + 1}`,
+        }),
+      );
+
+      await Promise.all(insertPromises);
+
+      await authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`);
+
+      await expect(authedPage).toHaveURL("/app/upgrade");
+      await expect(
+        authedPage.getByRole("heading", { name: "Upgrade your plan" }),
+      ).toBeVisible();
     },
   );
 });

--- a/e2e/smoke/planLimits.spec.ts
+++ b/e2e/smoke/planLimits.spec.ts
@@ -50,9 +50,11 @@ authedTest.describe("Plan limits", () => {
 
       await Promise.all(insertPromises);
 
-      await authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`);
+      await Promise.all([
+        authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`),
+        authedPage.waitForURL("/app/upgrade"),
+      ]);
 
-      await expect(authedPage).toHaveURL("/app/upgrade");
       await expect(
         authedPage.getByRole("heading", { name: "Upgrade your plan" }),
       ).toBeVisible();


### PR DESCRIPTION
## Summary

- Extends plan-limits smoke coverage to the questions flow for free users.
- Adds `createTestQuestion` e2e helper (mirrors `createTestInterview`) to seed questions via `insertQuestionDb`.
- Asserts that a free user at the 10-question limit is redirected from `/app/jobInfo/:id/questions` to `/app/upgrade` and sees the upgrade page.

This complements the existing interview limit test in `planLimits.spec.ts` (from #127). Interviews show an inline `PlanLimitAlert`; questions are gated server-side in the questions page and redirect when `checkQuestionsPermission()` fails.

## Test plan

- [x] Run `npm run test:e2e`
- [x] Confirm both tests pass:
  - free user at interview limit sees `PlanLimitAlert` on the interviews page
  - free user at questions limit is redirected to `/app/upgrade`
- [x] Verify the questions test uses an isolated auth prefix (`questions-plan-limit-`) so it does not collide with the interview limit test