### PR TITLE
test(questions): add mocked AI question generation e2e flow

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -9,3 +9,4 @@ export { createTestJobInfoUI } from "./createJobInfoUI";
 export { signInViaUI, signUpViaUI, logOutViaUI } from "./authViaUi";
 export { expectAppHome } from "./expectAppHome";
 export { openJobInfoFromApp } from "./openJobInfoFromApp";
+export { mockAiQuestionGenerationRoute } from "./mockAiQuestionGeneration";

--- a/e2e/helpers/mockAiQuestionGeneration.ts
+++ b/e2e/helpers/mockAiQuestionGeneration.ts
@@ -1,0 +1,41 @@
+import type { Page } from "@playwright/test";
+
+type MockAiQuestionGenerationOptions = {
+  questionText?: string;
+  questionId?: string;
+};
+
+const defaultQuestionText = "What is a React hook?";
+const defaultQuestionId = "00000000-0000-4000-8000-000000009901";
+
+export async function mockAiQuestionGenerationRoute(
+  page: Page,
+  options: MockAiQuestionGenerationOptions = {},
+) {
+  const questionText = options.questionText ?? defaultQuestionText;
+  const questionId = options.questionId ?? defaultQuestionId;
+  const completion = `${questionText}Question ID: ${questionId}`;
+
+  await page.route("**/api/ai/questions/generate-question", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+
+    const chunk = {
+      type: "text-delta",
+      id: "generate-question",
+      delta: completion,
+    };
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      headers: {
+        "cache-control": "no-cache",
+        "x-vercel-ai-ui-message-stream": "v1",
+      },
+      body: `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+    });
+  });
+}

--- a/e2e/helpers/mockAiQuestionGeneration.ts
+++ b/e2e/helpers/mockAiQuestionGeneration.ts
@@ -1,6 +1,10 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
+
+import type { QuestionDifficulty } from "@/core/drizzle/schema";
 
 type MockAiQuestionGenerationOptions = {
+  expectedPrompt: QuestionDifficulty;
+  expectedJobInfoId: string;
   questionText?: string;
   questionId?: string;
 };
@@ -10,7 +14,7 @@ const defaultQuestionId = "00000000-0000-4000-8000-000000009901";
 
 export async function mockAiQuestionGenerationRoute(
   page: Page,
-  options: MockAiQuestionGenerationOptions = {},
+  options: MockAiQuestionGenerationOptions,
 ) {
   const questionText = options.questionText ?? defaultQuestionText;
   const questionId = options.questionId ?? defaultQuestionId;
@@ -21,6 +25,13 @@ export async function mockAiQuestionGenerationRoute(
       await route.fallback();
       return;
     }
+
+    const requestBody: unknown = route.request().postDataJSON();
+
+    expect(requestBody).toMatchObject({
+      prompt: options.expectedPrompt,
+      jobInfoId: options.expectedJobInfoId,
+    });
 
     const chunk = {
       type: "text-delta",

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -26,6 +26,7 @@ authedTest.describe("AI questions", () => {
       await authedPage.getByRole("button", { name: "Easy" }).click();
 
       await expect(authedPage.getByText("What is a React hook?")).toBeVisible();
+      await expect(authedPage.getByText(/Question ID:/)).toHaveCount(0);
 
       const answer = authedPage.getByPlaceholder("Type your answer here...");
       const sampleAnswer =

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from "@playwright/test";
+
+import { authedTest } from "../fixtures/auth";
+import { createTestJobInfo, mockAiQuestionGenerationRoute } from "../helpers";
+
+authedTest.describe("AI questions", () => {
+  authedTest.use({ authEmailPrefix: "ai-question-generation-" });
+
+  authedTest(
+    "user can generate a question and enter an answer",
+    async ({ authedPage, session }) => {
+      const jobInfo = await createTestJobInfo(session.userId);
+      await mockAiQuestionGenerationRoute(authedPage);
+
+      await authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`);
+
+      await expect(
+        authedPage.getByText(
+          "Get started by selecting a question difficulty above.",
+        ),
+      ).toBeVisible();
+
+      await authedPage.getByRole("button", { name: "Easy" }).click();
+
+      await expect(authedPage.getByText("What is a React hook?")).toBeVisible();
+
+      const answer = authedPage.getByPlaceholder("Type your answer here...");
+      const sampleAnswer =
+        "A hook lets React components use state and effects.";
+
+      await expect(answer).toBeEnabled();
+      await answer.fill(sampleAnswer);
+      await expect(answer).toHaveValue(sampleAnswer);
+    },
+  );
+});

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -10,7 +10,10 @@ authedTest.describe("AI questions", () => {
     "user can generate a question and enter an answer",
     async ({ authedPage, session }) => {
       const jobInfo = await createTestJobInfo(session.userId);
-      await mockAiQuestionGenerationRoute(authedPage);
+      await mockAiQuestionGenerationRoute(authedPage, {
+        expectedPrompt: "easy",
+        expectedJobInfoId: jobInfo.id,
+      });
 
       await authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`);
 


### PR DESCRIPTION
## Summary

- Add a Playwright route helper that mocks AI question generation using the AI SDK SSE protocol
- Add an authenticated e2e test covering difficulty selection, generated question display, and answer entry
- Avoid real Gemini requests and leave feedback generation out of scope

## Verification

- `npx tsc --noEmit`
- `npm test -- --runInBand` — 730 tests passed
- `npm run test:e2e -- e2e/smoke/aiQuestions.spec.ts` — 1 test passed
- Biome check passed

## Notes / Risks

- Only question generation is mocked
- The feedback flow remains untested for a follow-up slice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the AI questions flow, including question generation, difficulty selection, and answer entry.
  * Added shared test support for mocking AI question generation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->