### PR TITLE
test(e2e): cover resume analysis with mocked AI stream

### DIFF
--- a/e2e/fixtures/sample-resume.txt
+++ b/e2e/fixtures/sample-resume.txt
@@ -1,0 +1,3 @@
+Senior Frontend Engineer
+
+Experienced with React, Next.js, TypeScript, and accessible web applications.

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -11,3 +11,4 @@ export { signInViaUI, signUpViaUI, logOutViaUI } from "./authViaUi";
 export { expectAppHome } from "./expectAppHome";
 export { openJobInfoFromApp } from "./openJobInfoFromApp";
 export { mockAiQuestionGenerationRoute } from "./mockAiQuestionGeneration";
+export { mockAiResumeAnalysisRoute } from "./mockAiResumeAnalysis";

--- a/e2e/helpers/mockAiResumeAnalysis.ts
+++ b/e2e/helpers/mockAiResumeAnalysis.ts
@@ -1,0 +1,78 @@
+import { expect, type Page } from "@playwright/test";
+import type { z } from "zod";
+
+import type { aiAnalyzeSchema } from "@/core/services/ai/resumes/schemas";
+
+type MockAiResumeAnalysisOptions = {
+  expectedJobInfoId?: string;
+  overallScore?: number;
+  atsSummary?: string;
+};
+
+const defaultOverallScore = 8;
+const defaultAtsSummary = "Resume is ATS-friendly.";
+
+export async function mockAiResumeAnalysisRoute(
+  page: Page,
+  options: MockAiResumeAnalysisOptions = {},
+) {
+  const analysis = {
+    overallScore: options.overallScore ?? defaultOverallScore,
+    ats: {
+      score: 8,
+      summary: options.atsSummary ?? defaultAtsSummary,
+      feedback: [
+        {
+          type: "strength",
+          name: "Readable structure",
+          message: "The resume uses clear sections that an ATS can parse.",
+        },
+      ],
+    },
+    jobMatch: {
+      score: 8,
+      summary: "The resume matches the role.",
+      feedback: [],
+    },
+    writingAndFormatting: {
+      score: 8,
+      summary: "The resume is clear and well formatted.",
+      feedback: [],
+    },
+    keywordCoverage: {
+      score: 8,
+      summary: "The resume includes relevant keywords.",
+      feedback: [],
+    },
+    other: {
+      score: 8,
+      summary: "No additional issues were found.",
+      feedback: [],
+    },
+  } satisfies z.infer<typeof aiAnalyzeSchema>;
+
+  await page.route("**/api/ai/resumes/analyze", async (route) => {
+    const request = route.request();
+
+    expect(request.method()).toBe("POST");
+    expect(request.headers()["content-type"]).toMatch(
+      /^multipart\/form-data; boundary=/,
+    );
+
+    const requestBody = request.postData();
+    expect(requestBody).toContain('name="resumeFile"');
+
+    if (options.expectedJobInfoId != null) {
+      expect(requestBody).toContain('name="jobInfoId"');
+      expect(requestBody).toContain(options.expectedJobInfoId);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain; charset=utf-8",
+      body: JSON.stringify(analysis),
+    });
+  });
+}

--- a/e2e/helpers/mockAiResumeAnalysis.ts
+++ b/e2e/helpers/mockAiResumeAnalysis.ts
@@ -4,23 +4,21 @@ import type { z } from "zod";
 import type { aiAnalyzeSchema } from "@/core/services/ai/resumes/schemas";
 
 type MockAiResumeAnalysisOptions = {
-  expectedJobInfoId?: string;
+  expectedJobInfoId: string;
   overallScore?: number;
   atsSummary?: string;
+  /** Optional artificial delay before the response is sent (for loading UI). */
+  responseDelayMs?: number;
 };
 
-const defaultOverallScore = 8;
-const defaultAtsSummary = "Resume is ATS-friendly.";
-
-export async function mockAiResumeAnalysisRoute(
-  page: Page,
-  options: MockAiResumeAnalysisOptions = {},
-) {
-  const analysis = {
-    overallScore: options.overallScore ?? defaultOverallScore,
+function buildResumeAnalysis(
+  options: MockAiResumeAnalysisOptions,
+): z.infer<typeof aiAnalyzeSchema> {
+  return {
+    overallScore: options.overallScore ?? 8,
     ats: {
       score: 8,
-      summary: options.atsSummary ?? defaultAtsSummary,
+      summary: options.atsSummary ?? "Resume is ATS-friendly.",
       feedback: [
         {
           type: "strength",
@@ -49,25 +47,32 @@ export async function mockAiResumeAnalysisRoute(
       summary: "No additional issues were found.",
       feedback: [],
     },
-  } satisfies z.infer<typeof aiAnalyzeSchema>;
+  };
+}
+
+export async function mockAiResumeAnalysisRoute(
+  page: Page,
+  options: MockAiResumeAnalysisOptions,
+) {
+  const analysis = buildResumeAnalysis(options);
 
   await page.route("**/api/ai/resumes/analyze", async (route) => {
-    const request = route.request();
-
-    expect(request.method()).toBe("POST");
-    expect(request.headers()["content-type"]).toMatch(
-      /^multipart\/form-data; boundary=/,
-    );
-
-    const requestBody = request.postData();
-    expect(requestBody).toContain('name="resumeFile"');
-
-    if (options.expectedJobInfoId != null) {
-      expect(requestBody).toContain('name="jobInfoId"');
-      expect(requestBody).toContain(options.expectedJobInfoId);
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    const requestBody = route.request().postData();
+    expect(requestBody).not.toBeNull();
+    expect(requestBody).toContain('name="resumeFile"');
+    expect(requestBody).toContain('name="jobInfoId"');
+    expect(requestBody).toContain(options.expectedJobInfoId);
+
+    if (options.responseDelayMs) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, options.responseDelayMs),
+      );
+    }
 
     await route.fulfill({
       status: 200,

--- a/e2e/smoke/aiResume.spec.ts
+++ b/e2e/smoke/aiResume.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from "@playwright/test";
+import { resolve } from "node:path";
+
+import { authedTest } from "../fixtures/auth";
+import { createTestJobInfo, mockAiResumeAnalysisRoute } from "../helpers";
+
+authedTest.describe("AI resume analysis", () => {
+  authedTest.use({ authEmailPrefix: "ai-resume-analysis-" });
+
+  authedTest(
+    "user can upload a resume and see analysis results",
+    async ({ authedPage, session }) => {
+      const jobInfo = await createTestJobInfo(session.userId);
+      await mockAiResumeAnalysisRoute(authedPage, {
+        expectedJobInfoId: jobInfo.id,
+      });
+
+      await authedPage.goto(`/app/jobInfo/${jobInfo.id}/resume`);
+
+      await expect(
+        authedPage.locator('[data-slot="card-title"]', {
+          hasText: "Upload your resume",
+        }),
+      ).toBeVisible();
+      await expect(
+        authedPage.getByText("Drag your resume here or click to upload"),
+      ).toBeVisible();
+
+      await authedPage
+        .locator("#resume-upload")
+        .setInputFiles(resolve("e2e/fixtures/sample-resume.txt"));
+
+      await expect(
+        authedPage.locator('[data-slot="card-title"]', {
+          hasText: "Analyzing your resume...",
+        }),
+      ).toBeVisible();
+      await expect(
+        authedPage.locator('[data-slot="card-title"]', {
+          hasText: "Analysis Results",
+        }),
+      ).toBeVisible();
+      await expect(authedPage.getByText("Overall Score: 8/10")).toBeVisible();
+
+      const atsSection = authedPage.getByRole("button", {
+        name: /ATS Compatibility/,
+      });
+      await expect(atsSection).toBeVisible();
+      await atsSection.click();
+
+      await expect(
+        authedPage.getByText("Resume is ATS-friendly."),
+      ).toBeVisible();
+    },
+  );
+});

--- a/e2e/smoke/aiResume.spec.ts
+++ b/e2e/smoke/aiResume.spec.ts
@@ -11,45 +11,29 @@ authedTest.describe("AI resume analysis", () => {
     "user can upload a resume and see analysis results",
     async ({ authedPage, session }) => {
       const jobInfo = await createTestJobInfo(session.userId);
+
       await mockAiResumeAnalysisRoute(authedPage, {
         expectedJobInfoId: jobInfo.id,
+        overallScore: 7,
+        atsSummary: "The resume is readable and ATS-friendly.",
       });
 
       await authedPage.goto(`/app/jobInfo/${jobInfo.id}/resume`);
 
-      await expect(
-        authedPage.locator('[data-slot="card-title"]', {
-          hasText: "Upload your resume",
-        }),
-      ).toBeVisible();
-      await expect(
-        authedPage.getByText("Drag your resume here or click to upload"),
-      ).toBeVisible();
-
       await authedPage
-        .locator("#resume-upload")
+        .getByLabel("Upload your resume")
         .setInputFiles(resolve("e2e/fixtures/sample-resume.txt"));
 
-      await expect(
-        authedPage.locator('[data-slot="card-title"]', {
-          hasText: "Analyzing your resume...",
-        }),
-      ).toBeVisible();
-      await expect(
-        authedPage.locator('[data-slot="card-title"]', {
-          hasText: "Analysis Results",
-        }),
-      ).toBeVisible();
-      await expect(authedPage.getByText("Overall Score: 8/10")).toBeVisible();
+      await expect(authedPage.getByText("Overall Score: 7/10")).toBeVisible();
 
-      const atsSection = authedPage.getByRole("button", {
-        name: /ATS Compatibility/,
-      });
-      await expect(atsSection).toBeVisible();
-      await atsSection.click();
+      await authedPage
+        .getByRole("button", {
+          name: /ATS Compatibility/,
+        })
+        .click();
 
       await expect(
-        authedPage.getByText("Resume is ATS-friendly."),
+        authedPage.getByText("The resume is readable and ATS-friendly."),
       ).toBeVisible();
     },
   );


### PR DESCRIPTION
## Summary

Adds a Playwright e2e test for resume analysis that uses a mocked AI API response instead of calling Gemini.

## What changed

- Added `mockAiResumeAnalysisRoute` to intercept `POST /api/ai/resumes/analyze`
- Added a sample resume fixture for upload coverage
- Added an authed e2e spec that:
  - opens the resume analysis page
  - uploads a resume file
  - waits for analysis to load
  - verifies the analysis results render, including overall score and ATS feedback

## Verification

- `npx.cmd tsc --noEmit`
- `npm.cmd test`
- `npm.cmd run test:e2e -- e2e/smoke/aiResume.spec.ts`

## Notes

- The AI call is fully mocked; no real Gemini request is made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end smoke test for AI resume analysis, validating resume upload, “Overall Score” display, and ATS compatibility messaging.
  * Enhanced the realism of the sample resume fixture used by the test.
* **Bug Fixes**
  * Strengthened AI analysis mocking by enforcing request body checks (resume file, job info ID) and supporting optional response delays for more reliable timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->