### PR TITLE
test(e2e): mock AI answer feedback in questions flow

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -11,3 +11,4 @@ export { signInViaUI, signUpViaUI, logOutViaUI } from "./authViaUi";
 export { expectAppHome } from "./expectAppHome";
 export { openJobInfoFromApp } from "./openJobInfoFromApp";
 export { mockAiQuestionGenerationRoute } from "./mockAiQuestionGeneration";
+export { mockAiFeedbackGenerationRoute } from "./mockAiFeedbackGeneration";

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -11,4 +11,4 @@ export { signInViaUI, signUpViaUI, logOutViaUI } from "./authViaUi";
 export { expectAppHome } from "./expectAppHome";
 export { openJobInfoFromApp } from "./openJobInfoFromApp";
 export { mockAiQuestionGenerationRoute } from "./mockAiQuestionGeneration";
-export { mockAiFeedbackGenerationRoute } from "./mockAiFeedbackGeneration";
+export { mockAiAnswerFeedbackGenerationRoute } from "./mockAiAnswerFeedbackGeneration";

--- a/e2e/helpers/mockAiAnswerFeedbackGeneration.ts
+++ b/e2e/helpers/mockAiAnswerFeedbackGeneration.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 
-type MockAiFeedbackGenerationOptions = {
+type MockAiAnswerFeedbackGenerationOptions = {
   expectedPrompt: string;
   expectedQuestionId: string;
   feedbackText?: string;
@@ -10,7 +10,7 @@ const defaultFeedbackText = "Good job!";
 
 export async function mockAiAnswerFeedbackGenerationRoute(
   page: Page,
-  options: MockAiFeedbackGenerationOptions,
+  options: MockAiAnswerFeedbackGenerationOptions,
 ) {
   const feedbackText = options.feedbackText ?? defaultFeedbackText;
 

--- a/e2e/helpers/mockAiAnswerFeedbackGeneration.ts
+++ b/e2e/helpers/mockAiAnswerFeedbackGeneration.ts
@@ -8,7 +8,7 @@ type MockAiFeedbackGenerationOptions = {
 
 const defaultFeedbackText = "Good job!";
 
-export async function mockAiFeedbackGenerationRoute(
+export async function mockAiAnswerFeedbackGenerationRoute(
   page: Page,
   options: MockAiFeedbackGenerationOptions,
 ) {

--- a/e2e/helpers/mockAiFeedbackGeneration.ts
+++ b/e2e/helpers/mockAiFeedbackGeneration.ts
@@ -1,0 +1,46 @@
+import { expect, type Page } from "@playwright/test";
+
+type MockAiFeedbackGenerationOptions = {
+  expectedPrompt: string;
+  expectedQuestionId: string;
+  feedbackText?: string;
+};
+
+const defaultFeedbackText = "Good job!";
+
+export async function mockAiFeedbackGenerationRoute(
+  page: Page,
+  options: MockAiFeedbackGenerationOptions,
+) {
+  const feedbackText = options.feedbackText ?? defaultFeedbackText;
+
+  await page.route("**/api/ai/questions/generate-feedback", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+
+    const requestBody: unknown = route.request().postDataJSON();
+
+    expect(requestBody).toMatchObject({
+      prompt: options.expectedPrompt,
+      questionId: options.expectedQuestionId,
+    });
+
+    const chunk = {
+      type: "text-delta",
+      id: "generate-feedback",
+      delta: feedbackText,
+    };
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      headers: {
+        "cache-control": "no-cache",
+        "x-vercel-ai-ui-message-stream": "v1",
+      },
+      body: `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+    });
+  });
+}

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from "@playwright/test";
 
 import { authedTest } from "../fixtures/auth";
-import { createTestJobInfo, mockAiQuestionGenerationRoute } from "../helpers";
+import {
+  createTestJobInfo,
+  mockAiQuestionGenerationRoute,
+  mockAiFeedbackGenerationRoute,
+} from "../helpers";
 
 authedTest.describe("AI questions", () => {
   authedTest.use({ authEmailPrefix: "ai-question-generation-" });
@@ -35,6 +39,48 @@ authedTest.describe("AI questions", () => {
       await expect(answer).toBeEnabled();
       await answer.fill(sampleAnswer);
       await expect(answer).toHaveValue(sampleAnswer);
+    },
+  );
+
+  authedTest(
+    "user can submit an answer and receive feedback",
+    async ({ authedPage, session }) => {
+      const jobInfo = await createTestJobInfo(session.userId);
+      await mockAiQuestionGenerationRoute(authedPage, {
+        expectedPrompt: "easy",
+        expectedJobInfoId: jobInfo.id,
+        questionId: "00000000-0000-4000-8000-000000009901",
+        questionText: "What is a React hook?",
+      });
+      await mockAiFeedbackGenerationRoute(authedPage, {
+        expectedPrompt: "A hook lets React components use state and effects.",
+        expectedQuestionId: "00000000-0000-4000-8000-000000009901",
+        feedbackText: "Good answer. You explained hooks clearly.",
+      });
+
+      await authedPage.goto(`/app/jobInfo/${jobInfo.id}/questions`);
+      await authedPage.getByRole("button", { name: "Easy" }).click();
+
+      await expect(authedPage.getByText("What is a React hook?")).toBeVisible();
+
+      const answer = authedPage.getByPlaceholder("Type your answer here...");
+      await expect(answer).toBeEnabled();
+      await answer.fill("A hook lets React components use state and effects.");
+
+      await authedPage.getByRole("button", { name: "Answer " }).click();
+
+      await expect(
+        authedPage.getByText("Good answer. You explained hooks clearly."),
+      ).toBeVisible();
+      await expect(
+        authedPage.getByRole("button", { name: "Easy" }),
+      ).toBeVisible();
+      await expect(
+        authedPage.getByRole("button", { name: "Medium" }),
+      ).toBeVisible();
+      await expect(
+        authedPage.getByRole("button", { name: "Hard" }),
+      ).toBeVisible();
     },
   );
 });

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -42,6 +42,8 @@ authedTest.describe("AI questions", () => {
     },
   );
 
+  authedTest.use({ authEmailPrefix: "ai-answer-feedback-generation" });
+
   authedTest(
     "user can submit an answer and receive feedback",
     async ({ authedPage, session }) => {

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -4,7 +4,7 @@ import { authedTest } from "../fixtures/auth";
 import {
   createTestJobInfo,
   mockAiQuestionGenerationRoute,
-  mockAiFeedbackGenerationRoute,
+  mockAiAnswerFeedbackGenerationRoute,
 } from "../helpers";
 
 authedTest.describe("AI questions", () => {
@@ -54,7 +54,7 @@ authedTest.describe("AI questions", () => {
         questionId: "00000000-0000-4000-8000-000000009901",
         questionText: "What is a React hook?",
       });
-      await mockAiFeedbackGenerationRoute(authedPage, {
+      await mockAiAnswerFeedbackGenerationRoute(authedPage, {
         expectedPrompt: "A hook lets React components use state and effects.",
         expectedQuestionId: "00000000-0000-4000-8000-000000009901",
         feedbackText: "Good answer. You explained hooks clearly.",

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -42,7 +42,7 @@ authedTest.describe("AI questions", () => {
     },
   );
 
-  authedTest.use({ authEmailPrefix: "ai-answer-feedback-generation" });
+  authedTest.use({ authEmailPrefix: "ai-answer-feedback-generation-" });
 
   authedTest(
     "user can submit an answer and receive feedback",

--- a/e2e/smoke/aiQuestions.spec.ts
+++ b/e2e/smoke/aiQuestions.spec.ts
@@ -67,7 +67,7 @@ authedTest.describe("AI questions", () => {
       await expect(answer).toBeEnabled();
       await answer.fill("A hook lets React components use state and effects.");
 
-      await authedPage.getByRole("button", { name: "Answer " }).click();
+      await authedPage.getByRole("button", { name: "Answer" }).click();
 
       await expect(
         authedPage.getByText("Good answer. You explained hooks clearly."),


### PR DESCRIPTION
## Summary

- Add `mockAiAnswerFeedbackGenerationRoute` to intercept `POST /api/ai/questions/generate-feedback` with the same AI SDK UI message stream format used for question generation.
- Extend `aiQuestions.spec.ts` with a second test that covers the full answer → feedback loop without calling Gemini or requiring a DB question row.
- Assert feedback text is shown and difficulty buttons return after submission (`awaiting-difficulty` state).

## Why

Question generation was already covered in e2e, but the feedback step was not. Mocking both routes keeps the test fast, deterministic, and CI-safe while still verifying client ↔ API wiring for the core questions workflow.

## Test plan

- [x] `npm run test:e2e -- e2e/smoke/aiQuestions.spec.ts`
- [x] `npx tsc --noEmit`
- [x] Full `npm run test:e2e` (if not run on this branch)

## Notes

- Both mocks must be registered before navigation; the fake `questionId` is shared between generation and feedback mocks so the real feedback route is never hit (would 404 without a DB row).
- No production code changes.