### PR TITLE
fix(resume-analysis): atomic quota reservation for concurrent uploads

### DIFF
--- a/app/api/ai/resumes/analyze/route.test.ts
+++ b/app/api/ai/resumes/analyze/route.test.ts
@@ -200,6 +200,25 @@ describe("POST /api/ai/resumes/analyze", () => {
     expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
   });
 
+  it("maps reservation failures to a 500 response", async () => {
+    mockReserveResumeAnalysisUsage.mockRejectedValueOnce(
+      new DatabaseError("Reservation insert failed"),
+    );
+
+    const response = await POST(buildFormRequest());
+
+    await expectTextResponse(
+      response,
+      500,
+      "An error occurred while analyzing your resume",
+    );
+    expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error analyzing resume:",
+      expect.any(DatabaseError),
+    );
+  });
+
   it("returns a streamed success response for resume analysis", async () => {
     const resumeFile = makeResumeFile();
     const jobInfo = makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID });

--- a/app/api/ai/resumes/analyze/route.test.ts
+++ b/app/api/ai/resumes/analyze/route.test.ts
@@ -7,11 +7,7 @@ jest.mock("@/core/features/jobInfos/actions", () => ({
 }));
 
 jest.mock("@/core/features/resumeAnalysis/permissions", () => ({
-  checkResumeAnalysisPermission: jest.fn(),
-}));
-
-jest.mock("@/core/features/resumeAnalysis/db", () => ({
-  insertResumeAnalysisDb: jest.fn(),
+  reserveResumeAnalysisUsage: jest.fn(),
 }));
 
 jest.mock("@/core/features/resumeAnalysis/schemas", () => {
@@ -38,8 +34,7 @@ import { z } from "zod";
 
 import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { getJobInfoAction } from "@/core/features/jobInfos/actions";
-import { checkResumeAnalysisPermission } from "@/core/features/resumeAnalysis/permissions";
-import { insertResumeAnalysisDb } from "@/core/features/resumeAnalysis/db";
+import { reserveResumeAnalysisUsage } from "@/core/features/resumeAnalysis/permissions";
 import { resumeAnalysisInputSchema } from "@/core/features/resumeAnalysis/schemas";
 import { analyzeResumeForJob } from "@/core/services/ai/resumes/ai";
 import {
@@ -55,10 +50,7 @@ import { POST } from "./route";
 
 const mockGetCurrentUserAction = jest.mocked(getCurrentUserAction);
 const mockGetJobInfoAction = jest.mocked(getJobInfoAction);
-const mockCheckResumeAnalysisPermission = jest.mocked(
-  checkResumeAnalysisPermission,
-);
-const mockInsertResumeAnalysisDb = jest.mocked(insertResumeAnalysisDb);
+const mockReserveResumeAnalysisUsage = jest.mocked(reserveResumeAnalysisUsage);
 const mockAnalyzeResumeForJob = jest.mocked(analyzeResumeForJob);
 const mockResumeAnalysisSafeParse = jest.mocked(
   resumeAnalysisInputSchema.safeParse,
@@ -135,8 +127,7 @@ describe("POST /api/ai/resumes/analyze", () => {
     mockGetJobInfoAction.mockResolvedValue(
       makeJobInfo({ id: jobInfoId, userId: TEST_USER_ID }),
     );
-    mockCheckResumeAnalysisPermission.mockResolvedValue(true);
-    mockInsertResumeAnalysisDb.mockResolvedValue({ id: jobInfoId });
+    mockReserveResumeAnalysisUsage.mockResolvedValue(true);
     mockResumeAnalysisSafeParse.mockImplementation((input) =>
       actualResumeAnalysisInputSchema.safeParse(input),
     );
@@ -154,7 +145,7 @@ describe("POST /api/ai/resumes/analyze", () => {
 
     await expectTextResponse(response, 400, "Missing resume or job info id");
     expect(mockGetJobInfoAction).not.toHaveBeenCalled();
-    expect(mockCheckResumeAnalysisPermission).not.toHaveBeenCalled();
+    expect(mockReserveResumeAnalysisUsage).not.toHaveBeenCalled();
     expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
   });
 
@@ -196,12 +187,12 @@ describe("POST /api/ai/resumes/analyze", () => {
       403,
       "You do not have permission to do this",
     );
-    expect(mockCheckResumeAnalysisPermission).not.toHaveBeenCalled();
+    expect(mockReserveResumeAnalysisUsage).not.toHaveBeenCalled();
     expect(mockAnalyzeResumeForJob).not.toHaveBeenCalled();
   });
 
   it("returns the plan limit response when resume analysis is not allowed", async () => {
-    mockCheckResumeAnalysisPermission.mockResolvedValueOnce(false);
+    mockReserveResumeAnalysisUsage.mockResolvedValueOnce(false);
 
     const response = await POST(buildFormRequest());
 
@@ -222,7 +213,10 @@ describe("POST /api/ai/resumes/analyze", () => {
     });
 
     expect(mockGetJobInfoAction).toHaveBeenCalledWith(jobInfoId);
-    expect(mockInsertResumeAnalysisDb).toHaveBeenCalledWith({ jobInfoId });
+    expect(mockReserveResumeAnalysisUsage).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      jobInfoId,
+    );
     expect(mockAnalyzeResumeForJob).toHaveBeenCalledWith({
       resumeFile: expect.objectContaining({
         name: resumeFile.name,

--- a/app/api/ai/resumes/analyze/route.ts
+++ b/app/api/ai/resumes/analyze/route.ts
@@ -1,8 +1,7 @@
 import { getCurrentUserAction } from "@/core/features/auth/actions";
 import { analyzeResumeForJob } from "@/core/services/ai/resumes/ai";
 import { getJobInfoAction } from "@/core/features/jobInfos/actions";
-import { checkResumeAnalysisPermission } from "@/core/features/resumeAnalysis/permissions";
-import { insertResumeAnalysisDb } from "@/core/features/resumeAnalysis/db";
+import { reserveResumeAnalysisUsage } from "@/core/features/resumeAnalysis/permissions";
 import { resumeAnalysisInputSchema } from "@/core/features/resumeAnalysis/schemas";
 import { PLAN_LIMIT_MESSAGE } from "@/core/lib/errorToast";
 import { NotFoundError, PermissionError } from "@/core/dal/errors";
@@ -37,13 +36,11 @@ export async function POST(req: Request) {
       });
     }
 
-    if (!(await checkResumeAnalysisPermission())) {
+    if (!(await reserveResumeAnalysisUsage(userId, jobInfoId))) {
       return new Response(PLAN_LIMIT_MESSAGE, {
         status: 403,
       });
     }
-
-    await insertResumeAnalysisDb({ jobInfoId });
 
     const res = await analyzeResumeForJob({
       resumeFile,

--- a/core/features/resumeAnalysis/db.ts
+++ b/core/features/resumeAnalysis/db.ts
@@ -1,16 +1,30 @@
 import { count, eq } from "drizzle-orm";
 
 import { db } from "@/core/drizzle/db";
-import { JobInfoTable, ResumeAnalysisTable } from "@/core/drizzle/schema";
+import {
+  JobInfoTable,
+  ResumeAnalysisTable,
+  UserTable,
+} from "@/core/drizzle/schema";
 
-export async function getResumeAnalysisCountDb(userId: string) {
-  const [{ count: resumeAnalysisCount }] = await db
+type DbClient = typeof db;
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+async function getResumeAnalysisCountWithClient(
+  client: DbClient | DbTransaction,
+  userId: string,
+) {
+  const [{ count: resumeAnalysisCount }] = await client
     .select({ count: count() })
     .from(ResumeAnalysisTable)
     .innerJoin(JobInfoTable, eq(ResumeAnalysisTable.jobInfoId, JobInfoTable.id))
     .where(eq(JobInfoTable.userId, userId));
 
   return resumeAnalysisCount;
+}
+
+export async function getResumeAnalysisCountDb(userId: string) {
+  return getResumeAnalysisCountWithClient(db, userId);
 }
 
 export async function insertResumeAnalysisDb(
@@ -22,4 +36,42 @@ export async function insertResumeAnalysisDb(
     .returning({ id: ResumeAnalysisTable.id });
 
   return newResumeAnalysis;
+}
+
+/**
+ * Atomically reserves one resume analysis slot for a limited-plan user.
+ * Serializes concurrent requests per user so quota cannot be exceeded.
+ */
+export async function tryInsertResumeAnalysisDb({
+  userId,
+  jobInfoId,
+  limit,
+}: {
+  userId: string;
+  jobInfoId: string;
+  limit: number;
+}): Promise<{ id: string } | null> {
+  return db.transaction(async (tx) => {
+    await tx
+      .select({ id: UserTable.id })
+      .from(UserTable)
+      .where(eq(UserTable.id, userId))
+      .for("update");
+
+    const resumeAnalysisCount = await getResumeAnalysisCountWithClient(
+      tx,
+      userId,
+    );
+
+    if (resumeAnalysisCount >= limit) {
+      return null;
+    }
+
+    const [newResumeAnalysis] = await tx
+      .insert(ResumeAnalysisTable)
+      .values({ jobInfoId })
+      .returning({ id: ResumeAnalysisTable.id });
+
+    return newResumeAnalysis ?? null;
+  });
 }

--- a/core/features/resumeAnalysis/permissions.test.ts
+++ b/core/features/resumeAnalysis/permissions.test.ts
@@ -25,6 +25,8 @@ jest.mock("@/core/features/auth/permissions", () => ({
 
 jest.mock("@/core/features/resumeAnalysis/db", () => ({
   getResumeAnalysisCountDb: jest.fn(),
+  insertResumeAnalysisDb: jest.fn(),
+  tryInsertResumeAnalysisDb: jest.fn(),
 }));
 
 import { getCurrentUserAction } from "@/core/features/auth/actions";
@@ -33,15 +35,25 @@ import {
   hasPermission,
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
-import { getResumeAnalysisCountDb } from "@/core/features/resumeAnalysis/db";
+import {
+  getResumeAnalysisCountDb,
+  insertResumeAnalysisDb,
+  tryInsertResumeAnalysisDb,
+} from "@/core/features/resumeAnalysis/db";
+import { DatabaseError } from "@/core/dal/errors";
 import { TEST_USER_ID } from "@/core/test-utils/constants";
 import { makeCurrentUser } from "@/core/test-utils/factories/user";
 
-import { checkResumeAnalysisPermission } from "./permissions";
+import {
+  checkResumeAnalysisPermission,
+  reserveResumeAnalysisUsage,
+} from "./permissions";
 
 const mockGetCurrentUser = jest.mocked(getCurrentUserAction);
 const mockHasPermission = jest.mocked(hasPermission);
 const mockGetResumeAnalysisCountDb = jest.mocked(getResumeAnalysisCountDb);
+const mockInsertResumeAnalysisDb = jest.mocked(insertResumeAnalysisDb);
+const mockTryInsertResumeAnalysisDb = jest.mocked(tryInsertResumeAnalysisDb);
 
 const SIGNED_IN_USER_ID = TEST_USER_ID;
 
@@ -119,5 +131,82 @@ describe("checkResumeAnalysisPermission", () => {
       "Error checking resume analysis permission:",
       expect.any(Error),
     );
+  });
+});
+
+describe("reserveResumeAnalysisUsage", () => {
+  const jobInfoId = "00000000-0000-4000-8000-000000000401";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasPermission.mockResolvedValue(false);
+  });
+
+  it("inserts without quota checks for unlimited users", async () => {
+    mockHasPermission.mockResolvedValueOnce(true);
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).resolves.toBe(true);
+
+    expect(mockInsertResumeAnalysisDb).toHaveBeenCalledWith({ jobInfoId });
+    expect(mockTryInsertResumeAnalysisDb).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the user lacks limited or unlimited permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).resolves.toBe(false);
+
+    expect(mockInsertResumeAnalysisDb).not.toHaveBeenCalled();
+    expect(mockTryInsertResumeAnalysisDb).not.toHaveBeenCalled();
+  });
+
+  it("returns true when a limited user successfully reserves quota", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockTryInsertResumeAnalysisDb.mockResolvedValue({ id: "analysis-id" });
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).resolves.toBe(true);
+
+    expect(mockTryInsertResumeAnalysisDb).toHaveBeenCalledWith({
+      userId: SIGNED_IN_USER_ID,
+      jobInfoId,
+      limit: FREE_PLAN_LIMITS.resume_analyses,
+    });
+  });
+
+  it("returns false when a limited user is at the quota limit", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockTryInsertResumeAnalysisDb.mockResolvedValue(null);
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).resolves.toBe(false);
+  });
+
+  it("propagates unexpected insert failures for unlimited users", async () => {
+    mockHasPermission.mockResolvedValueOnce(true);
+    mockInsertResumeAnalysisDb.mockRejectedValue(
+      new DatabaseError("Insert failed"),
+    );
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).rejects.toThrow(DatabaseError);
+  });
+
+  it("propagates unexpected reservation failures for limited users", async () => {
+    mockHasPermission.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockTryInsertResumeAnalysisDb.mockRejectedValue(
+      new DatabaseError("Reservation failed"),
+    );
+
+    await expect(
+      reserveResumeAnalysisUsage(SIGNED_IN_USER_ID, jobInfoId),
+    ).rejects.toThrow(DatabaseError);
   });
 });

--- a/core/features/resumeAnalysis/permissions.ts
+++ b/core/features/resumeAnalysis/permissions.ts
@@ -5,7 +5,11 @@ import {
   PERMISSIONS,
 } from "@/core/features/auth/permissions";
 
-import { getResumeAnalysisCountDb } from "./db";
+import {
+  getResumeAnalysisCountDb,
+  insertResumeAnalysisDb,
+  tryInsertResumeAnalysisDb,
+} from "./db";
 
 /**
  * Check if user can analyze resumes
@@ -45,4 +49,41 @@ export async function checkResumeAnalysisPermission(): Promise<boolean> {
 
 async function getResumeAnalysisCount(userId: string) {
   return getResumeAnalysisCountDb(userId);
+}
+
+/**
+ * Reserves one resume analysis for the current request.
+ * Pro users insert without quota checks; free users consume quota atomically.
+ */
+export async function reserveResumeAnalysisUsage(
+  userId: string,
+  jobInfoId: string,
+): Promise<boolean> {
+  try {
+    const hasUnlimited = await hasPermission(
+      PERMISSIONS.UNLIMITED.RESUME_ANALYSES,
+    );
+
+    if (hasUnlimited) {
+      await insertResumeAnalysisDb({ jobInfoId });
+      return true;
+    }
+
+    const hasLimited = await hasPermission(PERMISSIONS.LIMITED.RESUME_ANALYSES);
+
+    if (!hasLimited) {
+      return false;
+    }
+
+    const reserved = await tryInsertResumeAnalysisDb({
+      userId,
+      jobInfoId,
+      limit: FREE_PLAN_LIMITS.resume_analyses,
+    });
+
+    return reserved != null;
+  } catch (error) {
+    console.error("Error reserving resume analysis usage:", error);
+    return false;
+  }
 }

--- a/core/features/resumeAnalysis/permissions.ts
+++ b/core/features/resumeAnalysis/permissions.ts
@@ -59,31 +59,26 @@ export async function reserveResumeAnalysisUsage(
   userId: string,
   jobInfoId: string,
 ): Promise<boolean> {
-  try {
-    const hasUnlimited = await hasPermission(
-      PERMISSIONS.UNLIMITED.RESUME_ANALYSES,
-    );
+  const hasUnlimited = await hasPermission(
+    PERMISSIONS.UNLIMITED.RESUME_ANALYSES,
+  );
 
-    if (hasUnlimited) {
-      await insertResumeAnalysisDb({ jobInfoId });
-      return true;
-    }
+  if (hasUnlimited) {
+    await insertResumeAnalysisDb({ jobInfoId });
+    return true;
+  }
 
-    const hasLimited = await hasPermission(PERMISSIONS.LIMITED.RESUME_ANALYSES);
+  const hasLimited = await hasPermission(PERMISSIONS.LIMITED.RESUME_ANALYSES);
 
-    if (!hasLimited) {
-      return false;
-    }
-
-    const reserved = await tryInsertResumeAnalysisDb({
-      userId,
-      jobInfoId,
-      limit: FREE_PLAN_LIMITS.resume_analyses,
-    });
-
-    return reserved != null;
-  } catch (error) {
-    console.error("Error reserving resume analysis usage:", error);
+  if (!hasLimited) {
     return false;
   }
+
+  const reserved = await tryInsertResumeAnalysisDb({
+    userId,
+    jobInfoId,
+    limit: FREE_PLAN_LIMITS.resume_analyses,
+  });
+
+  return reserved != null;
 }

--- a/e2e/db/resumeAnalysisReservation.spec.ts
+++ b/e2e/db/resumeAnalysisReservation.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+import { FREE_PLAN_LIMITS } from "@/core/features/auth/permissions";
+import {
+  getResumeAnalysisCountDb,
+  tryInsertResumeAnalysisDb,
+} from "@/core/features/resumeAnalysis/db";
+
+import {
+  createAuthenticatedUser,
+  createTestJobInfo,
+  createTestResumeAnalysis,
+} from "../helpers";
+
+test.describe("tryInsertResumeAnalysisDb", () => {
+  test("serializes concurrent reservations at the quota boundary", async () => {
+    const session = await createAuthenticatedUser("resume-reservation-race-");
+    const jobInfo = await createTestJobInfo(session.userId);
+    const limit = FREE_PLAN_LIMITS.resume_analyses;
+
+    await Promise.all(
+      Array.from({ length: limit - 1 }, () =>
+        createTestResumeAnalysis(jobInfo.id),
+      ),
+    );
+
+    const [firstResult, secondResult] = await Promise.all([
+      tryInsertResumeAnalysisDb({
+        userId: session.userId,
+        jobInfoId: jobInfo.id,
+        limit,
+      }),
+      tryInsertResumeAnalysisDb({
+        userId: session.userId,
+        jobInfoId: jobInfo.id,
+        limit,
+      }),
+    ]);
+
+    const results = [firstResult, secondResult];
+    const reservedIds = results.flatMap((result) => (result ? [result.id] : []));
+
+    expect(reservedIds).toHaveLength(1);
+    expect(results.filter((result) => result == null)).toHaveLength(1);
+    expect(await getResumeAnalysisCountDb(session.userId)).toBe(limit);
+  });
+});

--- a/e2e/db/resumeAnalysisReservation.spec.ts
+++ b/e2e/db/resumeAnalysisReservation.spec.ts
@@ -38,7 +38,9 @@ test.describe("tryInsertResumeAnalysisDb", () => {
     ]);
 
     const results = [firstResult, secondResult];
-    const reservedIds = results.flatMap((result) => (result ? [result.id] : []));
+    const reservedIds = results.flatMap((result) =>
+      result ? [result.id] : [],
+    );
 
     expect(reservedIds).toHaveLength(1);
     expect(results.filter((result) => result == null)).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Close a TOCTOU race where parallel resume analysis requests could both pass `checkResumeAnalysisPermission()` before either usage row was inserted, allowing free users to exceed the 3-analysis limit.
- Add `tryInsertResumeAnalysisDb()` to check quota and insert inside a single transaction, serialized per user with `SELECT … FOR UPDATE` on the user row.
- Add `reserveResumeAnalysisUsage()` and use it in the analyze API route instead of separate check + insert calls.
- Keep `checkResumeAnalysisPermission()` for read-only UI gating (page redirect); e2e seeding still uses direct `insertResumeAnalysisDb()`.

## Test plan

- [x] `npm test` — 733 unit tests pass
- [x] `npm run test:e2e -- e2e/smoke/aiResume.spec.ts e2e/smoke/planLimits.spec.ts`
- [x] `npx tsc --noEmit`

## Notes

- Pro users still bypass quota via direct insert (unchanged behavior).
- Quota is still consumed before the AI call runs; failed analyses after reservation still count toward usage (pre-existing behavior).
- Same check-then-insert pattern may still exist for questions and interviews; out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume analysis now uses quota-aware usage reservation, helping enforce plan limits more consistently.
  * Users with unlimited access can continue analyzing resumes without hitting quota checks.

* **Bug Fixes**
  * Improved handling of plan-limit responses when the resume analysis quota has been reached.
  * Better safeguards ensure analysis is only reserved after basic validation and access checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->